### PR TITLE
Add 'expired' payment status for abandoned registrations

### DIFF
--- a/src/app/(user)/user/captain/[id]/roster/page.tsx
+++ b/src/app/(user)/user/captain/[id]/roster/page.tsx
@@ -153,8 +153,8 @@ export default function CaptainRosterPage() {
     }
   }
 
-  // All active members (unfiltered, used for summary counts)
-  const allActiveMembers = registrationData.filter(r => r.payment_status !== 'refunded')
+  // Only paid members belong on the active roster
+  const allActiveMembers = registrationData.filter(r => r.payment_status === 'paid')
   const refundedMembers = registrationData.filter(r => r.payment_status === 'refunded')
 
   // Unique categories with counts (from all active members)

--- a/src/app/api/create-registration-payment-intent/route.ts
+++ b/src/app/api/create-registration-payment-intent/route.ts
@@ -692,7 +692,7 @@ export async function POST(request: NextRequest) {
       // Separate records by status
       const awaitingPaymentRecords = existingRecords?.filter(r => r.payment_status === 'awaiting_payment') || []
       const processingRecords = existingRecords?.filter(r => r.payment_status === 'processing') || []
-      const failedRecords = existingRecords?.filter(r => r.payment_status === 'failed') || []
+      const failedRecords = existingRecords?.filter(r => r.payment_status === 'failed' || r.payment_status === 'expired') || []
       
       // Handle 'processing' records - check Stripe status before blocking
       if (processingRecords.length > 0) {

--- a/src/app/api/cron/maintenance/route.ts
+++ b/src/app/api/cron/maintenance/route.ts
@@ -43,57 +43,69 @@ export async function GET(request: NextRequest) {
         'info'
       )
 
-      // Clean up expired reservations (older than 1 hour)
+      // Clean up abandoned registrations older than 1 hour.
+      //
+      // The safe signal for "never completed" is registered_at IS NULL —
+      // that field is only written at payment completion, so it is null for
+      // any awaiting_payment row that was abandoned before checkout finished.
+      // This correctly excludes 'refunded' records (which have registered_at
+      // set because they were once paid) and any other terminal statuses.
+      //
+      // We do NOT filter on reservation_expires_at because unlimited-capacity
+      // categories never set that field, yet they can still be abandoned.
       const oneHourAgo = new Date()
       oneHourAgo.setHours(oneHourAgo.getHours() - 1)
 
-      const { data: expiredReservations, error: cleanupError } = await supabase
+      const { data: abandonedRegistrations, error: cleanupError } = await supabase
         .from('user_registrations')
         .select('id')
         .eq('payment_status', 'awaiting_payment')
-        .lt('reservation_expires_at', oneHourAgo.toISOString())
+        .is('registered_at', null)
+        .lt('created_at', oneHourAgo.toISOString())
 
       if (cleanupError) {
         results.cleanup.error = cleanupError.message
         logger.logPaymentProcessing(
           'cron-cleanup-error',
-          'Failed to fetch expired reservations',
+          'Failed to fetch abandoned registrations',
           { error: results.cleanup.error },
           'error'
         )
       } else {
-        results.cleanup.cleaned = expiredReservations?.length || 0
+        results.cleanup.cleaned = abandonedRegistrations?.length || 0
 
-        if (expiredReservations && expiredReservations.length > 0) {
+        if (abandonedRegistrations && abandonedRegistrations.length > 0) {
           logger.logPaymentProcessing(
             'cron-cleanup-found',
-            `Found ${expiredReservations.length} expired reservations to clean up`,
-            { count: expiredReservations.length },
+            `Found ${abandonedRegistrations.length} abandoned registrations to mark as expired`,
+            { count: abandonedRegistrations.length },
             'info'
           )
 
-          // Update expired reservations to failed status
+          // Mark as 'expired' — distinct from 'failed' (which means Stripe
+          // rejected an active payment attempt). 'expired' means the user
+          // started checkout but never submitted payment.
           const { error: updateError } = await supabase
             .from('user_registrations')
-            .update({ 
-              payment_status: 'failed',
+            .update({
+              payment_status: 'expired',
               reservation_expires_at: null
             })
-            .in('id', expiredReservations.map(r => r.id))
+            .in('id', abandonedRegistrations.map(r => r.id))
 
           if (updateError) {
             results.cleanup.error = updateError.message
             logger.logPaymentProcessing(
               'cron-cleanup-update-error',
-              'Failed to update expired reservations',
+              'Failed to mark abandoned registrations as expired',
               { error: results.cleanup.error },
               'error'
             )
           } else {
             logger.logPaymentProcessing(
               'cron-cleanup-update-success',
-              'Successfully updated expired reservations to failed status',
-              { updated: expiredReservations.length },
+              'Successfully marked abandoned registrations as expired',
+              { updated: abandonedRegistrations.length },
               'info'
             )
           }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -277,7 +277,7 @@ export type Database = {
           user_membership_id: string | null
           payment_id: string | null
           xero_invoice_id: string | null
-          payment_status: 'awaiting_payment' | 'processing' | 'paid' | 'failed' | 'refunded'
+          payment_status: 'awaiting_payment' | 'processing' | 'paid' | 'failed' | 'refunded' | 'expired'
           registration_fee: number | null
           amount_paid: number | null
           presale_code_used: string | null
@@ -294,7 +294,7 @@ export type Database = {
           user_membership_id?: string | null
           payment_id?: string | null
           xero_invoice_id?: string | null
-          payment_status: 'awaiting_payment' | 'processing' | 'paid' | 'failed' | 'refunded'
+          payment_status: 'awaiting_payment' | 'processing' | 'paid' | 'failed' | 'refunded' | 'expired'
           registration_fee?: number | null
           amount_paid?: number | null
           presale_code_used?: string | null
@@ -311,7 +311,7 @@ export type Database = {
           user_membership_id?: string | null
           payment_id?: string | null
           xero_invoice_id?: string | null
-          payment_status?: 'awaiting_payment' | 'processing' | 'paid' | 'failed' | 'refunded'
+          payment_status?: 'awaiting_payment' | 'processing' | 'paid' | 'failed' | 'refunded' | 'expired'
           registration_fee?: number | null
           amount_paid?: number | null
           presale_code_used?: string | null

--- a/supabase/migrations/2026-03-18-add-expired-status-to-user-registrations.sql
+++ b/supabase/migrations/2026-03-18-add-expired-status-to-user-registrations.sql
@@ -1,0 +1,25 @@
+-- Add 'expired' to user_registrations payment_status constraint
+--
+-- 'expired' is used for registrations where payment was never completed
+-- (registered_at IS NULL) and the record has been abandoned. This is
+-- distinct from 'failed' which means a payment was actively attempted
+-- and rejected by Stripe.
+--
+-- The maintenance cron will transition awaiting_payment records to
+-- 'expired' when registered_at IS NULL and created_at > 1 hour ago.
+
+-- Step 1: Drop the existing constraint
+ALTER TABLE user_registrations DROP CONSTRAINT IF EXISTS user_registrations_payment_status_check;
+
+-- Step 2: Recreate with 'expired' added
+ALTER TABLE user_registrations
+ADD CONSTRAINT user_registrations_payment_status_check
+CHECK (payment_status IN ('awaiting_payment', 'processing', 'paid', 'failed', 'refunded', 'expired'));
+
+-- Status reference:
+-- 'awaiting_payment' = spot reserved, user needs to submit payment
+-- 'processing'       = payment submitted to Stripe, waiting for result
+-- 'paid'             = payment completed successfully (registered_at is set)
+-- 'failed'           = payment was attempted and failed in Stripe
+-- 'refunded'         = payment was completed then refunded (registered_at is set)
+-- 'expired'          = registration was started but never completed (registered_at IS NULL)


### PR DESCRIPTION
## Summary

- **New `expired` status** — introduces a terminal `payment_status` for
  registrations where checkout was started but payment never completed
  (`registered_at IS NULL`). Semantically distinct from `failed` (which
  means Stripe actively rejected a payment attempt).

- **Migration** — drops and recreates the `payment_status` check constraint
  to include `'expired'`.

- **Maintenance cron fixed** — previously used `reservation_expires_at < 1hr ago`,
  which missed unlimited-capacity categories that never set that field.
  Now uses `registered_at IS NULL AND created_at < 1hr ago`, which is the
  correct universal signal for "never completed". Updates to `'expired'`
  instead of `'failed'`.

- **Retry logic updated** — `create-registration-payment-intent` now treats
  `'expired'` records the same as `'failed'` so users can retry an abandoned
  checkout without hitting a unique-constraint error.

- **Captain's roster bug fixed** — same ghost-entry bug as the previous PR
  (`!== 'refunded'` → `=== 'paid'`). Captains were also seeing abandoned
  reservations on their roster.

## Test plan
- [ ] Apply the migration in Supabase
- [ ] Confirm existing `awaiting_payment` records in the DB can be manually
      updated to `expired` without a constraint error
- [ ] Start a registration checkout and abandon it — after the cron runs,
      confirm the record shows `payment_status = expired`
- [ ] After a record is expired, start checkout again for the same registration
      — confirm it succeeds (the expired row is reused, no "conflict" error)
- [ ] Open the captain's roster and confirm no phantom entries appear
