### PR TITLE
Sort registrations report by creation date

### DIFF
--- a/src/app/api/admin/reports/registrations/route.ts
+++ b/src/app/api/admin/reports/registrations/route.ts
@@ -313,8 +313,8 @@ export async function GET(request: NextRequest) {
       const { data: registrationsList, error: registrationsError } = await adminSupabase
         .from('registrations')
         .select(`
-          id, 
-          name, 
+          id,
+          name,
           type,
           seasons (
             name
@@ -329,7 +329,7 @@ export async function GET(request: NextRequest) {
           )
         `)
         .eq('is_active', true)
-        .order('name')
+        .order('created_at', { ascending: false })
 
       if (registrationsError) {
         logger.logSystem('registration-reports-api', 'Error fetching registrations list', { error: registrationsError }, 'error')


### PR DESCRIPTION
Changed the admin/reports/registrations API to order registrations by created_at in descending order (newest first) instead of by name.