### PR TITLE
Fix dark mode styling for date/time inputs and add accounting code picker

### DIFF
--- a/src/app/admin/registrations/new/page.tsx
+++ b/src/app/admin/registrations/new/page.tsx
@@ -6,6 +6,7 @@ import { createClient } from '@/lib/supabase/client'
 import { convertToNYTimezone } from '@/lib/date-utils'
 import Link from 'next/link'
 import EventDateTimeInput from '@/components/EventDateTimeInput'
+import AccountingCodeInput from '@/components/admin/AccountingCodeInput'
 
 export default function NewRegistrationPage() {
   const router = useRouter()
@@ -408,19 +409,15 @@ export default function NewRegistrationPage() {
 
                     {/* Alternate Accounting Code */}
                     <div>
-                      <label htmlFor="alternate_accounting_code" className="block text-sm font-medium text-gray-700">
-                        Alternate Accounting Code
-                      </label>
-                      <input
-                        type="text"
-                        id="alternate_accounting_code"
+                      <AccountingCodeInput
                         value={formData.alternate_accounting_code}
-                        onChange={(e) => setFormData(prev => ({ ...prev, alternate_accounting_code: e.target.value }))}
-                        className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                        placeholder="e.g., ALT001"
+                        onChange={(value) => setFormData(prev => ({ ...prev, alternate_accounting_code: value }))}
+                        label="Alternate Accounting Code"
                         required={formData.allow_alternates}
+                        placeholder="Search by code or name..."
+                        suggestedAccountType="REVENUE"
                       />
-                      <p className="mt-1 text-sm text-gray-500">
+                      <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
                         Accounting code used for alternate charges in Xero
                       </p>
                     </div>

--- a/src/components/DateTimePicker.tsx
+++ b/src/components/DateTimePicker.tsx
@@ -152,7 +152,7 @@ export default function DateTimePicker({
       placeholder={placeholder}
       required={required}
       disabled={disabled}
-      className={`block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm ${className}`}
+      className={`block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm dark:bg-gray-700 dark:border-gray-600 dark:text-white dark:placeholder-gray-400 ${className}`}
     />
   )
 }

--- a/src/components/DurationInput.tsx
+++ b/src/components/DurationInput.tsx
@@ -140,21 +140,21 @@ export default function DurationInput({
           step={roundToNearest}
           className={`block w-32 rounded-md shadow-sm sm:text-sm ${
             error
-              ? 'border-red-300 text-red-900 focus:ring-red-500 focus:border-red-500'
-              : 'border-gray-300 focus:ring-blue-500 focus:border-blue-500'
+              ? 'border-red-300 text-red-900 focus:ring-red-500 focus:border-red-500 dark:border-red-600 dark:text-red-300'
+              : 'border-gray-300 focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:border-gray-600 dark:text-white'
           } ${className}`}
           required={required}
           disabled={disabled}
         />
-        <span className="text-sm text-gray-700">minutes</span>
+        <span className="text-sm text-gray-700 dark:text-gray-300">minutes</span>
         {localValue && localValue !== '' && !error && (
-          <span className="text-sm text-gray-500">
+          <span className="text-sm text-gray-500 dark:text-gray-400">
             ({formatDuration(localValue)})
           </span>
         )}
       </div>
       {error && (
-        <p className="mt-1 text-sm text-red-600" role="alert">
+        <p className="mt-1 text-sm text-red-600 dark:text-red-400" role="alert">
           {error}
         </p>
       )}

--- a/src/components/EditableAlternateConfiguration.tsx
+++ b/src/components/EditableAlternateConfiguration.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import { createClient } from '@/lib/supabase/client'
+import AccountingCodeInput from '@/components/admin/AccountingCodeInput'
 
 interface EditableAlternateConfigurationProps {
   registrationId: string
@@ -161,17 +162,14 @@ export default function EditableAlternateConfiguration({
 
           {/* Alternate Accounting Code */}
           <div>
-            <label htmlFor="alternate_accounting_code" className="block text-xs font-medium text-gray-700">
-              Accounting Code
-            </label>
-            <input
-              type="text"
-              id="alternate_accounting_code"
+            <AccountingCodeInput
               value={config.alternate_accounting_code}
-              onChange={(e) => setConfig(prev => ({ ...prev, alternate_accounting_code: e.target.value }))}
-              className="mt-1 block w-full py-1 text-sm border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
-              placeholder="e.g., ALT001"
+              onChange={(value) => setConfig(prev => ({ ...prev, alternate_accounting_code: value }))}
+              label="Accounting Code"
               required
+              placeholder="Search by code or name..."
+              suggestedAccountType="REVENUE"
+              className="text-sm"
             />
           </div>
         </div>

--- a/src/components/EventDateTimeInput.tsx
+++ b/src/components/EventDateTimeInput.tsx
@@ -40,13 +40,13 @@ export default function EventDateTimeInput({
   }, [startDate])
 
   return (
-    <div className="space-y-4 p-4 bg-blue-50 border border-blue-200 rounded-md">
-      <div className="text-sm text-blue-800 mb-3">
+    <div className="space-y-4 p-4 bg-blue-50 border border-blue-200 rounded-md dark:bg-blue-900/20 dark:border-blue-800">
+      <div className="text-sm text-blue-800 mb-3 dark:text-blue-300">
         <strong>Date & Time:</strong> Enter times in Eastern Time (New York)
       </div>
 
       <div>
-        <label htmlFor="start_date" className="block text-sm font-medium text-gray-700 mb-1">
+        <label htmlFor="start_date" className="block text-sm font-medium text-gray-700 mb-1 dark:text-gray-300">
           Start Date & Time {required && <span className="text-red-500">*</span>}
         </label>
         <DateTimePicker
@@ -59,15 +59,15 @@ export default function EventDateTimeInput({
           disabled={disabled}
           placeholder="Select date and time..."
         />
-        <p className="mt-1 text-xs text-gray-500">Time in 5-minute increments</p>
+        <p className="mt-1 text-xs text-gray-500 dark:text-gray-400">Time in 5-minute increments</p>
 
         {isPastDate && (
-          <div className="mt-2 p-2 bg-yellow-50 border border-yellow-300 rounded-md">
+          <div className="mt-2 p-2 bg-yellow-50 border border-yellow-300 rounded-md dark:bg-yellow-900/20 dark:border-yellow-800">
             <div className="flex items-start">
-              <svg className="h-5 w-5 text-yellow-600 mr-2 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+              <svg className="h-5 w-5 text-yellow-600 mr-2 mt-0.5 flex-shrink-0 dark:text-yellow-400" fill="currentColor" viewBox="0 0 20 20">
                 <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
               </svg>
-              <p className="text-sm text-yellow-800">
+              <p className="text-sm text-yellow-800 dark:text-yellow-300">
                 <strong>Warning:</strong> You've selected a date/time in the past.
               </p>
             </div>
@@ -76,7 +76,7 @@ export default function EventDateTimeInput({
       </div>
 
       <div>
-        <label htmlFor="duration_minutes" className="block text-sm font-medium text-gray-700">
+        <label htmlFor="duration_minutes" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
           Duration {required && <span className="text-red-500">*</span>}
         </label>
         <div className="mt-1">
@@ -90,7 +90,7 @@ export default function EventDateTimeInput({
             roundToNearest={5}
           />
         </div>
-        <p className="mt-1 text-sm text-gray-500">
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
           Default: {registrationType === 'scrimmage' || registrationType === 'game' ? '90 minutes (1.5 hours)' : '180 minutes (3 hours)'}
         </p>
       </div>


### PR DESCRIPTION
This commit addresses two issues:

1. Dark Mode Input Visibility
   - Added dark mode classes to DateTimePicker, EventDateTimeInput, and DurationInput components
   - Input fields now have proper dark backgrounds (dark:bg-gray-700), borders (dark:border-gray-600), and text colors (dark:text-white) for better visibility in dark mode
   - Updated info boxes, labels, and help text with appropriate dark mode colors
   - Warning messages now display correctly in dark mode

2. Alternate Accounting Code Input Enhancement
   - Replaced plain text inputs with AccountingCodeInput component for alternate accounting codes
   - Updated both new registration page and EditableAlternateConfiguration component
   - Users now get autocomplete, validation, and smart suggestions when entering accounting codes
   - Provides same UX as category accounting code selection

Files modified:
- src/components/DateTimePicker.tsx: Added dark mode classes to input field
- src/components/EventDateTimeInput.tsx: Added dark mode styling to wrapper, labels, and warnings
- src/components/DurationInput.tsx: Added dark mode classes to input and text elements
- src/app/admin/registrations/new/page.tsx: Replaced text input with AccountingCodeInput
- src/components/EditableAlternateConfiguration.tsx: Replaced text input with AccountingCodeInput