### PR TITLE
Fix: use admin client in payment registrations API to bypass RLS

### DIFF
--- a/src/app/api/admin/payments/[paymentId]/registrations/route.ts
+++ b/src/app/api/admin/payments/[paymentId]/registrations/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { createClient } from '@/lib/supabase/server'
+import { createClient, createAdminClient } from '@/lib/supabase/server'
 
 interface RouteParams {
   params: {
@@ -10,7 +10,8 @@ interface RouteParams {
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
     const supabase = await createClient()
-    
+    const adminSupabase = createAdminClient()
+
     // Check if user is authenticated and is admin
     const { data: { user }, error: authError } = await supabase.auth.getUser()
     if (authError || !user) {
@@ -28,8 +29,8 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
       return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
     }
 
-    // Get registrations associated with this payment
-    const { data: registrations, error: registrationsError } = await supabase
+    // Get registrations associated with this payment (admin client bypasses RLS)
+    const { data: registrations, error: registrationsError } = await adminSupabase
       .from('user_registrations')
       .select(`
         registration_id,


### PR DESCRIPTION
## Summary

- The **Apply Discount Code** option in the Process Refund modal was not appearing for waitlist-initiated registration payments
- Root cause: the `/api/admin/payments/[paymentId]/registrations` route was using the regular Supabase client (subject to RLS). An earlier migration (`2025-06-16-fix-policies-v2.sql`) dropped the `"Admins can view all registrations"` RLS policy on `user_registrations` and it was never recreated.
- This meant admins could only read their **own** `user_registrations` rows, so looking up another user's payment returned 0 results → `isRegistrationPayment = false` → "Apply Discount Code" hidden.
- Fix: switch to `createAdminClient()` for the `user_registrations` query. Admin status is already verified before the query runs, so this is safe.

## Test plan

- [ ] Open the refund modal for a waitlist-initiated registration payment — both "Proportional Refund" and "Apply Discount Code" options should now appear
- [ ] Confirm "Apply Discount Code" works end-to-end (enter a code, validate, preview, process)
- [ ] Open the refund modal for a non-registration payment (e.g. membership fee) — only "Proportional Refund" should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)