### PR TITLE
Fix game description warning showing incorrectly

### DIFF
--- a/src/components/GameCreationForm.tsx
+++ b/src/components/GameCreationForm.tsx
@@ -30,14 +30,20 @@ export default function GameCreationForm({
     // Show warning if setting a date but description is empty
     if (newDate && !gameDescription.trim()) {
       setShowDescriptionWarning(true)
+    } else {
+      // Hide warning if description exists or date is cleared
+      setShowDescriptionWarning(false)
     }
   }
 
   const handleDescriptionChange = (newDescription: string) => {
     setGameDescription(newDescription)
-    // Hide warning once description is entered
+    // Show/hide warning based on whether description is filled and date is set
     if (newDescription.trim()) {
       setShowDescriptionWarning(false)
+    } else if (gameDate) {
+      // Show warning if description is empty and date is already set
+      setShowDescriptionWarning(true)
     }
   }
 


### PR DESCRIPTION
- Add else clause to handleDateChange to hide warning when description exists
- Add logic to handleDescriptionChange to show warning if description is cleared while date is set
- Ensures warning only shows when date is set without a description
- Warning properly hides when description is filled in, regardless of order

This fixes the issue where the warning would show even when a game description was already entered.