### PR TITLE
fix: send waitlist.selected emails from select route and stop duplicate admin emails

### DIFF
--- a/src/app/api/waitlists/[waitlistId]/select/route.ts
+++ b/src/app/api/waitlists/[waitlistId]/select/route.ts
@@ -7,6 +7,7 @@ import { RegistrationValidationService } from '@/lib/services/registration-valid
 import { logger } from '@/lib/logging/logger'
 import { stageCaptainRosterChangeNotification } from '@/lib/email/captain-notifications'
 import { stageAdminNewRegistrationNotification } from '@/lib/email/admin-notifications'
+import { stageWaitlistSelectedEmail } from '@/lib/email/waitlist-notifications'
 
 // POST /api/waitlists/[waitlistId]/select - Select a user from waitlist
 export async function POST(
@@ -216,8 +217,13 @@ export async function POST(
         chargeResult.amountCharged
       ).catch((err) => logger.logSystem('waitlist-selection-admin-notify', 'Admin notification failed (non-fatal)', { error: err?.message }))
 
-      // Email confirmation will be sent via webhook after payment is confirmed
-      // This ensures emails are only sent if payment succeeds
+      stageWaitlistSelectedEmail(
+        waitlistEntry.registration_id,
+        waitlistEntry.user_id,
+        chargeResult.paymentId ?? null,
+        waitlistEntry.registration_category_id,
+        chargeResult.amountCharged
+      ).catch((err) => logger.logSystem('waitlist-selection-member-notify', 'Member notification failed (non-fatal)', { error: err?.message }))
       logger.logSystem('waitlist-selection-success', 'Successfully selected user from waitlist', {
         waitlistId,
         userId: waitlistEntry.user_id,

--- a/src/lib/email/processor.ts
+++ b/src/lib/email/processor.ts
@@ -102,7 +102,7 @@ export class EmailProcessor {
         await this.stageMembershipConfirmationEmail(event, user)
       }
       // Handle registration emails (including waitlist selections)
-      else if (event.trigger_source === 'user_registrations' || event.trigger_source === 'stripe_webhook_registration' || event.trigger_source === 'free_registration' || event.trigger_source === 'stripe_webhook_waitlist') {
+      else if (event.trigger_source === 'user_registrations' || event.trigger_source === 'stripe_webhook_registration' || event.trigger_source === 'free_registration') {
         this.logger.logPaymentProcessing('process-confirmation-emails', '📧 Triggering registration email staging', {
           triggerSource: event.trigger_source,
           amount: event.amount,
@@ -122,7 +122,7 @@ export class EmailProcessor {
       else {
         this.logger.logPaymentProcessing('process-confirmation-emails', '⚠️ Unknown trigger source, no email staged', {
           triggerSource: event.trigger_source,
-          supportedSources: ['user_memberships', 'stripe_webhook_membership', 'free_membership', 'user_registrations', 'stripe_webhook_registration', 'free_registration', 'stripe_webhook_waitlist', 'stripe_webhook_alternate']
+          supportedSources: ['user_memberships', 'stripe_webhook_membership', 'free_membership', 'user_registrations', 'stripe_webhook_registration', 'free_registration', 'stripe_webhook_alternate']
         }, 'warn')
       }
 

--- a/src/lib/email/waitlist-notifications.ts
+++ b/src/lib/email/waitlist-notifications.ts
@@ -1,0 +1,100 @@
+/**
+ * Waitlist notification helpers
+ *
+ * Sends a confirmation email to the member when they are selected off a waitlist.
+ * Called directly from the waitlist selection route after payment is confirmed.
+ */
+
+import { createAdminClient } from '@/lib/supabase/server'
+import { emailService } from '@/lib/email/service'
+
+/**
+ * Send a `waitlist.selected` confirmation email to the member who was selected.
+ *
+ * @param registrationId         - The registration the user was waitlisted for
+ * @param userId                 - The user being selected off the waitlist
+ * @param paymentId              - Payment ID (null for free/fully-discounted charges)
+ * @param registrationCategoryId - The category they were waitlisted under
+ * @param amountCharged          - Amount charged in cents
+ */
+export async function stageWaitlistSelectedEmail(
+  registrationId: string,
+  userId: string,
+  paymentId: string | null,
+  registrationCategoryId: string,
+  amountCharged: number
+): Promise<void> {
+  if (!process.env.LOOPS_WAITLIST_SELECTED_TEMPLATE_ID) {
+    console.warn('LOOPS_WAITLIST_SELECTED_TEMPLATE_ID not configured, skipping waitlist selected notification')
+    return
+  }
+
+  try {
+    const supabase = createAdminClient()
+
+    // Fetch user details
+    const { data: user, error: userError } = await supabase
+      .from('users')
+      .select('id, email, first_name, last_name')
+      .eq('id', userId)
+      .single()
+
+    if (userError || !user) {
+      console.error('stageWaitlistSelectedEmail: user not found', { userId, error: userError })
+      return
+    }
+
+    // Fetch registration + season
+    const { data: registration, error: regError } = await supabase
+      .from('registrations')
+      .select('name, season:seasons(name)')
+      .eq('id', registrationId)
+      .single()
+
+    if (regError || !registration) {
+      console.error('stageWaitlistSelectedEmail: registration not found', { registrationId, error: regError })
+      return
+    }
+
+    const season = Array.isArray(registration.season) ? registration.season[0] : registration.season
+    const seasonName = season?.name ?? ''
+
+    // Resolve category name
+    const { data: regCategory } = await supabase
+      .from('registration_categories')
+      .select('custom_name, category:categories(name)')
+      .eq('id', registrationCategoryId)
+      .single()
+
+    const masterCategory = regCategory?.category
+      ? (Array.isArray(regCategory.category) ? regCategory.category[0] : regCategory.category)
+      : null
+    const categoryName = regCategory?.custom_name || masterCategory?.name || 'Standard'
+
+    // Resolve payment intent ID if a payment exists
+    let paymentIntentId: string | undefined
+    if (paymentId) {
+      const { data: payment } = await supabase
+        .from('payments')
+        .select('stripe_payment_intent_id')
+        .eq('id', paymentId)
+        .single()
+      paymentIntentId = payment?.stripe_payment_intent_id ?? undefined
+    }
+
+    await emailService.sendWaitlistSelectedNotification({
+      userId: user.id,
+      email: user.email,
+      userName: `${user.first_name} ${user.last_name}`,
+      registrationName: registration.name,
+      categoryName,
+      seasonName,
+      amountCharged,
+      paymentIntentId,
+    })
+
+  } catch (error) {
+    console.error('stageWaitlistSelectedEmail: unexpected error', error)
+    // Don't throw — notifications must never break the main flow
+  }
+}


### PR DESCRIPTION
## Summary
- Since commit `23371fa` (Dec 31, 2025), no confirmation email was being sent to members when selected off the waitlist. The old direct send was replaced with a Stripe webhook-based path that silently failed — even the fallback `registration.completed` event never reached `email_logs`.
- As a side effect of the same webhook path, admin/captain `new_registration` notification emails were being sent twice per selection (once from the route, once from the webhook's call to `stageRegistrationConfirmationEmail`).

## Changes
- **`src/lib/email/waitlist-notifications.ts`** *(new)* — `stageWaitlistSelectedEmail` function that looks up member, registration, category, and payment details and sends a `waitlist.selected` email via `emailService.sendWaitlistSelectedNotification`. Follows the same fire-and-forget pattern as `admin-notifications.ts`.
- **`src/app/api/waitlists/[waitlistId]/select/route.ts`** — Calls `stageWaitlistSelectedEmail` after payment is confirmed, alongside the existing admin/captain notifications.
- **`src/lib/email/processor.ts`** — Removes `stripe_webhook_waitlist` from the registration email branch. The webhook still runs `processPaymentCompletion` for Xero staging; it just no longer attempts (and silently fails) to stage a member email or double-fire admin/captain notifications.

## Test plan
- [ ] Select a test user from a waitlist in the dev admin UI
- [ ] Confirm one `waitlist.selected` row appears in `email_logs` with `status = pending` immediately after selection
- [ ] Confirm it flips to `sent` after the cron runs (`/api/cron/email-sync`)
- [ ] Confirm no duplicate `admin.new_registration` emails for the same selection
- [ ] Confirm no `registration.completed` row is staged for the same user
