### PR TITLE
Add team email composer for captains and admins

### DIFF
--- a/src/app/(user)/user/captain/[id]/roster/page.tsx
+++ b/src/app/(user)/user/captain/[id]/roster/page.tsx
@@ -7,6 +7,7 @@ import { getLgbtqStatusLabel, getLgbtqStatusStyles, getGoalieStatusLabel, getGoa
 import UserLink from '@/components/UserLink'
 import { formatDate as formatDateUtil, formatTime as formatTimeUtil } from '@/lib/date-utils'
 import FinancialSummary from '@/components/FinancialSummary'
+import EmailComposerModal from '@/components/EmailComposerModal'
 
 interface FinancialSummaryData {
   roster_gross: number
@@ -102,6 +103,8 @@ export default function CaptainRosterPage() {
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null)
   const [lgbtqFilter, setLgbtqFilter] = useState<LgbtqFilter | null>(null)
   const [goalieFilter, setGoalieFilter] = useState<GoalieFilter | null>(null)
+
+  const [showEmailComposer, setShowEmailComposer] = useState(false)
 
   useEffect(() => {
     if (registrationId) {
@@ -307,14 +310,27 @@ export default function CaptainRosterPage() {
           <div className="mb-6 bg-white shadow rounded-lg p-4 space-y-3">
             <div className="flex items-center justify-between">
               <h2 className="text-lg font-semibold text-gray-900">Roster Summary</h2>
-              {hasActiveFilters && (
-                <button
-                  onClick={() => { setCategoryFilter(null); setLgbtqFilter(null); setGoalieFilter(null) }}
-                  className="text-xs text-gray-500 hover:text-gray-700 underline"
-                >
-                  Clear filters
-                </button>
-              )}
+              <div className="flex items-center gap-3">
+                {hasActiveFilters && (
+                  <button
+                    onClick={() => { setCategoryFilter(null); setLgbtqFilter(null); setGoalieFilter(null) }}
+                    className="text-xs text-gray-500 hover:text-gray-700 underline"
+                  >
+                    Clear filters
+                  </button>
+                )}
+                {filteredActiveMembers.length > 0 && (
+                  <button
+                    onClick={() => setShowEmailComposer(true)}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700"
+                  >
+                    <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                    </svg>
+                    Email Team
+                  </button>
+                )}
+              </div>
             </div>
 
             {/* Category */}
@@ -798,6 +814,18 @@ export default function CaptainRosterPage() {
             </Link>
           </div>
         </>
+      )}
+
+      {showEmailComposer && (
+        <EmailComposerModal
+          recipients={filteredActiveMembers.map(m => ({
+            userId: m.user_id,
+            email: m.email,
+            name: `${m.first_name} ${m.last_name}`.trim(),
+          }))}
+          apiEndpoint={`/api/captain/registrations/${registrationId}/send-team-email`}
+          onClose={() => setShowEmailComposer(false)}
+        />
       )}
     </div>
   )

--- a/src/app/(user)/user/captain/[id]/roster/page.tsx
+++ b/src/app/(user)/user/captain/[id]/roster/page.tsx
@@ -275,8 +275,21 @@ export default function CaptainRosterPage() {
 
       {/* Header */}
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900 mb-2">{registrationName}</h1>
-        <p className="text-lg text-gray-600">{seasonName}</p>
+        <div className="flex items-center gap-3">
+          <h1 className="text-3xl font-bold text-gray-900">{registrationName}</h1>
+          {allActiveMembers.length > 0 && (
+            <button
+              onClick={() => setShowEmailComposer(true)}
+              title="Email Team"
+              className="text-gray-400 hover:text-indigo-600 transition-colors mt-1"
+            >
+              <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+              </svg>
+            </button>
+          )}
+        </div>
+        <p className="text-lg text-gray-600 mt-1">{seasonName}</p>
       </div>
 
       {/* Error Display */}
@@ -310,27 +323,14 @@ export default function CaptainRosterPage() {
           <div className="mb-6 bg-white shadow rounded-lg p-4 space-y-3">
             <div className="flex items-center justify-between">
               <h2 className="text-lg font-semibold text-gray-900">Roster Summary</h2>
-              <div className="flex items-center gap-3">
-                {hasActiveFilters && (
-                  <button
-                    onClick={() => { setCategoryFilter(null); setLgbtqFilter(null); setGoalieFilter(null) }}
-                    className="text-xs text-gray-500 hover:text-gray-700 underline"
-                  >
-                    Clear filters
-                  </button>
-                )}
-                {filteredActiveMembers.length > 0 && (
-                  <button
-                    onClick={() => setShowEmailComposer(true)}
-                    className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700"
-                  >
-                    <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
-                      <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                    </svg>
-                    Email Team
-                  </button>
-                )}
-              </div>
+              {hasActiveFilters && (
+                <button
+                  onClick={() => { setCategoryFilter(null); setLgbtqFilter(null); setGoalieFilter(null) }}
+                  className="text-xs text-gray-500 hover:text-gray-700 underline"
+                >
+                  Clear filters
+                </button>
+              )}
             </div>
 
             {/* Category */}

--- a/src/app/(user)/user/captain/page.tsx
+++ b/src/app/(user)/user/captain/page.tsx
@@ -4,6 +4,13 @@ import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
 import FinancialSummary from '@/components/FinancialSummary'
+import EmailComposerModal from '@/components/EmailComposerModal'
+
+interface EmailRecipient {
+  userId: string
+  email: string
+  name: string
+}
 
 interface FinancialSummaryData {
   roster_gross: number
@@ -42,7 +49,37 @@ export default function CaptainDashboardPage() {
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
   const [showPastTeams, setShowPastTeams] = useState(false)
+  const [emailTargetId, setEmailTargetId] = useState<string | null>(null)
+  const [emailRecipients, setEmailRecipients] = useState<EmailRecipient[]>([])
+  const [emailLoading, setEmailLoading] = useState(false)
   const router = useRouter()
+
+  const handleEmailClick = async (registrationId: string) => {
+    setEmailLoading(true)
+    setEmailTargetId(registrationId)
+    try {
+      const res = await fetch(`/api/user/captain/${registrationId}/roster`)
+      if (!res.ok) throw new Error('Failed to load roster')
+      const result = await res.json()
+      const paid = (result.data || [])
+        .filter((m: { payment_status: string }) => m.payment_status === 'paid')
+        .map((m: { user_id: string; email: string; first_name: string; last_name: string }) => ({
+          userId: m.user_id,
+          email: m.email,
+          name: `${m.first_name} ${m.last_name}`.trim(),
+        }))
+      setEmailRecipients(paid)
+    } catch {
+      setEmailTargetId(null)
+    } finally {
+      setEmailLoading(false)
+    }
+  }
+
+  const handleEmailClose = () => {
+    setEmailTargetId(null)
+    setEmailRecipients([])
+  }
 
   useEffect(() => {
     fetchRegistrations(showPastTeams)
@@ -205,7 +242,26 @@ export default function CaptainDashboardPage() {
               >
                 <div className="flex items-start justify-between mb-3">
                   <div className="flex-1">
-                    <h3 className="text-lg font-semibold text-gray-900 mb-1">{registration.name}</h3>
+                    <div className="flex items-center gap-2 mb-1">
+                      <h3 className="text-lg font-semibold text-gray-900">{registration.name}</h3>
+                      <button
+                        onClick={() => handleEmailClick(registration.id)}
+                        title="Email Team"
+                        disabled={emailLoading && emailTargetId === registration.id}
+                        className="text-gray-400 hover:text-indigo-600 transition-colors disabled:opacity-50"
+                      >
+                        {emailLoading && emailTargetId === registration.id ? (
+                          <svg className="h-5 w-5 animate-spin" fill="none" viewBox="0 0 24 24">
+                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
+                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
+                          </svg>
+                        ) : (
+                          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                            <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                          </svg>
+                        )}
+                      </button>
+                    </div>
                     <p className="text-sm text-gray-600">{registration.season_name}</p>
                   </div>
                   <span className={`inline-flex px-2 py-1 text-xs font-semibold rounded-full ${getRegistrationTypeColor(registration.type)}`}>
@@ -383,6 +439,13 @@ export default function CaptainDashboardPage() {
             ))}
           </div>
         </div>
+      )}
+      {emailTargetId && emailRecipients.length > 0 && (
+        <EmailComposerModal
+          recipients={emailRecipients}
+          apiEndpoint={`/api/captain/registrations/${emailTargetId}/send-team-email`}
+          onClose={handleEmailClose}
+        />
       )}
     </div>
   )

--- a/src/app/admin/reports/registrations/[id]/page.tsx
+++ b/src/app/admin/reports/registrations/[id]/page.tsx
@@ -5,6 +5,7 @@ import { useParams } from 'next/navigation'
 import Link from 'next/link'
 import { getLgbtqStatusLabel, getLgbtqStatusStyles, getGoalieStatusLabel, getGoalieStatusStyles, getCategoryPillStyles } from '@/lib/user-attributes'
 import WaitlistSelectionModal from '@/components/WaitlistSelectionModal'
+import EmailComposerModal from '@/components/EmailComposerModal'
 import UserLink from '@/components/UserLink'
 import { formatDate as formatDateUtil, formatTime as formatTimeUtil } from '@/lib/date-utils'
 import { buildBreadcrumbUrl } from '@/lib/breadcrumb-utils'
@@ -110,6 +111,7 @@ export default function RegistrationDetailPage() {
   const [alternatesSortDirection, setAlternatesSortDirection] = useState<'asc' | 'desc'>('asc')
   const [selectedWaitlistEntry, setSelectedWaitlistEntry] = useState<WaitlistData | null>(null)
   const [showWaitlistSelectionModal, setShowWaitlistSelectionModal] = useState(false)
+  const [showEmailComposer, setShowEmailComposer] = useState(false)
 
   // Filter state
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null)
@@ -369,14 +371,27 @@ export default function RegistrationDetailPage() {
           <div className="mb-6 bg-white shadow rounded-lg p-4 space-y-3">
             <div className="flex items-center justify-between">
               <h2 className="text-lg font-semibold text-gray-900">Roster Summary</h2>
-              {hasActiveFilters && (
-                <button
-                  onClick={() => { setCategoryFilter(null); setLgbtqFilter(null); setGoalieFilter(null) }}
-                  className="text-xs text-gray-500 hover:text-gray-700 underline"
-                >
-                  Clear filters
-                </button>
-              )}
+              <div className="flex items-center gap-3">
+                {hasActiveFilters && (
+                  <button
+                    onClick={() => { setCategoryFilter(null); setLgbtqFilter(null); setGoalieFilter(null) }}
+                    className="text-xs text-gray-500 hover:text-gray-700 underline"
+                  >
+                    Clear filters
+                  </button>
+                )}
+                {filteredActiveMembers.length > 0 && (
+                  <button
+                    onClick={() => setShowEmailComposer(true)}
+                    className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700"
+                  >
+                    <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                    </svg>
+                    Email Team
+                  </button>
+                )}
+              </div>
             </div>
 
             {/* Category */}
@@ -957,6 +972,18 @@ export default function RegistrationDetailPage() {
             setShowWaitlistSelectionModal(false)
             setSelectedWaitlistEntry(null)
           }}
+        />
+      )}
+
+      {showEmailComposer && (
+        <EmailComposerModal
+          recipients={filteredActiveMembers.map(m => ({
+            userId: m.user_id,
+            email: m.email,
+            name: `${m.first_name} ${m.last_name}`.trim(),
+          }))}
+          apiEndpoint={`/api/admin/registrations/${registrationId}/send-team-email`}
+          onClose={() => setShowEmailComposer(false)}
         />
       )}
     </div>

--- a/src/app/api/admin/registrations/[id]/send-team-email/route.ts
+++ b/src/app/api/admin/registrations/[id]/send-team-email/route.ts
@@ -18,7 +18,7 @@ export async function POST(
     // Verify admin
     const { data: userProfile } = await supabase
       .from('users')
-      .select('is_admin, first_name, last_name')
+      .select('is_admin, email, first_name, last_name')
       .eq('id', user.id)
       .single()
 
@@ -74,6 +74,15 @@ export async function POST(
         name: `${u.first_name} ${u.last_name}`.trim(),
       }
     })
+
+    // Always CC the sender
+    if (userProfile.email && !recipients.some(r => r.userId === user.id)) {
+      recipients.push({
+        userId: user.id,
+        email: userProfile.email,
+        name: `${userProfile.first_name || ''} ${userProfile.last_name || ''}`.trim(),
+      })
+    }
 
     await emailService.stageTeamMessageEmail(recipients, {
       senderName,

--- a/src/app/api/admin/registrations/[id]/send-team-email/route.ts
+++ b/src/app/api/admin/registrations/[id]/send-team-email/route.ts
@@ -1,0 +1,90 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient, createAdminClient } from '@/lib/supabase/server'
+import { emailService } from '@/lib/email/service'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const supabase = await createClient()
+    const { id: registrationId } = await params
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    // Verify admin
+    const { data: userProfile } = await supabase
+      .from('users')
+      .select('is_admin, first_name, last_name')
+      .eq('id', user.id)
+      .single()
+
+    if (!userProfile?.is_admin) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const body = await request.json()
+    const { subject, body: messageBody, recipientUserIds } = body
+
+    if (!subject?.trim()) {
+      return NextResponse.json({ error: 'Subject is required' }, { status: 400 })
+    }
+    if (!messageBody?.trim()) {
+      return NextResponse.json({ error: 'Message body is required' }, { status: 400 })
+    }
+    if (!Array.isArray(recipientUserIds) || recipientUserIds.length === 0) {
+      return NextResponse.json({ error: 'At least one recipient is required' }, { status: 400 })
+    }
+
+    const adminSupabase = createAdminClient()
+
+    const firstName = userProfile.first_name || ''
+    const lastInitial = userProfile.last_name?.[0] || ''
+    const senderName = `${firstName} ${lastInitial}`.trim()
+
+    // Fetch registration name for senderRole
+    const { data: registration } = await adminSupabase
+      .from('registrations')
+      .select('name')
+      .eq('id', registrationId)
+      .single()
+
+    const senderRole = `Admin – ${registration?.name || 'Team'}`
+
+    // Verify recipients are active paid members of this registration
+    const { data: validMembers } = await adminSupabase
+      .from('user_registrations')
+      .select('user_id, users!inner(id, email, first_name, last_name)')
+      .eq('registration_id', registrationId)
+      .eq('payment_status', 'paid')
+      .in('user_id', recipientUserIds)
+
+    if (!validMembers || validMembers.length === 0) {
+      return NextResponse.json({ error: 'No valid recipients found' }, { status: 400 })
+    }
+
+    const recipients = validMembers.map(m => {
+      const u = Array.isArray(m.users) ? m.users[0] : m.users
+      return {
+        userId: m.user_id,
+        email: u.email,
+        name: `${u.first_name} ${u.last_name}`.trim(),
+      }
+    })
+
+    await emailService.stageTeamMessageEmail(recipients, {
+      senderName,
+      senderRole,
+      messageSubject: subject.trim(),
+      messageBody: messageBody.trim(),
+    })
+
+    return NextResponse.json({ queued: recipients.length })
+  } catch (error) {
+    console.error('Error in admin send-team-email:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/captain/registrations/[id]/send-team-email/route.ts
+++ b/src/app/api/captain/registrations/[id]/send-team-email/route.ts
@@ -45,7 +45,7 @@ export async function POST(
     // Fetch sender profile
     const { data: senderProfile } = await adminSupabase
       .from('users')
-      .select('first_name, last_name')
+      .select('email, first_name, last_name')
       .eq('id', user.id)
       .single()
 
@@ -82,6 +82,15 @@ export async function POST(
         name: `${u.first_name} ${u.last_name}`.trim(),
       }
     })
+
+    // Always CC the sender
+    if (senderProfile?.email && !recipients.some(r => r.userId === user.id)) {
+      recipients.push({
+        userId: user.id,
+        email: senderProfile.email,
+        name: `${senderProfile.first_name || ''} ${senderProfile.last_name || ''}`.trim(),
+      })
+    }
 
     await emailService.stageTeamMessageEmail(recipients, {
       senderName,

--- a/src/app/api/captain/registrations/[id]/send-team-email/route.ts
+++ b/src/app/api/captain/registrations/[id]/send-team-email/route.ts
@@ -1,0 +1,98 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient, createAdminClient } from '@/lib/supabase/server'
+import { emailService } from '@/lib/email/service'
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const supabase = await createClient()
+    const { id: registrationId } = await params
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    // Verify the user is a captain of this registration
+    const { data: captainship } = await supabase
+      .from('registration_captains')
+      .select('id')
+      .eq('user_id', user.id)
+      .eq('registration_id', registrationId)
+      .single()
+
+    if (!captainship) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const body = await request.json()
+    const { subject, body: messageBody, recipientUserIds } = body
+
+    if (!subject?.trim()) {
+      return NextResponse.json({ error: 'Subject is required' }, { status: 400 })
+    }
+    if (!messageBody?.trim()) {
+      return NextResponse.json({ error: 'Message body is required' }, { status: 400 })
+    }
+    if (!Array.isArray(recipientUserIds) || recipientUserIds.length === 0) {
+      return NextResponse.json({ error: 'At least one recipient is required' }, { status: 400 })
+    }
+
+    const adminSupabase = createAdminClient()
+
+    // Fetch sender profile
+    const { data: senderProfile } = await adminSupabase
+      .from('users')
+      .select('first_name, last_name')
+      .eq('id', user.id)
+      .single()
+
+    const firstName = senderProfile?.first_name || ''
+    const lastInitial = senderProfile?.last_name?.[0] || ''
+    const senderName = `${firstName} ${lastInitial}`.trim()
+
+    // Fetch registration name for senderRole
+    const { data: registration } = await adminSupabase
+      .from('registrations')
+      .select('name')
+      .eq('id', registrationId)
+      .single()
+
+    const senderRole = `Captain – ${registration?.name || 'Team'}`
+
+    // Verify recipients are active paid members of this registration
+    const { data: validMembers } = await adminSupabase
+      .from('user_registrations')
+      .select('user_id, users!inner(id, email, first_name, last_name)')
+      .eq('registration_id', registrationId)
+      .eq('payment_status', 'paid')
+      .in('user_id', recipientUserIds)
+
+    if (!validMembers || validMembers.length === 0) {
+      return NextResponse.json({ error: 'No valid recipients found' }, { status: 400 })
+    }
+
+    const recipients = validMembers.map(m => {
+      const u = Array.isArray(m.users) ? m.users[0] : m.users
+      return {
+        userId: m.user_id,
+        email: u.email,
+        name: `${u.first_name} ${u.last_name}`.trim(),
+      }
+    })
+
+    await emailService.stageTeamMessageEmail(recipients, {
+      senderName,
+      senderRole,
+      messageSubject: subject.trim(),
+      messageBody: messageBody.trim(),
+    })
+
+    return NextResponse.json({ queued: recipients.length })
+  } catch (error) {
+    console.error('Error in captain send-team-email:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/components/EmailComposerModal.tsx
+++ b/src/components/EmailComposerModal.tsx
@@ -1,0 +1,138 @@
+'use client'
+
+import { useState } from 'react'
+import { useToast } from '@/contexts/ToastContext'
+
+interface Recipient {
+  userId: string
+  email: string
+  name: string
+}
+
+interface EmailComposerModalProps {
+  recipients: Recipient[]
+  apiEndpoint: string
+  onClose: () => void
+}
+
+export default function EmailComposerModal({
+  recipients,
+  apiEndpoint,
+  onClose,
+}: EmailComposerModalProps) {
+  const [subject, setSubject] = useState('')
+  const [body, setBody] = useState('')
+  const [isSending, setIsSending] = useState(false)
+  const [showRecipients, setShowRecipients] = useState(false)
+  const { showSuccess, showError } = useToast()
+
+  const subjectTrimmed = subject.trim()
+  const bodyTrimmed = body.trim()
+  const isValid = subjectTrimmed.length > 0 && bodyTrimmed.length > 0
+
+  const handleSend = async () => {
+    if (!isValid || isSending) return
+    setIsSending(true)
+    try {
+      const res = await fetch(apiEndpoint, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          subject: subjectTrimmed,
+          body: bodyTrimmed,
+          recipientUserIds: recipients.map(r => r.userId),
+        }),
+      })
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}))
+        showError(data.error || 'Failed to send email')
+        return
+      }
+      const data = await res.json()
+      showSuccess(`Email queued for ${data.queued} recipient${data.queued !== 1 ? 's' : ''}`)
+      onClose()
+    } catch {
+      showError('Failed to send email')
+    } finally {
+      setIsSending(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40">
+      <div className="bg-white rounded-lg shadow-xl w-full max-w-lg mx-4 flex flex-col max-h-[90vh]">
+        <div className="px-6 py-4 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900">Email Team</h2>
+        </div>
+
+        <div className="px-6 py-4 overflow-y-auto flex-1 space-y-4">
+          {/* Recipients */}
+          <div>
+            <button
+              type="button"
+              onClick={() => setShowRecipients(v => !v)}
+              className="text-sm text-indigo-600 hover:text-indigo-800 font-medium"
+            >
+              Sending to {recipients.length} player{recipients.length !== 1 ? 's' : ''}{' '}
+              {showRecipients ? '▲' : '▼'}
+            </button>
+            {showRecipients && (
+              <ul className="mt-2 text-sm text-gray-700 max-h-32 overflow-y-auto border border-gray-200 rounded p-2 space-y-0.5">
+                {recipients.map(r => (
+                  <li key={r.userId}>{r.name}</li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {/* Subject */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Subject <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="text"
+              value={subject}
+              onChange={e => setSubject(e.target.value)}
+              className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm"
+              placeholder="Email subject"
+            />
+          </div>
+
+          {/* Body */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Message <span className="text-red-500">*</span>
+            </label>
+            <textarea
+              value={body}
+              onChange={e => setBody(e.target.value)}
+              rows={8}
+              className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-sm resize-y"
+              placeholder="Your message (plain text)"
+            />
+          </div>
+        </div>
+
+        <div className="px-6 py-4 border-t border-gray-200 flex justify-end gap-3">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isSending}
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSend}
+            disabled={!isValid || isSending}
+            className="px-4 py-2 text-sm font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isSending ? 'Sending…' : 'Send'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/lib/email/service.ts
+++ b/src/lib/email/service.ts
@@ -766,7 +766,7 @@ class EmailService {
     }
   ): Promise<void> {
     const { emailStagingManager } = await import('@/lib/email/staging')
-    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || ''
+    const dashboardUrl = `${process.env.NEXT_PUBLIC_SITE_URL}/user`
     await Promise.all(
       recipients.map(recipient =>
         emailStagingManager.stageEmail({
@@ -782,7 +782,7 @@ class EmailService {
             senderRole: templateVars.senderRole,
             messageSubject: templateVars.messageSubject,
             messageBody: templateVars.messageBody,
-            dashboardUrl: `${siteUrl}/user/dashboard`,
+            dashboardUrl,
           },
         })
       )

--- a/src/lib/email/service.ts
+++ b/src/lib/email/service.ts
@@ -25,6 +25,7 @@ export const EMAIL_EVENTS = {
   CAPTAIN_ROSTER_CHANGE: 'captain.roster_change',
   ADMIN_NEW_REGISTRATION: 'admin.new_registration',
   ADMIN_REFUND_NOTIFICATION: 'admin.refund_notification',
+  TEAM_MESSAGE: 'team.message',
 } as const
 
 export type EmailEventType = typeof EMAIL_EVENTS[keyof typeof EMAIL_EVENTS]
@@ -749,6 +750,43 @@ class EmailService {
         dashboard_url: `${process.env.NEXT_PUBLIC_SITE_URL}/user/dashboard`
       }
     })
+  }
+
+  /**
+   * Stage ad-hoc team message emails for batch delivery via cron.
+   * All recipients receive the same subject/body; one email_logs row is inserted per recipient.
+   */
+  async stageTeamMessageEmail(
+    recipients: { userId: string; email: string; name: string }[],
+    templateVars: {
+      senderName: string
+      senderRole: string
+      messageSubject: string
+      messageBody: string
+    }
+  ): Promise<void> {
+    const { emailStagingManager } = await import('@/lib/email/staging')
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || ''
+    await Promise.all(
+      recipients.map(recipient =>
+        emailStagingManager.stageEmail({
+          user_id: recipient.userId,
+          email_address: recipient.email,
+          event_type: EMAIL_EVENTS.TEAM_MESSAGE,
+          subject: templateVars.messageSubject,
+          template_id: process.env.LOOPS_TEAM_MESSAGE_TEMPLATE_ID,
+          triggered_by: 'admin_send',
+          email_data: {
+            recipientName: recipient.name,
+            senderName: templateVars.senderName,
+            senderRole: templateVars.senderRole,
+            messageSubject: templateVars.messageSubject,
+            messageBody: templateVars.messageBody,
+            dashboardUrl: `${siteUrl}/user/dashboard`,
+          },
+        })
+      )
+    )
   }
 }
 


### PR DESCRIPTION
## Summary
This PR adds the ability for team captains and admins to send emails to their team members directly from the application. A new email composer modal allows users to compose and send messages to filtered rosters with proper authorization checks and email staging.

## Key Changes

- **New EmailComposerModal component** (`src/components/EmailComposerModal.tsx`): A reusable modal for composing and sending emails to team members with subject/body validation and loading states

- **Captain email endpoint** (`src/app/api/captain/registrations/[id]/send-team-email/route.ts`): Allows team captains to send emails to paid members of their registered teams, with sender role displayed as "Captain – [Team Name]"

- **Admin email endpoint** (`src/app/api/admin/registrations/[id]/send-team-email/route.ts`): Allows admins to send emails to paid members of any registration, with sender role displayed as "Admin – [Team Name]"

- **Email service enhancement** (`src/lib/email/service.ts`): Added `stageTeamMessageEmail()` method to queue ad-hoc team messages for batch delivery via cron, with support for custom sender name/role and message content

- **Captain dashboard integration** (`src/app/(user)/user/captain/page.tsx`): Added email button to each team card that loads the roster and opens the composer modal

- **Captain roster page integration** (`src/app/(user)/user/captain/[id]/roster/page.tsx`): Added email button in the header to compose messages to filtered roster members

- **Admin registration detail page integration** (`src/app/admin/reports/registrations/[id]/page.tsx`): Added email button to send messages to filtered active members

## Implementation Details

- Both endpoints verify authorization (captain ownership or admin status) before allowing email sends
- Only paid members of a registration are eligible recipients
- Sender is automatically CC'd on all emails
- Recipients are validated against the registration's paid member list
- Email staging uses the existing email service infrastructure with a new `TEAM_MESSAGE` event type
- Modal includes collapsible recipient list, required field validation, and loading states
- All three UI entry points (captain dashboard, captain roster, admin registration detail) use the same reusable modal component

https://claude.ai/code/session_01TNH4TALt5MeD5rndg4YSy7