### PR TITLE
Fix: await params in payment registrations route (Next.js 15)

### DIFF
--- a/src/app/api/admin/payments/[paymentId]/registrations/route.ts
+++ b/src/app/api/admin/payments/[paymentId]/registrations/route.ts
@@ -2,13 +2,14 @@ import { NextRequest, NextResponse } from 'next/server'
 import { createClient, createAdminClient } from '@/lib/supabase/server'
 
 interface RouteParams {
-  params: {
+  params: Promise<{
     paymentId: string
-  }
+  }>
 }
 
 export async function GET(request: NextRequest, { params }: RouteParams) {
   try {
+    const { paymentId } = await params
     const supabase = await createClient()
     const adminSupabase = createAdminClient()
 
@@ -44,7 +45,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
           )
         )
       `)
-      .eq('payment_id', params.paymentId)
+      .eq('payment_id', paymentId)
 
     if (registrationsError) {
       console.error('Error fetching registrations for payment:', registrationsError)


### PR DESCRIPTION
params is a Promise in Next.js 15 — accessing .paymentId without awaiting it produces the string "undefined", which PostgreSQL rejects when casting to UUID. This was masked before because the RLS issue returned 0 rows without evaluating the payment_id filter.