### PR TITLE
Add roster/alternate status filtering and email capabilities

### DIFF
--- a/src/app/(user)/user/captain/[id]/roster/page.tsx
+++ b/src/app/(user)/user/captain/[id]/roster/page.tsx
@@ -323,14 +323,27 @@ export default function CaptainRosterPage() {
           <div className="mb-6 bg-white shadow rounded-lg p-4 space-y-3">
             <div className="flex items-center justify-between">
               <h2 className="text-lg font-semibold text-gray-900">Roster Summary</h2>
-              {hasActiveFilters && (
-                <button
-                  onClick={() => { setCategoryFilter(null); setLgbtqFilter(null); setGoalieFilter(null) }}
-                  className="text-xs text-gray-500 hover:text-gray-700 underline"
-                >
-                  Clear filters
-                </button>
-              )}
+              <div className="flex items-center gap-3">
+                {hasActiveFilters && (
+                  <button
+                    onClick={() => { setCategoryFilter(null); setLgbtqFilter(null); setGoalieFilter(null) }}
+                    className="text-xs text-gray-500 hover:text-gray-700 underline"
+                  >
+                    Clear filters
+                  </button>
+                )}
+                {filteredActiveMembers.length > 0 && (
+                  <button
+                    onClick={() => setShowEmailComposer(true)}
+                    className="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-indigo-600 transition-colors"
+                  >
+                    <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                      <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+                    </svg>
+                    Email selected ({filteredActiveMembers.length})
+                  </button>
+                )}
+              </div>
             </div>
 
             {/* Category */}

--- a/src/app/(user)/user/captain/[id]/roster/page.tsx
+++ b/src/app/(user)/user/captain/[id]/roster/page.tsx
@@ -103,8 +103,10 @@ export default function CaptainRosterPage() {
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null)
   const [lgbtqFilter, setLgbtqFilter] = useState<LgbtqFilter | null>(null)
   const [goalieFilter, setGoalieFilter] = useState<GoalieFilter | null>(null)
+  const [statusFilter, setStatusFilter] = useState<'roster' | 'alternate' | null>(null)
 
   const [showEmailComposer, setShowEmailComposer] = useState(false)
+  const [emailAllMembers, setEmailAllMembers] = useState(false)
 
   useEffect(() => {
     if (registrationId) {
@@ -249,7 +251,18 @@ export default function CaptainRosterPage() {
     return 0
   })
 
-  const hasActiveFilters = categoryFilter !== null || lgbtqFilter !== null || goalieFilter !== null
+  const hasActiveFilters = categoryFilter !== null || lgbtqFilter !== null || goalieFilter !== null || statusFilter !== null
+
+  const rosterRecipients = filteredActiveMembers.map(m => ({
+    userId: m.user_id, email: m.email, name: `${m.first_name} ${m.last_name}`.trim(),
+  }))
+  const alternateRecipients = alternatesData.map(m => ({
+    userId: m.user_id, email: m.email, name: `${m.first_name} ${m.last_name}`.trim(),
+  }))
+  const filteredEmailRecipients =
+    statusFilter === 'roster' ? rosterRecipients
+    : statusFilter === 'alternate' ? alternateRecipients
+    : [...rosterRecipients, ...alternateRecipients]
 
   const toggleCategoryFilter = (name: string) =>
     setCategoryFilter(prev => (prev === name ? null : name))
@@ -279,7 +292,7 @@ export default function CaptainRosterPage() {
           <h1 className="text-3xl font-bold text-gray-900">{registrationName}</h1>
           {allActiveMembers.length > 0 && (
             <button
-              onClick={() => setShowEmailComposer(true)}
+              onClick={() => { setEmailAllMembers(true); setShowEmailComposer(true) }}
               title="Email Team"
               className="text-gray-400 hover:text-indigo-600 transition-colors mt-1"
             >
@@ -326,21 +339,21 @@ export default function CaptainRosterPage() {
               <div className="flex items-center gap-3">
                 {hasActiveFilters && (
                   <button
-                    onClick={() => { setCategoryFilter(null); setLgbtqFilter(null); setGoalieFilter(null) }}
+                    onClick={() => { setCategoryFilter(null); setLgbtqFilter(null); setGoalieFilter(null); setStatusFilter(null) }}
                     className="text-xs text-gray-500 hover:text-gray-700 underline"
                   >
                     Clear filters
                   </button>
                 )}
-                {filteredActiveMembers.length > 0 && (
+                {filteredEmailRecipients.length > 0 && (
                   <button
-                    onClick={() => setShowEmailComposer(true)}
+                    onClick={() => { setEmailAllMembers(false); setShowEmailComposer(true) }}
                     className="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-indigo-600 transition-colors"
                   >
                     <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                     </svg>
-                    Email selected ({filteredActiveMembers.length})
+                    Email selected ({filteredEmailRecipients.length})
                   </button>
                 )}
               </div>
@@ -443,6 +456,37 @@ export default function CaptainRosterPage() {
                 </button>
               </div>
             </div>
+
+            {/* Status */}
+            {alternatesData.length > 0 && (
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-xs font-medium text-gray-500 uppercase tracking-wider w-20 shrink-0">Status</span>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    onClick={() => setStatusFilter(statusFilter === 'roster' ? null : 'roster')}
+                    className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+                      statusFilter === 'roster'
+                        ? 'bg-indigo-600 text-white border-indigo-600'
+                        : 'bg-indigo-50 text-indigo-800 border-indigo-200 hover:bg-indigo-100'
+                    }`}
+                  >
+                    Roster
+                    <span className={`font-normal ${statusFilter === 'roster' ? 'opacity-80' : 'opacity-60'}`}>({allActiveMembers.length})</span>
+                  </button>
+                  <button
+                    onClick={() => setStatusFilter(statusFilter === 'alternate' ? null : 'alternate')}
+                    className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+                      statusFilter === 'alternate'
+                        ? 'bg-indigo-600 text-white border-indigo-600'
+                        : 'bg-indigo-50 text-indigo-800 border-indigo-200 hover:bg-indigo-100'
+                    }`}
+                  >
+                    Alternate
+                    <span className={`font-normal ${statusFilter === 'alternate' ? 'opacity-80' : 'opacity-60'}`}>({alternatesData.length})</span>
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
 
           {/* Financial Summary */}
@@ -831,11 +875,13 @@ export default function CaptainRosterPage() {
 
       {showEmailComposer && (
         <EmailComposerModal
-          recipients={filteredActiveMembers.map(m => ({
-            userId: m.user_id,
-            email: m.email,
-            name: `${m.first_name} ${m.last_name}`.trim(),
-          }))}
+          recipients={emailAllMembers
+            ? [
+                ...allActiveMembers.map(m => ({ userId: m.user_id, email: m.email, name: `${m.first_name} ${m.last_name}`.trim() })),
+                ...alternatesData.map(m => ({ userId: m.user_id, email: m.email, name: `${m.first_name} ${m.last_name}`.trim() })),
+              ]
+            : filteredEmailRecipients
+          }
           apiEndpoint={`/api/captain/registrations/${registrationId}/send-team-email`}
           onClose={() => setShowEmailComposer(false)}
         />

--- a/src/app/(user)/user/captain/page.tsx
+++ b/src/app/(user)/user/captain/page.tsx
@@ -244,23 +244,6 @@ export default function CaptainDashboardPage() {
                   <div className="flex-1">
                     <div className="flex items-center gap-2 mb-1">
                       <h3 className="text-lg font-semibold text-gray-900">{registration.name}</h3>
-                      <button
-                        onClick={() => handleEmailClick(registration.id)}
-                        title="Email Team"
-                        disabled={emailLoading && emailTargetId === registration.id}
-                        className="text-gray-400 hover:text-indigo-600 transition-colors disabled:opacity-50"
-                      >
-                        {emailLoading && emailTargetId === registration.id ? (
-                          <svg className="h-5 w-5 animate-spin" fill="none" viewBox="0 0 24 24">
-                            <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4" />
-                            <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8v8H4z" />
-                          </svg>
-                        ) : (
-                          <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
-                            <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
-                          </svg>
-                        )}
-                      </button>
                     </div>
                     <p className="text-sm text-gray-600">{registration.season_name}</p>
                   </div>
@@ -327,7 +310,7 @@ export default function CaptainDashboardPage() {
                 )}
 
                 {/* Action buttons */}
-                <div className="flex gap-2 mt-4">
+                <div className="flex flex-col sm:flex-row gap-2 mt-4">
                   <Link
                     href={`/user/captain/${registration.id}/roster`}
                     className="flex-1 text-center px-3 py-2 text-sm font-medium text-indigo-700 bg-indigo-50 rounded-md hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
@@ -342,6 +325,13 @@ export default function CaptainDashboardPage() {
                       Manage Alternates
                     </Link>
                   )}
+                  <button
+                    onClick={() => handleEmailClick(registration.id)}
+                    disabled={emailLoading && emailTargetId === registration.id}
+                    className="flex-1 text-center px-3 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-gray-400 disabled:opacity-50"
+                  >
+                    {emailLoading && emailTargetId === registration.id ? 'Loading...' : 'Email Team'}
+                  </button>
                 </div>
               </div>
             ))}

--- a/src/app/(user)/user/captain/page.tsx
+++ b/src/app/(user)/user/captain/page.tsx
@@ -68,7 +68,14 @@ export default function CaptainDashboardPage() {
           email: m.email,
           name: `${m.first_name} ${m.last_name}`.trim(),
         }))
-      setEmailRecipients(paid)
+      const alts = (result.alternatesData || []).map(
+        (m: { user_id: string; email: string; first_name: string; last_name: string }) => ({
+          userId: m.user_id,
+          email: m.email,
+          name: `${m.first_name} ${m.last_name}`.trim(),
+        })
+      )
+      setEmailRecipients([...paid, ...alts])
     } catch {
       setEmailTargetId(null)
     } finally {

--- a/src/app/admin/reports/registrations/[id]/page.tsx
+++ b/src/app/admin/reports/registrations/[id]/page.tsx
@@ -112,6 +112,7 @@ export default function RegistrationDetailPage() {
   const [selectedWaitlistEntry, setSelectedWaitlistEntry] = useState<WaitlistData | null>(null)
   const [showWaitlistSelectionModal, setShowWaitlistSelectionModal] = useState(false)
   const [showEmailComposer, setShowEmailComposer] = useState(false)
+  const [emailAllMembers, setEmailAllMembers] = useState(false)
 
   // Filter state
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null)
@@ -340,7 +341,7 @@ export default function RegistrationDetailPage() {
           <h1 className="text-3xl font-bold text-gray-900">{registrationName}</h1>
           {allActiveMembers.length > 0 && (
             <button
-              onClick={() => setShowEmailComposer(true)}
+              onClick={() => { setEmailAllMembers(true); setShowEmailComposer(true) }}
               title="Email Team"
               className="text-gray-400 hover:text-indigo-600 transition-colors mt-1"
             >
@@ -395,7 +396,7 @@ export default function RegistrationDetailPage() {
                 )}
                 {filteredActiveMembers.length > 0 && (
                   <button
-                    onClick={() => setShowEmailComposer(true)}
+                    onClick={() => { setEmailAllMembers(false); setShowEmailComposer(true) }}
                     className="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-indigo-600 transition-colors"
                   >
                     <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
@@ -990,7 +991,7 @@ export default function RegistrationDetailPage() {
 
       {showEmailComposer && (
         <EmailComposerModal
-          recipients={filteredActiveMembers.map(m => ({
+          recipients={(emailAllMembers ? allActiveMembers : filteredActiveMembers).map(m => ({
             userId: m.user_id,
             email: m.email,
             name: `${m.first_name} ${m.last_name}`.trim(),

--- a/src/app/admin/reports/registrations/[id]/page.tsx
+++ b/src/app/admin/reports/registrations/[id]/page.tsx
@@ -118,6 +118,7 @@ export default function RegistrationDetailPage() {
   const [categoryFilter, setCategoryFilter] = useState<string | null>(null)
   const [lgbtqFilter, setLgbtqFilter] = useState<LgbtqFilter | null>(null)
   const [goalieFilter, setGoalieFilter] = useState<GoalieFilter | null>(null)
+  const [statusFilter, setStatusFilter] = useState<'roster' | 'alternate' | null>(null)
 
   useEffect(() => {
     if (registrationId) {
@@ -263,7 +264,23 @@ export default function RegistrationDetailPage() {
     return 0
   })
 
-  const hasActiveFilters = categoryFilter !== null || lgbtqFilter !== null || goalieFilter !== null
+  const hasActiveFilters = categoryFilter !== null || lgbtqFilter !== null || goalieFilter !== null || statusFilter !== null
+
+  const rosterRecipients = filteredActiveMembers.map(m => ({
+    userId: m.user_id, email: m.email, name: `${m.first_name} ${m.last_name}`.trim(),
+  }))
+  const alternateRecipients = alternatesData.map(m => ({
+    userId: m.user_id, email: m.email, name: `${m.first_name} ${m.last_name}`.trim(),
+  }))
+  const filteredEmailRecipients =
+    statusFilter === 'roster' ? rosterRecipients
+    : statusFilter === 'alternate' ? alternateRecipients
+    : [...rosterRecipients, ...alternateRecipients]
+
+  const allEmailRecipients = [
+    ...allActiveMembers.map(m => ({ userId: m.user_id, email: m.email, name: `${m.first_name} ${m.last_name}`.trim() })),
+    ...alternatesData.map(m => ({ userId: m.user_id, email: m.email, name: `${m.first_name} ${m.last_name}`.trim() })),
+  ]
 
   const toggleCategoryFilter = (name: string) =>
     setCategoryFilter(prev => (prev === name ? null : name))
@@ -388,13 +405,13 @@ export default function RegistrationDetailPage() {
               <div className="flex items-center gap-3">
                 {hasActiveFilters && (
                   <button
-                    onClick={() => { setCategoryFilter(null); setLgbtqFilter(null); setGoalieFilter(null) }}
+                    onClick={() => { setCategoryFilter(null); setLgbtqFilter(null); setGoalieFilter(null); setStatusFilter(null) }}
                     className="text-xs text-gray-500 hover:text-gray-700 underline"
                   >
                     Clear filters
                   </button>
                 )}
-                {filteredActiveMembers.length > 0 && (
+                {filteredEmailRecipients.length > 0 && (
                   <button
                     onClick={() => { setEmailAllMembers(false); setShowEmailComposer(true) }}
                     className="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-indigo-600 transition-colors"
@@ -402,7 +419,7 @@ export default function RegistrationDetailPage() {
                     <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                     </svg>
-                    Email selected ({filteredActiveMembers.length})
+                    Email selected ({filteredEmailRecipients.length})
                   </button>
                 )}
               </div>
@@ -505,6 +522,37 @@ export default function RegistrationDetailPage() {
                 </button>
               </div>
             </div>
+
+            {/* Status */}
+            {alternatesData.length > 0 && (
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-xs font-medium text-gray-500 uppercase tracking-wider w-20 shrink-0">Status</span>
+                <div className="flex flex-wrap gap-2">
+                  <button
+                    onClick={() => setStatusFilter(statusFilter === 'roster' ? null : 'roster')}
+                    className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+                      statusFilter === 'roster'
+                        ? 'bg-indigo-600 text-white border-indigo-600'
+                        : 'bg-indigo-50 text-indigo-800 border-indigo-200 hover:bg-indigo-100'
+                    }`}
+                  >
+                    Roster
+                    <span className={`font-normal ${statusFilter === 'roster' ? 'opacity-80' : 'opacity-60'}`}>({allActiveMembers.length})</span>
+                  </button>
+                  <button
+                    onClick={() => setStatusFilter(statusFilter === 'alternate' ? null : 'alternate')}
+                    className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
+                      statusFilter === 'alternate'
+                        ? 'bg-indigo-600 text-white border-indigo-600'
+                        : 'bg-indigo-50 text-indigo-800 border-indigo-200 hover:bg-indigo-100'
+                    }`}
+                  >
+                    Alternate
+                    <span className={`font-normal ${statusFilter === 'alternate' ? 'opacity-80' : 'opacity-60'}`}>({alternatesData.length})</span>
+                  </button>
+                </div>
+              </div>
+            )}
           </div>
 
           {/* Financial Summary */}
@@ -991,11 +1039,7 @@ export default function RegistrationDetailPage() {
 
       {showEmailComposer && (
         <EmailComposerModal
-          recipients={(emailAllMembers ? allActiveMembers : filteredActiveMembers).map(m => ({
-            userId: m.user_id,
-            email: m.email,
-            name: `${m.first_name} ${m.last_name}`.trim(),
-          }))}
+          recipients={emailAllMembers ? allEmailRecipients : filteredEmailRecipients}
           apiEndpoint={`/api/admin/registrations/${registrationId}/send-team-email`}
           onClose={() => setShowEmailComposer(false)}
         />

--- a/src/app/admin/reports/registrations/[id]/page.tsx
+++ b/src/app/admin/reports/registrations/[id]/page.tsx
@@ -336,7 +336,20 @@ export default function RegistrationDetailPage() {
 
       {/* Page Title */}
       <div className="mb-8">
-        <h1 className="text-3xl font-bold text-gray-900">{registrationName}</h1>
+        <div className="flex items-center gap-3">
+          <h1 className="text-3xl font-bold text-gray-900">{registrationName}</h1>
+          {allActiveMembers.length > 0 && (
+            <button
+              onClick={() => setShowEmailComposer(true)}
+              title="Email Team"
+              className="text-gray-400 hover:text-indigo-600 transition-colors mt-1"
+            >
+              <svg className="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={1.5}>
+                <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+              </svg>
+            </button>
+          )}
+        </div>
         <p className="mt-2 text-lg text-gray-600">{seasonName}</p>
       </div>
 
@@ -383,12 +396,12 @@ export default function RegistrationDetailPage() {
                 {filteredActiveMembers.length > 0 && (
                   <button
                     onClick={() => setShowEmailComposer(true)}
-                    className="inline-flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-white bg-indigo-600 rounded-md hover:bg-indigo-700"
+                    className="inline-flex items-center gap-1.5 text-xs text-gray-500 hover:text-indigo-600 transition-colors"
                   >
                     <svg className="h-3.5 w-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
                       <path strokeLinecap="round" strokeLinejoin="round" d="M3 8l7.89 5.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
                     </svg>
-                    Email Team
+                    Email selected ({filteredActiveMembers.length})
                   </button>
                 )}
               </div>

--- a/src/app/admin/reports/registrations/page.tsx
+++ b/src/app/admin/reports/registrations/page.tsx
@@ -3,6 +3,13 @@
 import { useState, useEffect, useCallback } from 'react'
 import Link from 'next/link'
 import FinancialSummary from '@/components/FinancialSummary'
+import EmailComposerModal from '@/components/EmailComposerModal'
+
+interface EmailRecipient {
+  userId: string
+  email: string
+  name: string
+}
 
 interface FinancialSummaryData {
   roster_gross: number
@@ -91,6 +98,32 @@ export default function RegistrationReportsPage() {
   const [showPastEvents, setShowPastEvents] = useState(false)
   const [sortBy, setSortBy] = useState<SortOption>('name-asc')
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set())
+  const [emailTargetId, setEmailTargetId] = useState<string | null>(null)
+  const [emailRecipients, setEmailRecipients] = useState<EmailRecipient[]>([])
+  const [emailLoading, setEmailLoading] = useState(false)
+
+  const handleEmailClick = async (registrationId: string, e: React.MouseEvent) => {
+    e.stopPropagation()
+    setEmailLoading(true)
+    setEmailTargetId(registrationId)
+    try {
+      const res = await fetch(`/api/admin/reports/registrations?registrationId=${registrationId}`)
+      if (!res.ok) throw new Error('Failed to load roster')
+      const result = await res.json()
+      const paid = (result.data || [])
+        .filter((m: { payment_status: string }) => m.payment_status === 'paid')
+        .map((m: { user_id: string; email: string; first_name: string; last_name: string }) => ({
+          userId: m.user_id,
+          email: m.email,
+          name: `${m.first_name} ${m.last_name}`.trim(),
+        }))
+      setEmailRecipients(paid)
+    } catch {
+      setEmailTargetId(null)
+    } finally {
+      setEmailLoading(false)
+    }
+  }
 
   useEffect(() => {
     fetchRegistrations()
@@ -339,11 +372,11 @@ export default function RegistrationReportsPage() {
                     </div>
 
                     {/* Action buttons */}
-                    <div className="mt-4 pt-4 border-t border-gray-100 flex gap-3">
+                    <div className="mt-4 pt-4 border-t border-gray-100 flex flex-col sm:flex-row gap-2">
                       <Link
                         href={`/admin/reports/registrations/${registration.id}`}
                         onClick={(e) => e.stopPropagation()}
-                        className="px-4 py-2 text-sm font-medium text-indigo-700 bg-indigo-50 rounded-md hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
+                        className="px-4 py-2 text-sm font-medium text-center text-indigo-700 bg-indigo-50 rounded-md hover:bg-indigo-100 focus:outline-none focus:ring-2 focus:ring-indigo-500"
                       >
                         View Roster
                       </Link>
@@ -351,11 +384,18 @@ export default function RegistrationReportsPage() {
                         <Link
                           href={`/admin/reports/registrations/${registration.id}?tab=alternates`}
                           onClick={(e) => e.stopPropagation()}
-                          className="px-4 py-2 text-sm font-medium text-purple-700 bg-purple-50 rounded-md hover:bg-purple-100 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                          className="px-4 py-2 text-sm font-medium text-center text-purple-700 bg-purple-50 rounded-md hover:bg-purple-100 focus:outline-none focus:ring-2 focus:ring-purple-500"
                         >
                           Manage Alternates
                         </Link>
                       )}
+                      <button
+                        onClick={(e) => handleEmailClick(registration.id, e)}
+                        disabled={emailLoading && emailTargetId === registration.id}
+                        className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-md hover:bg-gray-200 focus:outline-none focus:ring-2 focus:ring-gray-400 disabled:opacity-50"
+                      >
+                        {emailLoading && emailTargetId === registration.id ? 'Loading...' : 'Email Team'}
+                      </button>
                     </div>
                   </div>
                 )}
@@ -363,6 +403,13 @@ export default function RegistrationReportsPage() {
             )
           })}
         </div>
+      )}
+      {emailTargetId && emailRecipients.length > 0 && (
+        <EmailComposerModal
+          recipients={emailRecipients}
+          apiEndpoint={`/api/admin/registrations/${emailTargetId}/send-team-email`}
+          onClose={() => { setEmailTargetId(null); setEmailRecipients([]) }}
+        />
       )}
     </div>
   )

--- a/src/app/admin/reports/registrations/page.tsx
+++ b/src/app/admin/reports/registrations/page.tsx
@@ -117,7 +117,14 @@ export default function RegistrationReportsPage() {
           email: m.email,
           name: `${m.first_name} ${m.last_name}`.trim(),
         }))
-      setEmailRecipients(paid)
+      const alts = (result.alternatesData || []).map(
+        (m: { user_id: string; email: string; first_name: string; last_name: string }) => ({
+          userId: m.user_id,
+          email: m.email,
+          name: `${m.first_name} ${m.last_name}`.trim(),
+        })
+      )
+      setEmailRecipients([...paid, ...alts])
     } catch {
       setEmailTargetId(null)
     } finally {

--- a/src/app/api/admin/reports/registrations/route.ts
+++ b/src/app/api/admin/reports/registrations/route.ts
@@ -479,8 +479,7 @@ export async function GET(request: NextRequest) {
       const registrationIds = registrationsList?.map(r => r.id) || []
 
       // Fetch all user_registrations for counting and financials.
-      // No payment_status filter here so the count matches what the detail page shows.
-      // Financial totals are accumulated only for payment_status='paid' rows (see below).
+      // Refunded members are excluded from counts (see forEach below); paid-only for financials.
       const { data: registrationCounts, error: countsError } = await adminSupabase
         .from('user_registrations')
         .select(`
@@ -612,8 +611,12 @@ export async function GET(request: NextRequest) {
         if (!countsMap.has(regId)) {
           countsMap.set(regId, new Map())
         }
-        const regMap = countsMap.get(regId)!
-        regMap.set(catName, (regMap.get(catName) || 0) + 1)
+
+        // Only count active (non-refunded) members — matches email recipient logic
+        if (count.payment_status !== 'refunded') {
+          const regMap = countsMap.get(regId)!
+          regMap.set(catName, (regMap.get(catName) || 0) + 1)
+        }
 
         // Accumulate financial totals for paid members only — matches detail page paidRoster logic
         if (count.payment_status === 'paid') {


### PR DESCRIPTION
## Summary
This PR enhances team roster management by adding the ability to filter members by their status (roster vs. alternate) and improving email functionality across multiple pages. Users can now selectively email roster members, alternates, or both based on applied filters.

## Key Changes

### Filtering & Email Features
- **Status Filter**: Added new `statusFilter` state to allow filtering between roster members and alternates
  - Only displays when alternates exist for a registration
  - Shows member counts for each status
  - Integrated into existing filter clearing logic

- **Smart Email Recipients**: Implemented context-aware email recipient selection
  - "Email Team" button (in header) sends to all roster + alternate members
  - "Email selected" button (in filters section) respects active filters including status
  - Dynamically calculates recipient lists based on filter state

### UI/UX Improvements
- Added email icon button to registration headers for quick access
- Moved email action buttons to action button groups for better organization
- Changed email button styling from prominent blue to subtle gray for secondary action
- Updated button layouts to be responsive (flex-col on mobile, flex-row on desktop)
- Email button now displays recipient count when filters are active

### Pages Updated
1. **Captain Roster Page** (`src/app/(user)/user/captain/[id]/roster/page.tsx`)
   - Added status filter UI and logic
   - Implemented dual email modes (all vs. filtered)

2. **Admin Registration Detail** (`src/app/admin/reports/registrations/[id]/page.tsx`)
   - Added status filter UI and logic
   - Added email team button to page header
   - Updated email button styling and behavior

3. **Admin Registration Reports** (`src/app/admin/reports/registrations/page.tsx`)
   - Added email functionality to registration cards
   - Fetches roster + alternates data for email recipients

4. **Captain Dashboard** (`src/app/(user)/user/captain/page.tsx`)
   - Moved email button from header to action buttons group
   - Includes alternates in email recipients

### API Changes
- Updated `GET /api/admin/reports/registrations` to exclude refunded members from roster counts (matching email recipient logic)
- Ensures consistency between displayed counts and actual email recipients

## Implementation Details
- Email recipient calculation is centralized using `rosterRecipients`, `alternateRecipients`, and `filteredEmailRecipients` variables
- Status filter state is properly cleared along with other filters
- All email modals now receive recipients based on context (all members vs. filtered selection)

https://claude.ai/code/session_01TmcrhEriqqz3xtmddt2BWC