### PR TITLE
Fix: Silence misleading webhook warning and allow zero-price waitlist selection

### DIFF
--- a/src/lib/email/processor.ts
+++ b/src/lib/email/processor.ts
@@ -118,11 +118,17 @@ export class EmailProcessor {
         })
         await this.stageAlternateSelectionConfirmationEmail(event, user)
       }
+      // Waitlist selection emails are sent directly from the select route (not via webhook)
+      else if (event.trigger_source === 'stripe_webhook_waitlist') {
+        this.logger.logPaymentProcessing('process-confirmation-emails', 'ℹ️ Waitlist selection emails handled by select route, skipping webhook staging', {
+          triggerSource: event.trigger_source
+        })
+      }
       // Unknown trigger source
       else {
         this.logger.logPaymentProcessing('process-confirmation-emails', '⚠️ Unknown trigger source, no email staged', {
           triggerSource: event.trigger_source,
-          supportedSources: ['user_memberships', 'stripe_webhook_membership', 'free_membership', 'user_registrations', 'stripe_webhook_registration', 'free_registration', 'stripe_webhook_alternate']
+          supportedSources: ['user_memberships', 'stripe_webhook_membership', 'free_membership', 'user_registrations', 'stripe_webhook_registration', 'free_registration', 'stripe_webhook_waitlist', 'stripe_webhook_alternate']
         }, 'warn')
       }
 

--- a/src/lib/services/waitlist-payment-service.ts
+++ b/src/lib/services/waitlist-payment-service.ts
@@ -70,7 +70,7 @@ export class WaitlistPaymentService {
         throw new Error('Registration category not found')
       }
 
-      if (!category.price || !category.accounting_code) {
+      if (category.price == null || !category.accounting_code) {
         throw new Error('Registration category does not have pricing configured')
       }
 


### PR DESCRIPTION
## Summary

- **Silence misleading webhook log warning** (`processor.ts`): After PR #146 moved waitlist selection emails to the select route, the `stripe_webhook_waitlist` trigger source had no explicit handler in `processConfirmationEmails`, causing a spurious `⚠️ Unknown trigger source` warning on every waitlist payment webhook. Added an explicit `else if` branch that logs a clear info message explaining emails are handled upstream by the select route. Also added `stripe_webhook_waitlist` back to the `supportedSources` list in the fallthrough warning for documentation purposes.

- **Fix zero-price waitlist selection** (`waitlist-payment-service.ts`): The guard `!category.price` evaluated to `true` when `price === 0`, causing free categories (e.g. goalies) to throw `"Registration category does not have pricing configured"` and abort the selection. Changed to `category.price == null` so that a configured price of `$0` is treated as valid. The existing `finalAmount === 0` path already handles free charges correctly — this fix simply allows execution to reach it.

## Test plan

- [ ] Select a user from a paid waitlist — confirm one admin email, one captain roster-change email, and one `waitlist.selected` member email are sent; confirm no `⚠️ Unknown trigger source` warning appears in webhook logs
- [ ] Select a user from a zero-price waitlist category (e.g. Goalie) — confirm selection succeeds without a "pricing not configured" error and no Stripe charge is attempted
- [ ] Verify the `stripe_webhook_waitlist` webhook log now shows the info message instead of the warning
