### PR TITLE
Claude/fix auth email defender td5r t

### DIFF
--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,3 +1,4 @@
+import { createClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
 
 export const dynamic = 'force-dynamic'
@@ -7,7 +8,6 @@ export async function GET(request: Request) {
   const code = searchParams.get('code')
   const next = searchParams.get('next') ?? '/dashboard'
 
-  // Debug logging
   console.log('🔍 Auth callback debug:', {
     origin,
     next,
@@ -19,46 +19,32 @@ export async function GET(request: Request) {
   })
 
   if (code) {
-    // Store the auth code in an httpOnly cookie and redirect to the confirmation page
-    // WITHOUT the code in the URL. This prevents the Supabase browser client's
-    // detectSessionInUrl from auto-exchanging the code, and prevents Microsoft Defender
-    // (and similar link scanners) from consuming the token by visiting the magic link.
-    // The token is only exchanged when the real user clicks the button on the confirm page.
-    const forwardedHost = request.headers.get('x-forwarded-host')
-    const isLocalEnv = process.env.NODE_ENV === 'development'
+    const supabase = await createClient()
+    const { data, error } = await supabase.auth.exchangeCodeForSession(code)
+    const user = data?.user
 
-    let baseUrl = ''
-    if (isLocalEnv) {
-      baseUrl = origin
-    } else if (forwardedHost) {
-      baseUrl = `https://${forwardedHost}`
+    if (!error && user) {
+      const forwardedHost = request.headers.get('x-forwarded-host')
+      const isLocalEnv = process.env.NODE_ENV === 'development'
+
+      let redirectUrl = ''
+      if (isLocalEnv) {
+        redirectUrl = `${origin}${next}`
+      } else if (forwardedHost) {
+        redirectUrl = `https://${forwardedHost}${next}`
+      } else {
+        redirectUrl = `${origin}${next}`
+      }
+
+      console.log('✅ Auth success, redirecting to:', redirectUrl)
+      return NextResponse.redirect(redirectUrl)
     } else {
-      baseUrl = origin
+      console.log('❌ Auth error:', error)
     }
-
-    const confirmUrl = `${baseUrl}/auth/confirm`
-    console.log('🔗 Redirecting to confirmation page:', confirmUrl)
-    const response = NextResponse.redirect(confirmUrl)
-    response.cookies.set('auth_code_pending', code, {
-      httpOnly: true,
-      secure: !isLocalEnv,
-      sameSite: 'lax',
-      maxAge: 300, // 5 minutes, matching Supabase token expiry
-      path: '/auth/confirm',
-    })
-    response.cookies.set('auth_next_pending', next, {
-      httpOnly: true,
-      secure: !isLocalEnv,
-      sameSite: 'lax',
-      maxAge: 300,
-      path: '/auth/confirm',
-    })
-    return response
   } else {
     console.log('❌ No auth code provided')
   }
 
-  // return the user to an error page with instructions
   const errorUrl = `${origin}/auth/auth-code-error`
   console.log('❌ Auth failed, redirecting to:', errorUrl)
   return NextResponse.redirect(errorUrl)

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -19,10 +19,11 @@ export async function GET(request: Request) {
   })
 
   if (code) {
-    // Redirect to a confirmation page rather than exchanging the code immediately.
-    // This prevents Microsoft Defender (and similar link-scanning tools) from consuming
-    // the auth token by auto-visiting the magic link URL, which would invalidate the
-    // OTP as well. The token is only exchanged when the real user clicks the button.
+    // Store the auth code in an httpOnly cookie and redirect to the confirmation page
+    // WITHOUT the code in the URL. This prevents the Supabase browser client's
+    // detectSessionInUrl from auto-exchanging the code, and prevents Microsoft Defender
+    // (and similar link scanners) from consuming the token by visiting the magic link.
+    // The token is only exchanged when the real user clicks the button on the confirm page.
     const forwardedHost = request.headers.get('x-forwarded-host')
     const isLocalEnv = process.env.NODE_ENV === 'development'
 
@@ -35,11 +36,24 @@ export async function GET(request: Request) {
       baseUrl = origin
     }
 
-    const confirmUrl = new URL(`${baseUrl}/auth/confirm`)
-    confirmUrl.searchParams.set('code', code)
-    confirmUrl.searchParams.set('next', next)
-    console.log('🔗 Redirecting to confirmation page:', confirmUrl.toString())
-    return NextResponse.redirect(confirmUrl.toString())
+    const confirmUrl = `${baseUrl}/auth/confirm`
+    console.log('🔗 Redirecting to confirmation page:', confirmUrl)
+    const response = NextResponse.redirect(confirmUrl)
+    response.cookies.set('auth_code_pending', code, {
+      httpOnly: true,
+      secure: !isLocalEnv,
+      sameSite: 'lax',
+      maxAge: 300, // 5 minutes, matching Supabase token expiry
+      path: '/auth/confirm',
+    })
+    response.cookies.set('auth_next_pending', next, {
+      httpOnly: true,
+      secure: !isLocalEnv,
+      sameSite: 'lax',
+      maxAge: 300,
+      path: '/auth/confirm',
+    })
+    return response
   } else {
     console.log('❌ No auth code provided')
   }

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,4 +1,3 @@
-import { createClient } from '@/lib/supabase/server'
 import { NextResponse } from 'next/server'
 
 export const dynamic = 'force-dynamic'
@@ -20,33 +19,27 @@ export async function GET(request: Request) {
   })
 
   if (code) {
-    const supabase = await createClient()
-    const { data, error } = await supabase.auth.exchangeCodeForSession(code)
-    const user = data?.user
-    
-    if (!error && user) {
-      // Note: We no longer auto-create user records here.
-      // The onboarding page will handle user record creation after collecting required info.
+    // Redirect to a confirmation page rather than exchanging the code immediately.
+    // This prevents Microsoft Defender (and similar link-scanning tools) from consuming
+    // the auth token by auto-visiting the magic link URL, which would invalidate the
+    // OTP as well. The token is only exchanged when the real user clicks the button.
+    const forwardedHost = request.headers.get('x-forwarded-host')
+    const isLocalEnv = process.env.NODE_ENV === 'development'
 
-      const forwardedHost = request.headers.get('x-forwarded-host') // original origin before load balancer
-      const isLocalEnv = process.env.NODE_ENV === 'development'
-      
-      let redirectUrl = ''
-      
-      if (isLocalEnv) {
-        // we can be sure that there is no load balancer in between, so no need to watch for X-Forwarded-Host
-        redirectUrl = `${origin}${next}`
-      } else if (forwardedHost) {
-        redirectUrl = `https://${forwardedHost}${next}`
-      } else {
-        redirectUrl = `${origin}${next}`
-      }
-      
-      console.log('✅ Auth success, redirecting to:', redirectUrl)
-      return NextResponse.redirect(redirectUrl)
+    let baseUrl = ''
+    if (isLocalEnv) {
+      baseUrl = origin
+    } else if (forwardedHost) {
+      baseUrl = `https://${forwardedHost}`
     } else {
-      console.log('❌ Auth error:', error)
+      baseUrl = origin
     }
+
+    const confirmUrl = new URL(`${baseUrl}/auth/confirm`)
+    confirmUrl.searchParams.set('code', code)
+    confirmUrl.searchParams.set('next', next)
+    console.log('🔗 Redirecting to confirmation page:', confirmUrl.toString())
+    return NextResponse.redirect(confirmUrl.toString())
   } else {
     console.log('❌ No auth code provided')
   }

--- a/src/app/auth/confirm/page.tsx
+++ b/src/app/auth/confirm/page.tsx
@@ -1,0 +1,91 @@
+'use server'
+
+import { redirect } from 'next/navigation'
+import { createClient } from '@/lib/supabase/server'
+import { headers } from 'next/headers'
+
+async function completeSignIn(formData: FormData) {
+  'use server'
+  const code = formData.get('code') as string
+  const next = (formData.get('next') as string) || '/dashboard'
+
+  if (!code) {
+    redirect('/auth/auth-code-error')
+  }
+
+  const supabase = await createClient()
+  const { data, error } = await supabase.auth.exchangeCodeForSession(code)
+
+  if (error || !data?.user) {
+    redirect('/auth/auth-code-error')
+  }
+
+  // Mirror the host logic from the callback route
+  const headersList = await headers()
+  const forwardedHost = headersList.get('x-forwarded-host')
+  const host = headersList.get('host') ?? ''
+  const isLocalEnv = process.env.NODE_ENV === 'development'
+
+  let baseUrl = ''
+  if (isLocalEnv) {
+    baseUrl = `http://${host}`
+  } else if (forwardedHost) {
+    baseUrl = `https://${forwardedHost}`
+  } else {
+    baseUrl = `https://${host}`
+  }
+
+  redirect(`${baseUrl}${next}`)
+}
+
+export default async function ConfirmPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ code?: string; next?: string }>
+}) {
+  const { code, next } = await searchParams
+
+  if (!code) {
+    redirect('/auth/auth-code-error')
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full space-y-8">
+        <div>
+          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+            Welcome to your My NYCPHA Account!
+          </h2>
+          <p className="mt-2 text-center text-sm text-gray-600">
+            Click the button below to complete your sign in.
+          </p>
+        </div>
+
+        <div className="bg-white shadow rounded-lg p-6">
+          <form action={completeSignIn}>
+            <input type="hidden" name="code" value={code} />
+            <input type="hidden" name="next" value={next ?? '/dashboard'} />
+            <button
+              type="submit"
+              className="w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-base font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            >
+              Sign in
+            </button>
+          </form>
+
+          <p className="mt-4 text-center text-xs text-gray-500">
+            If you did not request this login, you can safely ignore this page.
+          </p>
+        </div>
+
+        <div className="text-center">
+          <img
+            src="https://my.nycpha.org/images/NYCPHA_Wordmark_Horizontal_Black_Tide.png"
+            alt="NYCPHA Logo"
+            className="mx-auto max-w-full h-auto"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/auth/confirm/page.tsx
+++ b/src/app/auth/confirm/page.tsx
@@ -58,7 +58,7 @@ export default async function ConfirmPage() {
             Welcome to your My NYCPHA Account!
           </h2>
           <p className="mt-2 text-center text-sm text-gray-600">
-            Click the button below to complete your sign in.
+            Your identity has been verified. Click below to continue.
           </p>
         </div>
 
@@ -68,7 +68,7 @@ export default async function ConfirmPage() {
               type="submit"
               className="w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-base font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
             >
-              Sign in
+              Open Dashboard
             </button>
           </form>
 

--- a/src/app/auth/confirm/page.tsx
+++ b/src/app/auth/confirm/page.tsx
@@ -2,12 +2,13 @@
 
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
-import { headers } from 'next/headers'
+import { cookies, headers } from 'next/headers'
 
-async function completeSignIn(formData: FormData) {
+async function completeSignIn() {
   'use server'
-  const code = formData.get('code') as string
-  const next = (formData.get('next') as string) || '/dashboard'
+  const cookieStore = await cookies()
+  const code = cookieStore.get('auth_code_pending')?.value
+  const next = cookieStore.get('auth_next_pending')?.value || '/dashboard'
 
   if (!code) {
     redirect('/auth/auth-code-error')
@@ -20,7 +21,10 @@ async function completeSignIn(formData: FormData) {
     redirect('/auth/auth-code-error')
   }
 
-  // Mirror the host logic from the callback route
+  // Clear the pending cookies
+  cookieStore.delete('auth_code_pending')
+  cookieStore.delete('auth_next_pending')
+
   const headersList = await headers()
   const forwardedHost = headersList.get('x-forwarded-host')
   const host = headersList.get('host') ?? ''
@@ -38,14 +42,11 @@ async function completeSignIn(formData: FormData) {
   redirect(`${baseUrl}${next}`)
 }
 
-export default async function ConfirmPage({
-  searchParams,
-}: {
-  searchParams: Promise<{ code?: string; next?: string }>
-}) {
-  const { code, next } = await searchParams
+export default async function ConfirmPage() {
+  const cookieStore = await cookies()
+  const hasCode = !!cookieStore.get('auth_code_pending')?.value
 
-  if (!code) {
+  if (!hasCode) {
     redirect('/auth/auth-code-error')
   }
 
@@ -63,8 +64,6 @@ export default async function ConfirmPage({
 
         <div className="bg-white shadow rounded-lg p-6">
           <form action={completeSignIn}>
-            <input type="hidden" name="code" value={code} />
-            <input type="hidden" name="next" value={next ?? '/dashboard'} />
             <button
               type="submit"
               className="w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-base font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -35,7 +35,7 @@ export default function LoginPage() {
       const { error } = await supabase.auth.signInWithOtp({
         email,
         options: {
-          emailRedirectTo: `${window.location.origin}/auth/callback`,
+          emailRedirectTo: `${window.location.origin}/auth/magic-confirm`,
         }
       })
 

--- a/src/app/auth/magic-confirm/page.tsx
+++ b/src/app/auth/magic-confirm/page.tsx
@@ -2,28 +2,26 @@
 
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
-import { cookies, headers } from 'next/headers'
+import { headers } from 'next/headers'
 
-async function completeSignIn() {
+async function completeSignIn(formData: FormData) {
   'use server'
-  const cookieStore = await cookies()
-  const code = cookieStore.get('auth_code_pending')?.value
-  const next = cookieStore.get('auth_next_pending')?.value || '/dashboard'
+  const tokenHash = formData.get('token_hash') as string
+  const type = (formData.get('type') as string) || 'magiclink'
 
-  if (!code) {
+  if (!tokenHash) {
     redirect('/auth/auth-code-error')
   }
 
   const supabase = await createClient()
-  const { data, error } = await supabase.auth.exchangeCodeForSession(code)
+  const { error } = await supabase.auth.verifyOtp({
+    token_hash: tokenHash,
+    type: type as 'magiclink' | 'email',
+  })
 
-  if (error || !data?.user) {
+  if (error) {
     redirect('/auth/auth-code-error')
   }
-
-  // Clear the pending cookies
-  cookieStore.delete('auth_code_pending')
-  cookieStore.delete('auth_next_pending')
 
   const headersList = await headers()
   const forwardedHost = headersList.get('x-forwarded-host')
@@ -39,14 +37,17 @@ async function completeSignIn() {
     baseUrl = `https://${host}`
   }
 
-  redirect(`${baseUrl}${next}`)
+  redirect(`${baseUrl}/dashboard`)
 }
 
-export default async function ConfirmPage() {
-  const cookieStore = await cookies()
-  const hasCode = !!cookieStore.get('auth_code_pending')?.value
+export default async function MagicConfirmPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ token_hash?: string; type?: string }>
+}) {
+  const { token_hash, type } = await searchParams
 
-  if (!hasCode) {
+  if (!token_hash) {
     redirect('/auth/auth-code-error')
   }
 
@@ -64,6 +65,8 @@ export default async function ConfirmPage() {
 
         <div className="bg-white shadow rounded-lg p-6">
           <form action={completeSignIn}>
+            <input type="hidden" name="token_hash" value={token_hash} />
+            <input type="hidden" name="type" value={type ?? 'magiclink'} />
             <button
               type="submit"
               className="w-full flex justify-center py-3 px-4 border border-transparent rounded-md shadow-sm text-base font-medium text-white bg-indigo-600 hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"

--- a/src/app/auth/magic-confirm/page.tsx
+++ b/src/app/auth/magic-confirm/page.tsx
@@ -1,5 +1,3 @@
-'use server'
-
 import { redirect } from 'next/navigation'
 import { createClient } from '@/lib/supabase/server'
 import { headers } from 'next/headers'


### PR DESCRIPTION
## Fix: Magic link and OTP invalidated by Microsoft Defender

### Problem

Users with Microsoft Defender (common at nhl.com) were unable to sign in.
Defender scans email links by visiting them automatically. The magic link in
the Supabase email pointed directly to Supabase's verify endpoint
(`/auth/v1/verify?token=...`), which consumed the auth token the moment
Defender visited it — invalidating both the magic link and the OTP before
the user ever saw the email.

### Code Changes

**New page: `/auth/magic-confirm`**
- Replaces the direct Supabase verify endpoint as the magic link destination
- Displays an "Open Dashboard" button; `verifyOtp` is only called when the
  user explicitly clicks it
- Defender visits the page, sees a button, and stops — the token is never consumed
- OTP remains valid since nothing has touched the token

**Updated `/auth/login`**
- Changed `emailRedirectTo` from `/auth/callback` to `/auth/magic-confirm`
- Ensures `{{ .RedirectTo }}` in the email template resolves to the correct
  origin (production, preview, or localhost) rather than the hardcoded Site URL

**Restored `/auth/callback`**
- Back to its original behaviour (immediate `exchangeCodeForSession`)
- Now used exclusively for Google OAuth

### Supabase Email Template Changes (Manual)

**Magic Link template** — change the magic link `href` from:
```html
<a href="{{ .ConfirmationURL }}">Sign in</a>
to:
<a href="{{ .RedirectTo }}?token_hash={{ .TokenHash }}&type=magiclink">Sign in</a>
```

### Supabase Settings Changes (Manual)
Authentication → Settings → Disable "Confirm email"

- New users previously received a separate confirmation email (link only, no
OTP) before they could sign in — a two-email flow with worse UX
- Since auth is entirely email-based, successfully receiving and using a magic
link or OTP already proves email ownership — confirmation is redundant
- Fake/spam emails are equally harmless either way: without inbox access,
nobody can sign in, and accounts never reach public.users without
completing onboarding

