### PR TITLE
Co-pilot review fixes: Update time formatting for consistency

### DIFF
--- a/src/lib/date-utils.ts
+++ b/src/lib/date-utils.ts
@@ -36,7 +36,7 @@ export function formatTime(
 ): string {
   const dateObj = typeof date === 'string' || typeof date === 'number' ? new Date(date) : date
   return dateObj.toLocaleTimeString('en-US', {
-    hour: '2-digit',
+    hour: 'numeric',
     minute: '2-digit',
     timeZone: APP_TIMEZONE,
     ...options

--- a/src/lib/logging/logger.ts
+++ b/src/lib/logging/logger.ts
@@ -1,31 +1,33 @@
 /**
  * Centralized Logging Service
- * 
+ *
  * Provides structured logging with console output, file persistence,
  * integration with the admin log viewer, and automatic Sentry error reporting.
- * 
+ *
  * FEATURES:
  * - Automatic Sentry reporting for all 'error' level logs
  * - Manual Sentry reporting for critical warnings
  * - Category-based filtering for different types of operations
  * - Rich context and metadata support
  * - Production-only Sentry integration (development safe)
- * 
+ *
  * USAGE EXAMPLES:
- * 
+ *
  * // Basic error logging (automatically reported to Sentry)
  * logger.error('payment-processing', 'stripe-webhook', 'Payment failed', { paymentId: 'pi_123' })
- * 
+ *
  * // Critical warning (manually reported to Sentry)
  * logger.reportWarningToSentry('xero-sync', 'invoice-creation', 'Xero API rate limit approaching')
- * 
+ *
  * // Manual Sentry reporting for any level
  * logger.reportToSentryManual('info', 'system', 'maintenance', 'Database backup completed')
- * 
+ *
  * // Category-based logging methods
  * logger.logPaymentProcessing('webhook-received', 'Stripe webhook processed', { amount: 5000 })
  * logger.logXeroSync('contact-sync', 'Contact synced to Xero', { contactId: 'xero_123' })
  */
+
+import { formatTime } from '@/lib/date-utils'
 
 // Only import fs on server side
 let fs: any = null
@@ -296,7 +298,7 @@ export class Logger {
 
     const emoji = emojis[entry.level]
     const categoryEmoji = categoryEmojis[entry.category]
-    const timestamp = new Date(entry.timestamp).toLocaleTimeString()
+    const timestamp = formatTime(entry.timestamp)
     
     // Build colored output
     const levelColor = levelColors[entry.level]


### PR DESCRIPTION
- Changed hour format from '2-digit' to 'numeric' in formatTime() to display times like "2:11 PM" instead of "02:11 PM"
- Updated logger.ts to use formatTime() from date-utils for consistent timezone-aware logging
- Ensures all timestamps across the app use the configured timezone
- Grep verification now returns 0 (no old patterns remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)