### PR TITLE
Add passkey (WebAuthn) sign-in via Supabase native passkeys

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@stripe/react-stripe-js": "^3.7.0",
         "@stripe/stripe-js": "^7.3.1",
         "@supabase/ssr": "^0.6.1",
-        "@supabase/supabase-js": "^2.50.0",
+        "@supabase/supabase-js": "^2.108.1",
         "@types/flatpickr": "^3.0.2",
         "flatpickr": "^4.6.13",
         "loops": "^5.0.1",
@@ -3546,44 +3546,58 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.71.1",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.108.1.tgz",
+      "integrity": "sha512-Lle5rKU8f9LF3K5dDd8Or8mkkG+ptzRZZWKPVMm9B9UuovH65Ss2+iFnQqRsCqaGouvJEcTWyl0cj2riNrrDLQ==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.4.5",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.108.1.tgz",
+      "integrity": "sha512-fxBRW/A4IG7ADQztVt0NaEy5ysiO1WJ2pbldsnBchrkHuyepX0Krek9qA9T4gUQBVVTCE9Ea4pdsM5hfn3nc4A==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
-      }
-    },
-    "node_modules/@supabase/node-fetch": {
-      "version": "2.6.15",
-      "license": "MIT",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "tslib": "2.8.1"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": ">=20.0.0"
       }
     },
+    "node_modules/@supabase/phoenix": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@supabase/phoenix/-/phoenix-0.4.2.tgz",
+      "integrity": "sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==",
+      "license": "MIT"
+    },
     "node_modules/@supabase/postgrest-js": {
-      "version": "1.19.4",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.108.1.tgz",
+      "integrity": "sha512-9lj2MCPPMgSTaJ5y+amnhb3TWPtMFVlbDn2hmX/VV91xQU4j0AauwfMaBErHBJ+zzsSwjc0jLU+zLIZFLQzfig==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.15.1",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.108.1.tgz",
+      "integrity": "sha512-mHGGqOjwd1XTydcoffUqEMsbFQHUi6A3uhQ0EXr3iqzpLqItxKA9nbN6gIQxrZ7JRRnuUe/iOFPUkYV9Tdc5lg==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.13",
-        "@types/phoenix": "^1.6.6",
-        "@types/ws": "^8.18.1",
-        "ws": "^8.18.2"
+        "@supabase/phoenix": "^0.4.2",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/ssr": {
@@ -3597,22 +3611,32 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.11.0",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.108.1.tgz",
+      "integrity": "sha512-Er0SGGt85iT6ye+SSh98Az6L2CesoZJuyzEZYH2oBOAnIxa9Nn4CtwUC3veGxYggoT56X+3tVuuQeDBP8kR8sg==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/node-fetch": "^2.6.14"
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.55.0",
+      "version": "2.108.1",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.108.1.tgz",
+      "integrity": "sha512-V/1hRKLSCJ0zEL+9QFRBUtivvePfOsaAYQmC0HhFNSHC2F3xFs4jSF3YhkLmzex6E4V4FGvmBDOP72D/53NnZA==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.71.1",
-        "@supabase/functions-js": "2.4.5",
-        "@supabase/node-fetch": "2.6.15",
-        "@supabase/postgrest-js": "1.19.4",
-        "@supabase/realtime-js": "2.15.1",
-        "@supabase/storage-js": "^2.10.4"
+        "@supabase/auth-js": "2.108.1",
+        "@supabase/functions-js": "2.108.1",
+        "@supabase/postgrest-js": "2.108.1",
+        "@supabase/realtime-js": "2.108.1",
+        "@supabase/storage-js": "2.108.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@swc/helpers": {
@@ -4119,10 +4143,6 @@
         "@types/pg": "*"
       }
     },
-    "node_modules/@types/phoenix": {
-      "version": "1.6.6",
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
       "version": "19.1.10",
       "dev": true,
@@ -4148,13 +4168,6 @@
       "version": "4.0.14",
       "resolved": "https://registry.npmjs.org/@types/tedious/-/tedious-4.0.14.tgz",
       "integrity": "sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==",
-      "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/ws": {
-      "version": "8.18.1",
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
@@ -7372,6 +7385,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=10.17.0"
+      }
+    },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/ignore": {
@@ -11905,27 +11927,6 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
-      }
-    },
-    "node_modules/ws": {
-      "version": "8.21.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10.0.0"
-      },
-      "peerDependencies": {
-        "bufferutil": "^4.0.1",
-        "utf-8-validate": ">=5.0.2"
-      },
-      "peerDependenciesMeta": {
-        "bufferutil": {
-          "optional": true
-        },
-        "utf-8-validate": {
-          "optional": true
-        }
       }
     },
     "node_modules/xero-node": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@stripe/react-stripe-js": "^3.7.0",
     "@stripe/stripe-js": "^7.3.1",
     "@supabase/ssr": "^0.6.1",
-    "@supabase/supabase-js": "^2.50.0",
+    "@supabase/supabase-js": "^2.108.1",
     "@types/flatpickr": "^3.0.2",
     "flatpickr": "^4.6.13",
     "loops": "^5.0.1",

--- a/src/__tests__/lib/passkeys.test.ts
+++ b/src/__tests__/lib/passkeys.test.ts
@@ -1,0 +1,133 @@
+import {
+  isWebAuthnSupported,
+  isUserCancelledError,
+  isDuplicateRegistrationError,
+  isUnsupportedOriginError,
+  getNextSnoozeDays,
+  getNextSnoozeDate,
+  isPasskeyPromptEligible,
+} from '@/lib/passkeys'
+
+describe('isWebAuthnSupported', () => {
+  afterEach(() => {
+    delete (global as any).window
+  })
+
+  it('returns false when window is undefined (server)', () => {
+    expect(isWebAuthnSupported()).toBe(false)
+  })
+
+  it('returns false when PublicKeyCredential is absent', () => {
+    ;(global as any).window = {}
+    expect(isWebAuthnSupported()).toBe(false)
+  })
+
+  it('returns true when PublicKeyCredential exists', () => {
+    ;(global as any).window = { PublicKeyCredential: function () {} }
+    expect(isWebAuthnSupported()).toBe(true)
+  })
+})
+
+describe('isUserCancelledError', () => {
+  it('returns true for the Supabase ceremony-aborted code', () => {
+    expect(isUserCancelledError({ code: 'ERROR_CEREMONY_ABORTED', name: 'WebAuthnError' })).toBe(true)
+  })
+
+  it('returns true for NotAllowedError directly', () => {
+    expect(isUserCancelledError({ name: 'NotAllowedError' })).toBe(true)
+  })
+
+  it('returns true for AbortError directly', () => {
+    expect(isUserCancelledError({ name: 'AbortError' })).toBe(true)
+  })
+
+  it('returns true when the cause is NotAllowedError', () => {
+    expect(isUserCancelledError({ name: 'WebAuthnError', cause: { name: 'NotAllowedError' } })).toBe(true)
+  })
+
+  it('returns false for generic errors', () => {
+    expect(isUserCancelledError(new Error('boom'))).toBe(false)
+  })
+
+  it('returns false for null/undefined', () => {
+    expect(isUserCancelledError(null)).toBe(false)
+    expect(isUserCancelledError(undefined)).toBe(false)
+  })
+})
+
+describe('isDuplicateRegistrationError', () => {
+  it('returns true for the Supabase previously-registered code', () => {
+    expect(isDuplicateRegistrationError({ code: 'ERROR_AUTHENTICATOR_PREVIOUSLY_REGISTERED' })).toBe(true)
+  })
+
+  it('returns true for InvalidStateError directly and as cause', () => {
+    expect(isDuplicateRegistrationError({ name: 'InvalidStateError' })).toBe(true)
+    expect(isDuplicateRegistrationError({ name: 'WebAuthnError', cause: { name: 'InvalidStateError' } })).toBe(true)
+  })
+
+  it('returns false for other errors', () => {
+    expect(isDuplicateRegistrationError(new Error('boom'))).toBe(false)
+    expect(isDuplicateRegistrationError(null)).toBe(false)
+  })
+})
+
+describe('isUnsupportedOriginError', () => {
+  it('returns true for invalid domain / RP ID codes', () => {
+    expect(isUnsupportedOriginError({ code: 'ERROR_INVALID_DOMAIN' })).toBe(true)
+    expect(isUnsupportedOriginError({ code: 'ERROR_INVALID_RP_ID' })).toBe(true)
+  })
+
+  it('returns true for SecurityError directly and as cause', () => {
+    expect(isUnsupportedOriginError({ name: 'SecurityError' })).toBe(true)
+    expect(isUnsupportedOriginError({ name: 'WebAuthnError', cause: { name: 'SecurityError' } })).toBe(true)
+  })
+
+  it('returns false for other errors', () => {
+    expect(isUnsupportedOriginError(new Error('boom'))).toBe(false)
+    expect(isUnsupportedOriginError(null)).toBe(false)
+  })
+})
+
+describe('getNextSnoozeDays', () => {
+  it('follows the 7 -> 30 -> 90 ladder and caps at 90', () => {
+    expect(getNextSnoozeDays(0)).toBe(7)
+    expect(getNextSnoozeDays(1)).toBe(30)
+    expect(getNextSnoozeDays(2)).toBe(90)
+    expect(getNextSnoozeDays(5)).toBe(90)
+  })
+
+  it('treats negative counts as a first dismissal', () => {
+    expect(getNextSnoozeDays(-1)).toBe(7)
+  })
+})
+
+describe('getNextSnoozeDate', () => {
+  it('returns an ISO date the right number of days out', () => {
+    const from = new Date('2026-06-11T12:00:00.000Z')
+    expect(getNextSnoozeDate(0, from)).toBe('2026-06-18T12:00:00.000Z')
+    expect(getNextSnoozeDate(1, from)).toBe('2026-07-11T12:00:00.000Z')
+    expect(getNextSnoozeDate(2, from)).toBe('2026-09-09T12:00:00.000Z')
+  })
+})
+
+describe('isPasskeyPromptEligible', () => {
+  const now = new Date('2026-06-11T12:00:00.000Z')
+
+  it('is eligible with no stored prefs', () => {
+    expect(isPasskeyPromptEligible(null, now)).toBe(true)
+    expect(isPasskeyPromptEligible(undefined, now)).toBe(true)
+    expect(isPasskeyPromptEligible({}, now)).toBe(true)
+  })
+
+  it('is not eligible when opted out', () => {
+    expect(isPasskeyPromptEligible({ optedOut: true }, now)).toBe(false)
+  })
+
+  it('is not eligible while snoozed', () => {
+    expect(isPasskeyPromptEligible({ snoozedUntil: '2026-06-20T00:00:00.000Z', dismissCount: 1 }, now)).toBe(false)
+  })
+
+  it('is eligible again after the snooze expires', () => {
+    expect(isPasskeyPromptEligible({ snoozedUntil: '2026-06-01T00:00:00.000Z', dismissCount: 1 }, now)).toBe(true)
+  })
+})

--- a/src/__tests__/lib/passkeys.test.ts
+++ b/src/__tests__/lib/passkeys.test.ts
@@ -6,6 +6,7 @@ import {
   getNextSnoozeDays,
   getNextSnoozeDate,
   isPasskeyPromptEligible,
+  getPasskeyStorageHint,
 } from '@/lib/passkeys'
 
 describe('isWebAuthnSupported', () => {
@@ -107,6 +108,30 @@ describe('getNextSnoozeDate', () => {
     expect(getNextSnoozeDate(0, from)).toBe('2026-06-18T12:00:00.000Z')
     expect(getNextSnoozeDate(1, from)).toBe('2026-07-11T12:00:00.000Z')
     expect(getNextSnoozeDate(2, from)).toBe('2026-09-09T12:00:00.000Z')
+  })
+})
+
+describe('getPasskeyStorageHint', () => {
+  it('recognizes Apple authenticators', () => {
+    expect(getPasskeyStorageHint('Apple Passwords')).toContain('Apple Passwords app')
+    expect(getPasskeyStorageHint('iCloud Keychain')).toContain('Apple Passwords app')
+  })
+
+  it('recognizes Google and Chrome authenticators', () => {
+    expect(getPasskeyStorageHint('Google Password Manager')).toBe('Google Password Manager')
+    expect(getPasskeyStorageHint('Chrome on Mac')).toBe('Google Password Manager')
+  })
+
+  it('recognizes third-party password managers', () => {
+    expect(getPasskeyStorageHint('1Password')).toBe('1Password')
+    expect(getPasskeyStorageHint('Bitwarden')).toBe('Bitwarden')
+    expect(getPasskeyStorageHint('Windows Hello')).toBe('Windows Hello')
+  })
+
+  it('falls back to a generic hint for renamed or missing names', () => {
+    expect(getPasskeyStorageHint('My hockey laptop')).toBe('your password manager')
+    expect(getPasskeyStorageHint(undefined)).toBe('your password manager')
+    expect(getPasskeyStorageHint(null)).toBe('your password manager')
   })
 })
 

--- a/src/app/(user)/user/account/page.tsx
+++ b/src/app/(user)/user/account/page.tsx
@@ -7,6 +7,7 @@ import { useToast } from '@/contexts/ToastContext'
 import SignOutButton from '@/components/SignOutButton'
 import DeleteAccountSection from '@/components/DeleteAccountSection'
 import RoleBadge from '@/components/RoleBadge'
+import PasskeysSection from '@/components/PasskeysSection'
 import dynamic from 'next/dynamic'
 
 const PaymentMethodsSection = dynamic(() => import('@/components/PaymentMethodsSection'), { ssr: false })
@@ -445,6 +446,9 @@ export default function AccountPage() {
         </div>
       )}
 
+      {/* Passkeys */}
+      <PasskeysSection />
+
       {/* Account Actions */}
       <div className="bg-white shadow rounded-lg">
         <div className="px-6 py-4 border-b border-gray-200">
@@ -484,7 +488,7 @@ export default function AccountPage() {
             <div className="mt-2 text-sm text-blue-700">
               <p>
                 Your account is secured with passwordless authentication.
-                You sign in using magic links or OAuth providers like Google.
+                You sign in using magic links, passkeys, or OAuth providers like Google.
               </p>
 
               {/* Google OAuth Status - Can Unlink (has 2+ identities) */}

--- a/src/app/(user)/user/page.tsx
+++ b/src/app/(user)/user/page.tsx
@@ -3,6 +3,7 @@ import { getCategoryDisplayName } from '@/lib/registration-utils'
 import { headers } from 'next/headers'
 import { getBaseUrl } from '@/lib/url-utils'
 import DiscountUsage from '@/components/DiscountUsage'
+import PasskeySetupBanner from '@/components/PasskeySetupBanner'
 import RegistrationTypeBadge from '@/components/RegistrationTypeBadge'
 import RoleBadge from '@/components/RoleBadge'
 import EventCalendarButton from '@/components/EventCalendarButton'
@@ -226,6 +227,7 @@ export default async function UserDashboardPage() {
 
   return (
     <div className="px-4 py-3 sm:px-0">
+      <PasskeySetupBanner promptPrefs={userProfile?.preferences?.passkeyPrompt ?? null} />
       <div className="mb-6">
         <h1 className="text-3xl font-bold text-gray-900 mb-6">
           Welcome back, {userProfile?.first_name}!

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,20 +1,29 @@
 'use client'
 
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { KeyRound } from 'lucide-react'
 import { createClient } from '@/lib/supabase/client'
 import { useRouter } from 'next/navigation'
 import { useToast } from '@/contexts/ToastContext'
 import { getSystemTitle } from '@/lib/organization'
+import { isWebAuthnSupported, isUserCancelledError, isUnsupportedOriginError } from '@/lib/passkeys'
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')
   const [loading, setLoading] = useState(false)
+  const [passkeyLoading, setPasskeyLoading] = useState(false)
   const [message, setMessage] = useState('')
   const [authMethod, setAuthMethod] = useState<'magic' | 'otp'>('magic')
   const [showMagicLinkWarning, setShowMagicLinkWarning] = useState(false)
+  const [webauthnSupported, setWebauthnSupported] = useState(false)
   const router = useRouter()
   const supabase = createClient()
   const { showSuccess, showError } = useToast()
+
+  // Set in an effect to avoid a hydration mismatch on the SSR'd page
+  useEffect(() => {
+    setWebauthnSupported(isWebAuthnSupported())
+  }, [])
 
   // Email validation function
   const isValidEmail = (email: string) => {
@@ -120,6 +129,58 @@ export default function LoginPage() {
     }
   }
 
+  const handlePasskeyLogin = async () => {
+    setPasskeyLoading(true)
+    setMessage('')
+
+    try {
+      const { data, error } = await supabase.auth.signInWithPasskey()
+
+      if (error) {
+        if (isUserCancelledError(error)) {
+          // User dismissed the OS passkey dialog — not an error
+          setPasskeyLoading(false)
+          return
+        }
+        if (isUnsupportedOriginError(error)) {
+          showError('Passkeys unavailable', 'Passkey sign-in isn\'t available on this site. Please use email or Google instead.')
+        } else {
+          showError('Passkey sign-in failed', 'We couldn\'t sign you in with a passkey. Please use email or Google instead.')
+        }
+        setPasskeyLoading(false)
+        return
+      }
+
+      if (data?.session) {
+        showSuccess('Welcome back!', 'You have been signed in successfully.')
+        router.push('/user')
+        // Keep loading state while redirecting
+      } else {
+        showError('Passkey sign-in failed', 'We couldn\'t sign you in with a passkey. Please use email or Google instead.')
+        setPasskeyLoading(false)
+      }
+    } catch (error: any) {
+      console.error('Passkey login error:', error)
+
+      if (isUserCancelledError(error)) {
+        setPasskeyLoading(false)
+        return
+      }
+
+      let errorMessage = 'An error occurred. Please try again.'
+      if (error?.message) {
+        if (error.message.includes('Failed to fetch') || error.message.includes('network')) {
+          errorMessage = 'Network error. Please check your connection and try again.'
+        } else {
+          errorMessage = error.message
+        }
+      }
+
+      setMessage(errorMessage)
+      showError('Passkey sign-in failed', errorMessage)
+      setPasskeyLoading(false)
+    }
+  }
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
@@ -231,7 +292,7 @@ export default function LoginPage() {
             <div>
               <button
                 type="submit"
-                disabled={loading || !isValidEmail(email)}
+                disabled={loading || passkeyLoading || !isValidEmail(email)}
                 className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {loading 
@@ -257,7 +318,7 @@ export default function LoginPage() {
             <div className="mt-6">
               <button
                 onClick={handleGoogleLogin}
-                disabled={loading}
+                disabled={loading || passkeyLoading}
                 className="w-full inline-flex justify-center py-2 px-4 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
               >
                 {loading ? (
@@ -275,6 +336,25 @@ export default function LoginPage() {
                 )}
               </button>
             </div>
+
+            {webauthnSupported && (
+              <div className="mt-3">
+                <button
+                  onClick={handlePasskeyLogin}
+                  disabled={loading || passkeyLoading}
+                  className="w-full inline-flex justify-center items-center py-2 px-4 border border-gray-300 rounded-md shadow-sm bg-white text-sm font-medium text-gray-500 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {passkeyLoading ? (
+                    'Waiting for passkey...'
+                  ) : (
+                    <>
+                      <KeyRound className="w-5 h-5" />
+                      <span className="ml-2">Sign in with a passkey</span>
+                    </>
+                  )}
+                </button>
+              </div>
+            )}
           </div>
         </div>
       </div>

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -145,7 +145,7 @@ export default function LoginPage() {
         if (isUnsupportedOriginError(error)) {
           showError('Passkeys unavailable', 'Passkey sign-in isn\'t available on this site. Please use email or Google instead.')
         } else {
-          showError('Passkey sign-in failed', 'We couldn\'t sign you in with a passkey. Please use email or Google instead.')
+          showError('Passkey sign-in failed', 'Don\'t have a passkey yet? Sign in with email or Google first, then add one from your Account page.')
         }
         setPasskeyLoading(false)
         return
@@ -156,7 +156,7 @@ export default function LoginPage() {
         router.push('/user')
         // Keep loading state while redirecting
       } else {
-        showError('Passkey sign-in failed', 'We couldn\'t sign you in with a passkey. Please use email or Google instead.')
+        showError('Passkey sign-in failed', 'Don\'t have a passkey yet? Sign in with email or Google first, then add one from your Account page.')
         setPasskeyLoading(false)
       }
     } catch (error: any) {

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -16,6 +16,7 @@ export default function LoginPage() {
   const [authMethod, setAuthMethod] = useState<'magic' | 'otp'>('magic')
   const [showMagicLinkWarning, setShowMagicLinkWarning] = useState(false)
   const [webauthnSupported, setWebauthnSupported] = useState(false)
+  const [showPasskeyHelp, setShowPasskeyHelp] = useState(false)
   const router = useRouter()
   const supabase = createClient()
   const { showSuccess, showError } = useToast()
@@ -132,6 +133,7 @@ export default function LoginPage() {
   const handlePasskeyLogin = async () => {
     setPasskeyLoading(true)
     setMessage('')
+    setShowPasskeyHelp(false)
 
     try {
       const { data, error } = await supabase.auth.signInWithPasskey()
@@ -143,10 +145,11 @@ export default function LoginPage() {
           return
         }
         if (isUnsupportedOriginError(error)) {
-          showError('Passkeys unavailable', 'Passkey sign-in isn\'t available on this site. Please use email or Google instead.')
+          showError('Passkeys unavailable', 'Passkey sign-in isn\'t available on this site.')
         } else {
-          showError('Passkey sign-in failed', 'Don\'t have a passkey yet? Sign in with email or Google first, then add one from your Account page.')
+          showError('Passkey sign-in failed', 'Your passkey didn\'t work.')
         }
+        setShowPasskeyHelp(true)
         setPasskeyLoading(false)
         return
       }
@@ -156,7 +159,8 @@ export default function LoginPage() {
         router.push('/user')
         // Keep loading state while redirecting
       } else {
-        showError('Passkey sign-in failed', 'Don\'t have a passkey yet? Sign in with email or Google first, then add one from your Account page.')
+        showError('Passkey sign-in failed', 'Your passkey didn\'t work.')
+        setShowPasskeyHelp(true)
         setPasskeyLoading(false)
       }
     } catch (error: any) {
@@ -178,6 +182,7 @@ export default function LoginPage() {
 
       setMessage(errorMessage)
       showError('Passkey sign-in failed', errorMessage)
+      setShowPasskeyHelp(true)
       setPasskeyLoading(false)
     }
   }
@@ -353,6 +358,17 @@ export default function LoginPage() {
                     </>
                   )}
                 </button>
+
+                {showPasskeyHelp && (
+                  <div className="mt-3 p-3 rounded-md bg-red-50 border border-red-200 text-sm text-red-800">
+                    <p className="font-medium">Passkey sign-in didn&apos;t work. This usually happens when:</p>
+                    <ul className="mt-1 list-disc list-inside space-y-1">
+                      <li>You haven&apos;t created a passkey yet — sign in with email or Google, then add one from your Account page</li>
+                      <li>Your passkey was created on a different device</li>
+                      <li>The passkey was removed from your account</li>
+                    </ul>
+                  </div>
+                )}
               </div>
             )}
           </div>

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from 'next/navigation'
 import { useToast } from '@/contexts/ToastContext'
 import { getSystemTitle } from '@/lib/organization'
 import { isWebAuthnSupported, isUserCancelledError, isUnsupportedOriginError } from '@/lib/passkeys'
+import PasskeyRemovalHelpDialog from '@/components/PasskeyRemovalHelpDialog'
 
 export default function LoginPage() {
   const [email, setEmail] = useState('')
@@ -17,6 +18,7 @@ export default function LoginPage() {
   const [showMagicLinkWarning, setShowMagicLinkWarning] = useState(false)
   const [webauthnSupported, setWebauthnSupported] = useState(false)
   const [showPasskeyHelp, setShowPasskeyHelp] = useState(false)
+  const [showRemovalHelp, setShowRemovalHelp] = useState(false)
   const router = useRouter()
   const supabase = createClient()
   const { showSuccess, showError } = useToast()
@@ -365,10 +367,24 @@ export default function LoginPage() {
                     <ul className="mt-1 list-disc list-inside space-y-1">
                       <li>You haven&apos;t created a passkey yet — sign in with email or Google, then add one from your Account page</li>
                       <li>You created your passkey on a different device</li>
-                      <li>You deleted this passkey from your account</li>
+                      <li>
+                        You deleted this passkey from your account{' '}
+                        <button
+                          type="button"
+                          onClick={() => setShowRemovalHelp(true)}
+                          className="underline hover:text-red-900"
+                        >
+                          (details)
+                        </button>
+                      </li>
                     </ul>
                   </div>
                 )}
+
+                <PasskeyRemovalHelpDialog
+                  isOpen={showRemovalHelp}
+                  onClose={() => setShowRemovalHelp(false)}
+                />
               </div>
             )}
           </div>

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -364,8 +364,8 @@ export default function LoginPage() {
                     <p className="font-medium">Passkey sign-in didn&apos;t work. This usually happens when:</p>
                     <ul className="mt-1 list-disc list-inside space-y-1">
                       <li>You haven&apos;t created a passkey yet — sign in with email or Google, then add one from your Account page</li>
-                      <li>Your passkey was created on a different device</li>
-                      <li>The passkey was removed from your account</li>
+                      <li>You created your passkey on a different device</li>
+                      <li>You deleted this passkey from your account</li>
                     </ul>
                   </div>
                 )}

--- a/src/components/PasskeyRemovalHelpDialog.tsx
+++ b/src/components/PasskeyRemovalHelpDialog.tsx
@@ -33,18 +33,20 @@ export default function PasskeyRemovalHelpDialog({ isOpen, onClose }: PasskeyRem
           </p>
           <ul className="list-disc list-inside space-y-2">
             <li>
-              <strong>iPhone / iPad:</strong> open the <strong>Passwords</strong> app (or
-              Settings → Passwords on older iOS), search for the site, and delete the passkey.
+              <strong>iPhone / iPad:</strong>{' '}
+              open the <strong>Passwords</strong>{' '}
+              app (or Settings → Passwords on older iOS), search for the site, and delete the passkey.
             </li>
             <li>
-              <strong>Mac:</strong> open the <strong>Passwords</strong> app (press ⌘ Space and
-              type &quot;Passwords&quot;), search for the site, and delete it. It won&apos;t
-              appear in the older Keychain Access app.
+              <strong>Mac:</strong>{' '}
+              open the <strong>Passwords</strong>{' '}
+              app (press ⌘ Space and type &quot;Passwords&quot;), search for the site, and delete it.
+              It won&apos;t appear in the older Keychain Access app.
             </li>
             <li>
-              <strong>Other password managers:</strong> if you saved it with Chrome (Google
-              Password Manager), 1Password, Bitwarden, or similar, open that app and search for
-              the site there.
+              <strong>Other password managers:</strong>{' '}
+              if you saved it with Chrome (Google Password Manager), 1Password, Bitwarden, or
+              similar, open that app and search for the site there.
             </li>
           </ul>
           <p>

--- a/src/components/PasskeyRemovalHelpDialog.tsx
+++ b/src/components/PasskeyRemovalHelpDialog.tsx
@@ -1,0 +1,58 @@
+'use client'
+
+import ConfirmationDialog from '@/components/ConfirmationDialog'
+
+interface PasskeyRemovalHelpDialogProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+/**
+ * Explains how to remove a leftover passkey from the user's device.
+ * Sites can't delete credentials from a device's password manager, so after
+ * a passkey is deleted from the account the device copy must be removed by hand.
+ */
+export default function PasskeyRemovalHelpDialog({ isOpen, onClose }: PasskeyRemovalHelpDialogProps) {
+  // Passkeys are filed under the site's domain in password managers
+  const domain = typeof window !== 'undefined' ? window.location.hostname : ''
+
+  return (
+    <ConfirmationDialog
+      isOpen={isOpen}
+      title="Removing a passkey from your device"
+      variant="info"
+      hideButtons
+      onConfirm={onClose}
+      onCancel={onClose}
+      message={
+        <div className="space-y-3">
+          <p>
+            Deleting a passkey from your account stops it from working, but your device&apos;s
+            password manager may still list it. To remove it completely, look for{' '}
+            <strong>{domain}</strong>:
+          </p>
+          <ul className="list-disc list-inside space-y-2">
+            <li>
+              <strong>iPhone / iPad:</strong> open the <strong>Passwords</strong> app (or
+              Settings → Passwords on older iOS), search for the site, and delete the passkey.
+            </li>
+            <li>
+              <strong>Mac:</strong> open the <strong>Passwords</strong> app (press ⌘ Space and
+              type &quot;Passwords&quot;), search for the site, and delete it. It won&apos;t
+              appear in the older Keychain Access app.
+            </li>
+            <li>
+              <strong>Other password managers:</strong> if you saved it with Chrome (Google
+              Password Manager), 1Password, Bitwarden, or similar, open that app and search for
+              the site there.
+            </li>
+          </ul>
+          <p>
+            Passkeys saved to iCloud Keychain sync across your Apple devices — deleting one there
+            removes it from all of them.
+          </p>
+        </div>
+      }
+    />
+  )
+}

--- a/src/components/PasskeySetupBanner.tsx
+++ b/src/components/PasskeySetupBanner.tsx
@@ -1,0 +1,156 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { KeyRound } from 'lucide-react'
+import { createClient } from '@/lib/supabase/client'
+import { useToast } from '@/contexts/ToastContext'
+import {
+  isWebAuthnSupported,
+  isUserCancelledError,
+  isDuplicateRegistrationError,
+  isUnsupportedOriginError,
+  isPasskeyPromptEligible,
+  getNextSnoozeDate,
+  type PasskeyPromptPrefs,
+} from '@/lib/passkeys'
+
+interface PasskeySetupBannerProps {
+  promptPrefs: PasskeyPromptPrefs | null
+}
+
+export default function PasskeySetupBanner({ promptPrefs }: PasskeySetupBannerProps) {
+  const [visible, setVisible] = useState(false)
+  const [registering, setRegistering] = useState(false)
+  const supabase = createClient()
+  const { showSuccess, showError } = useToast()
+
+  const dismissCount = promptPrefs?.dismissCount ?? 0
+
+  useEffect(() => {
+    if (!isPasskeyPromptEligible(promptPrefs) || !isWebAuthnSupported()) {
+      return
+    }
+
+    let cancelled = false
+    const checkExistingPasskeys = async () => {
+      const { data, error } = await supabase.auth.passkey.list()
+      if (cancelled) return
+      // Only show the banner when we know the user has no passkeys
+      if (!error && (data?.length ?? 0) === 0) {
+        setVisible(true)
+      }
+    }
+
+    checkExistingPasskeys()
+    return () => { cancelled = true }
+  }, [])
+
+  const savePromptPrefs = async (prefs: PasskeyPromptPrefs) => {
+    try {
+      await fetch('/api/user/preferences', {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ passkeyPrompt: prefs }),
+      })
+    } catch (error) {
+      // Non-critical: worst case the banner shows again next visit
+      console.error('Error saving passkey prompt preferences:', error)
+    }
+  }
+
+  const handleSetUp = async () => {
+    setRegistering(true)
+    try {
+      const { error } = await supabase.auth.registerPasskey()
+
+      if (error) {
+        if (isUserCancelledError(error)) {
+          return // User dismissed the OS dialog — keep the banner, no toast
+        }
+        if (isDuplicateRegistrationError(error)) {
+          showError('Already registered', 'This device already has a passkey for your account.')
+          setVisible(false)
+          return
+        }
+        if (isUnsupportedOriginError(error)) {
+          showError('Passkeys unavailable', 'Passkeys aren\'t available on this site.')
+          setVisible(false)
+          return
+        }
+        showError('Passkey setup failed', error.message || 'Something went wrong. You can try again from your account page.')
+        return
+      }
+
+      showSuccess('Passkey created!', 'You can now sign in with your passkey. Manage it from your account page.')
+      setVisible(false)
+    } catch (error: any) {
+      if (!isUserCancelledError(error)) {
+        console.error('Passkey registration error:', error)
+        showError('Passkey setup failed', 'Something went wrong. You can try again from your account page.')
+      }
+    } finally {
+      setRegistering(false)
+    }
+  }
+
+  const handleRemindLater = () => {
+    setVisible(false)
+    savePromptPrefs({
+      snoozedUntil: getNextSnoozeDate(dismissCount),
+      dismissCount: dismissCount + 1,
+    })
+  }
+
+  const handleDontAskAgain = () => {
+    setVisible(false)
+    savePromptPrefs({
+      ...promptPrefs,
+      optedOut: true,
+    })
+  }
+
+  if (!visible) {
+    return null
+  }
+
+  return (
+    <div className="p-4 rounded-md bg-blue-50 border border-blue-200 mb-6">
+      <div className="flex">
+        <div className="flex-shrink-0">
+          <KeyRound className="h-5 w-5 text-blue-500" />
+        </div>
+        <div className="ml-3 flex-1">
+          <h3 className="text-sm font-medium text-blue-800">Sign in faster with a passkey</h3>
+          <div className="mt-1 text-sm text-blue-700">
+            Skip the email codes — use your fingerprint, face, or device PIN to sign in securely with one tap.
+          </div>
+          <div className="mt-3 flex items-center space-x-4">
+            <button
+              onClick={handleSetUp}
+              disabled={registering}
+              className="px-3 py-1.5 text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {registering ? 'Waiting for your device...' : 'Set up passkey'}
+            </button>
+            <button
+              onClick={handleRemindLater}
+              disabled={registering}
+              className="text-sm font-medium text-blue-700 hover:text-blue-900 disabled:opacity-50"
+            >
+              Remind me later
+            </button>
+            {dismissCount >= 2 && (
+              <button
+                onClick={handleDontAskAgain}
+                disabled={registering}
+                className="text-sm text-blue-500 hover:text-blue-700 underline disabled:opacity-50"
+              >
+                Don&apos;t ask again
+              </button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/PasskeySetupBanner.tsx
+++ b/src/components/PasskeySetupBanner.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react'
 import { KeyRound } from 'lucide-react'
 import { createClient } from '@/lib/supabase/client'
 import { useToast } from '@/contexts/ToastContext'
+import ConfirmationDialog from '@/components/ConfirmationDialog'
 import {
   isWebAuthnSupported,
   isUserCancelledError,
@@ -11,6 +12,7 @@ import {
   isUnsupportedOriginError,
   isPasskeyPromptEligible,
   getNextSnoozeDate,
+  getNextSnoozeDays,
   type PasskeyPromptPrefs,
 } from '@/lib/passkeys'
 
@@ -21,6 +23,7 @@ interface PasskeySetupBannerProps {
 export default function PasskeySetupBanner({ promptPrefs }: PasskeySetupBannerProps) {
   const [visible, setVisible] = useState(false)
   const [registering, setRegistering] = useState(false)
+  const [showSnoozeNotice, setShowSnoozeNotice] = useState(false)
   const supabase = createClient()
   const { showSuccess, showError } = useToast()
 
@@ -95,6 +98,7 @@ export default function PasskeySetupBanner({ promptPrefs }: PasskeySetupBannerPr
 
   const handleRemindLater = () => {
     setVisible(false)
+    setShowSnoozeNotice(true)
     savePromptPrefs({
       snoozedUntil: getNextSnoozeDate(dismissCount),
       dismissCount: dismissCount + 1,
@@ -109,8 +113,42 @@ export default function PasskeySetupBanner({ promptPrefs }: PasskeySetupBannerPr
     })
   }
 
+  const snoozeNoticeDialog = (
+    <ConfirmationDialog
+      isOpen={showSnoozeNotice}
+      title="We'll remind you later"
+      variant="info"
+      hideButtons
+      onConfirm={() => setShowSnoozeNotice(false)}
+      onCancel={() => setShowSnoozeNotice(false)}
+      message={
+        <div className="space-y-3">
+          <p>
+            We&apos;ll show this reminder again in about {getNextSnoozeDays(dismissCount)} days.
+          </p>
+          <p>
+            You can also set up a passkey anytime from the <strong>Passkeys</strong> section of
+            your{' '}
+            <a href="/user/account" className="text-blue-600 hover:text-blue-800 underline">
+              Account page
+            </a>
+            .
+          </p>
+          <div className="flex justify-end">
+            <button
+              onClick={() => setShowSnoozeNotice(false)}
+              className="px-4 py-2 text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700"
+            >
+              Got it
+            </button>
+          </div>
+        </div>
+      }
+    />
+  )
+
   if (!visible) {
-    return null
+    return snoozeNoticeDialog
   }
 
   return (

--- a/src/components/PasskeySetupBanner.tsx
+++ b/src/components/PasskeySetupBanner.tsx
@@ -120,9 +120,9 @@ export default function PasskeySetupBanner({ promptPrefs }: PasskeySetupBannerPr
           <KeyRound className="h-5 w-5 text-blue-500" />
         </div>
         <div className="ml-3 flex-1">
-          <h3 className="text-sm font-medium text-blue-800">Sign in faster with a passkey</h3>
+          <h3 className="text-sm font-medium text-blue-800">Sign in faster — and more securely — with a passkey</h3>
           <div className="mt-1 text-sm text-blue-700">
-            Skip the email codes — use your fingerprint, face, or device PIN to sign in securely with one tap.
+            Use your fingerprint, face, or device PIN instead of email codes. Passkeys can&apos;t be phished or intercepted.
           </div>
           <div className="mt-3 flex items-center space-x-4">
             <button

--- a/src/components/PasskeysSection.tsx
+++ b/src/components/PasskeysSection.tsx
@@ -256,6 +256,11 @@ export default function PasskeysSection() {
               able to sign in with it anymore.
             </p>
             <p className="mt-2">
+              Your device&apos;s password manager (e.g. iCloud Keychain) will still show this
+              passkey until you remove it there too — but it will no longer work after you delete
+              it here.
+            </p>
+            <p className="mt-2">
               You can still sign in with email or Google, so you won&apos;t be locked out of your
               account.
             </p>

--- a/src/components/PasskeysSection.tsx
+++ b/src/components/PasskeysSection.tsx
@@ -5,12 +5,14 @@ import { KeyRound, Pencil, Trash2, Check, X } from 'lucide-react'
 import { createClient } from '@/lib/supabase/client'
 import { useToast } from '@/contexts/ToastContext'
 import ConfirmationDialog from '@/components/ConfirmationDialog'
+import PasskeyRemovalHelpDialog from '@/components/PasskeyRemovalHelpDialog'
 import { formatDate } from '@/lib/date-utils'
 import {
   isWebAuthnSupported,
   isUserCancelledError,
   isDuplicateRegistrationError,
   isUnsupportedOriginError,
+  getPasskeyStorageHint,
 } from '@/lib/passkeys'
 
 interface PasskeyItem {
@@ -30,6 +32,7 @@ export default function PasskeysSection() {
   const [savingRename, setSavingRename] = useState(false)
   const [deleteTarget, setDeleteTarget] = useState<PasskeyItem | null>(null)
   const [deleting, setDeleting] = useState(false)
+  const [showRemovalHelp, setShowRemovalHelp] = useState(false)
 
   const supabase = createClient()
   const { showSuccess, showError } = useToast()
@@ -256,13 +259,20 @@ export default function PasskeysSection() {
               able to sign in with it anymore.
             </p>
             <p className="mt-2">
-              Your device&apos;s password manager (e.g. iCloud Keychain) will still show this
-              passkey until you remove it there too — but it will no longer work after you delete
-              it here.
-            </p>
-            <p className="mt-2">
               You can still sign in with email or Google, so you won&apos;t be locked out of your
               account.
+            </p>
+            <p className="mt-2">
+              ⚠️ Your device will still list this passkey after you delete it here, but it will no
+              longer work. We recommend removing it right away from{' '}
+              {getPasskeyStorageHint(deleteTarget?.friendly_name)}{' '}
+              <button
+                type="button"
+                onClick={() => setShowRemovalHelp(true)}
+                className="underline text-blue-600 hover:text-blue-800"
+              >
+                (details)
+              </button>
             </p>
           </>
         }
@@ -271,6 +281,11 @@ export default function PasskeysSection() {
         isLoading={deleting}
         onConfirm={handleDelete}
         onCancel={() => setDeleteTarget(null)}
+      />
+
+      <PasskeyRemovalHelpDialog
+        isOpen={showRemovalHelp}
+        onClose={() => setShowRemovalHelp(false)}
       />
     </div>
   )

--- a/src/components/PasskeysSection.tsx
+++ b/src/components/PasskeysSection.tsx
@@ -1,0 +1,272 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { KeyRound, Pencil, Trash2, Check, X } from 'lucide-react'
+import { createClient } from '@/lib/supabase/client'
+import { useToast } from '@/contexts/ToastContext'
+import ConfirmationDialog from '@/components/ConfirmationDialog'
+import { formatDate } from '@/lib/date-utils'
+import {
+  isWebAuthnSupported,
+  isUserCancelledError,
+  isDuplicateRegistrationError,
+  isUnsupportedOriginError,
+} from '@/lib/passkeys'
+
+interface PasskeyItem {
+  id: string
+  friendly_name?: string
+  created_at: string
+  last_used_at?: string
+}
+
+export default function PasskeysSection() {
+  const [passkeys, setPasskeys] = useState<PasskeyItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [supported, setSupported] = useState(false)
+  const [adding, setAdding] = useState(false)
+  const [renamingId, setRenamingId] = useState<string | null>(null)
+  const [renameValue, setRenameValue] = useState('')
+  const [savingRename, setSavingRename] = useState(false)
+  const [deleteTarget, setDeleteTarget] = useState<PasskeyItem | null>(null)
+  const [deleting, setDeleting] = useState(false)
+
+  const supabase = createClient()
+  const { showSuccess, showError } = useToast()
+
+  useEffect(() => {
+    setSupported(isWebAuthnSupported())
+    loadPasskeys()
+  }, [])
+
+  const loadPasskeys = async () => {
+    const { data, error } = await supabase.auth.passkey.list()
+    if (error) {
+      console.error('Error loading passkeys:', error)
+    } else {
+      setPasskeys(data ?? [])
+    }
+    setLoading(false)
+  }
+
+  const handleAdd = async () => {
+    setAdding(true)
+    try {
+      const { error } = await supabase.auth.registerPasskey()
+
+      if (error) {
+        if (isUserCancelledError(error)) {
+          return // User dismissed the OS dialog
+        }
+        if (isDuplicateRegistrationError(error)) {
+          showError('Already registered', 'This device already has a passkey for your account.')
+          return
+        }
+        if (isUnsupportedOriginError(error)) {
+          showError('Passkeys unavailable', 'Passkeys aren\'t available on this site.')
+          return
+        }
+        showError('Passkey setup failed', error.message || 'Something went wrong. Please try again.')
+        return
+      }
+
+      showSuccess('Passkey created!', 'You can now sign in with your passkey.')
+      await loadPasskeys()
+    } catch (error: any) {
+      if (!isUserCancelledError(error)) {
+        console.error('Passkey registration error:', error)
+        showError('Passkey setup failed', 'Something went wrong. Please try again.')
+      }
+    } finally {
+      setAdding(false)
+    }
+  }
+
+  const startRename = (passkey: PasskeyItem) => {
+    setRenamingId(passkey.id)
+    setRenameValue(passkey.friendly_name || '')
+  }
+
+  const handleRename = async () => {
+    if (!renamingId) return
+    const friendlyName = renameValue.trim()
+    if (!friendlyName) return
+
+    setSavingRename(true)
+    try {
+      const { error } = await supabase.auth.passkey.update({
+        passkeyId: renamingId,
+        friendlyName,
+      })
+
+      if (error) {
+        showError('Rename failed', error.message || 'Could not rename this passkey.')
+      } else {
+        showSuccess('Passkey renamed', `Now called "${friendlyName}".`)
+        setRenamingId(null)
+        await loadPasskeys()
+      }
+    } finally {
+      setSavingRename(false)
+    }
+  }
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return
+
+    setDeleting(true)
+    try {
+      const { error } = await supabase.auth.passkey.delete({ passkeyId: deleteTarget.id })
+
+      if (error) {
+        showError('Delete failed', error.message || 'Could not delete this passkey.')
+      } else {
+        showSuccess('Passkey deleted', 'You may also want to remove it from your device\'s password manager.')
+        await loadPasskeys()
+      }
+    } finally {
+      setDeleting(false)
+      setDeleteTarget(null)
+    }
+  }
+
+  return (
+    <div className="bg-white shadow rounded-lg mb-6">
+      <div className="px-6 py-4 border-b border-gray-200 flex justify-between items-start">
+        <div>
+          <h2 className="text-lg font-medium text-gray-900">Passkeys</h2>
+          <p className="mt-1 text-sm text-gray-600">
+            Sign in with your fingerprint, face, or device PIN instead of email codes
+          </p>
+        </div>
+        {supported && (
+          <button
+            onClick={handleAdd}
+            disabled={adding}
+            className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors min-w-[120px] text-center disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {adding ? 'Waiting...' : 'Add Passkey'}
+          </button>
+        )}
+      </div>
+      <div className="px-6 py-4">
+        {!supported && (
+          <p className="text-sm text-gray-500">
+            This browser doesn&apos;t support passkeys. Any passkeys you&apos;ve created on other
+            devices are listed below and can be removed here.
+          </p>
+        )}
+
+        {loading ? (
+          <p className="text-sm text-gray-500">Loading passkeys...</p>
+        ) : passkeys.length === 0 ? (
+          supported ? (
+            <div className="flex items-start">
+              <KeyRound className="h-5 w-5 text-gray-400 mt-0.5 flex-shrink-0" />
+              <p className="ml-3 text-sm text-gray-600">
+                You don&apos;t have any passkeys yet. Add one to sign in faster and more securely —
+                no email codes needed.
+              </p>
+            </div>
+          ) : (
+            <p className="mt-2 text-sm text-gray-500">No passkeys on your account.</p>
+          )
+        ) : (
+          <ul className="divide-y divide-gray-200">
+            {passkeys.map((passkey) => (
+              <li key={passkey.id} className="py-3 flex items-center justify-between">
+                <div className="flex items-center min-w-0">
+                  <KeyRound className="h-5 w-5 text-gray-400 flex-shrink-0" />
+                  <div className="ml-3 min-w-0">
+                    {renamingId === passkey.id ? (
+                      <div className="flex items-center space-x-2">
+                        <input
+                          type="text"
+                          value={renameValue}
+                          onChange={(e) => setRenameValue(e.target.value)}
+                          onKeyDown={(e) => {
+                            if (e.key === 'Enter') handleRename()
+                            if (e.key === 'Escape') setRenamingId(null)
+                          }}
+                          maxLength={120}
+                          autoFocus
+                          className="block w-48 px-2 py-1 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500"
+                        />
+                        <button
+                          onClick={handleRename}
+                          disabled={savingRename || !renameValue.trim()}
+                          className="text-green-600 hover:text-green-800 disabled:opacity-50"
+                          title="Save name"
+                        >
+                          <Check className="h-4 w-4" />
+                        </button>
+                        <button
+                          onClick={() => setRenamingId(null)}
+                          disabled={savingRename}
+                          className="text-gray-400 hover:text-gray-600"
+                          title="Cancel"
+                        >
+                          <X className="h-4 w-4" />
+                        </button>
+                      </div>
+                    ) : (
+                      <p className="text-sm font-medium text-gray-900 truncate">
+                        {passkey.friendly_name || 'Unnamed passkey'}
+                      </p>
+                    )}
+                    <p className="text-sm text-gray-500">
+                      Added {formatDate(passkey.created_at)}
+                      {' · '}
+                      {passkey.last_used_at ? `Last used ${formatDate(passkey.last_used_at)}` : 'Never used'}
+                    </p>
+                  </div>
+                </div>
+                {renamingId !== passkey.id && (
+                  <div className="flex items-center space-x-3 ml-4 flex-shrink-0">
+                    <button
+                      onClick={() => startRename(passkey)}
+                      className="text-gray-400 hover:text-gray-600"
+                      title="Rename passkey"
+                    >
+                      <Pencil className="h-4 w-4" />
+                    </button>
+                    <button
+                      onClick={() => setDeleteTarget(passkey)}
+                      className="text-gray-400 hover:text-red-600"
+                      title="Delete passkey"
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </button>
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <ConfirmationDialog
+        isOpen={!!deleteTarget}
+        title="Delete Passkey"
+        message={
+          <>
+            <p>
+              Are you sure you want to delete{' '}
+              <strong>{deleteTarget?.friendly_name || 'this passkey'}</strong>? You won&apos;t be
+              able to sign in with it anymore.
+            </p>
+            <p className="mt-2">
+              You can still sign in with email or Google, so you won&apos;t be locked out of your
+              account.
+            </p>
+          </>
+        }
+        confirmText="Delete"
+        variant="danger"
+        isLoading={deleting}
+        onConfirm={handleDelete}
+        onCancel={() => setDeleteTarget(null)}
+      />
+    </div>
+  )
+}

--- a/src/components/PasskeysSection.tsx
+++ b/src/components/PasskeysSection.tsx
@@ -25,6 +25,7 @@ interface PasskeyItem {
 export default function PasskeysSection() {
   const [passkeys, setPasskeys] = useState<PasskeyItem[]>([])
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState(false)
   const [supported, setSupported] = useState(false)
   const [adding, setAdding] = useState(false)
   const [renamingId, setRenamingId] = useState<string | null>(null)
@@ -43,11 +44,14 @@ export default function PasskeysSection() {
   }, [])
 
   const loadPasskeys = async () => {
+    setLoading(true)
     const { data, error } = await supabase.auth.passkey.list()
     if (error) {
       console.error('Error loading passkeys:', error)
+      setLoadError(true)
     } else {
       setPasskeys(data ?? [])
+      setLoadError(false)
     }
     setLoading(false)
   }
@@ -162,6 +166,17 @@ export default function PasskeysSection() {
 
         {loading ? (
           <p className="text-sm text-gray-500">Loading passkeys...</p>
+        ) : loadError ? (
+          <p className="text-sm text-gray-600">
+            We couldn&apos;t load your passkeys.{' '}
+            <button
+              type="button"
+              onClick={loadPasskeys}
+              className="text-blue-600 hover:text-blue-800 underline font-medium"
+            >
+              Try again
+            </button>
+          </p>
         ) : passkeys.length === 0 ? (
           supported ? (
             <div className="flex items-start">

--- a/src/lib/passkeys.ts
+++ b/src/lib/passkeys.ts
@@ -1,0 +1,86 @@
+/**
+ * Helpers for passkey (WebAuthn) support detection, error classification,
+ * and the dashboard setup-banner snooze schedule.
+ *
+ * Supabase wraps browser WebAuthn failures in a WebAuthnError with a `code`
+ * property and returns them (rather than throwing), but we also check the
+ * underlying DOMException names defensively.
+ */
+
+export interface PasskeyPromptPrefs {
+  snoozedUntil?: string
+  dismissCount?: number
+  optedOut?: boolean
+}
+
+/** Snooze ladder in days: 1st dismissal -> 7, 2nd -> 30, 3rd+ -> 90 */
+const SNOOZE_LADDER_DAYS = [7, 30, 90]
+
+export function isWebAuthnSupported(): boolean {
+  return typeof window !== 'undefined' && !!window.PublicKeyCredential
+}
+
+function getErrorName(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined
+  return (error as { name?: string }).name
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (!error || typeof error !== 'object') return undefined
+  return (error as { code?: string }).code
+}
+
+function getErrorCause(error: unknown): unknown {
+  if (!error || typeof error !== 'object') return undefined
+  return (error as { cause?: unknown }).cause
+}
+
+/** User cancelled the OS passkey dialog or it timed out — handle silently */
+export function isUserCancelledError(error: unknown): boolean {
+  if (!error) return false
+  if (getErrorCode(error) === 'ERROR_CEREMONY_ABORTED') return true
+  const name = getErrorName(error)
+  if (name === 'NotAllowedError' || name === 'AbortError') return true
+  const cause = getErrorCause(error)
+  if (cause) {
+    const causeName = getErrorName(cause)
+    if (causeName === 'NotAllowedError' || causeName === 'AbortError') return true
+  }
+  return false
+}
+
+/** This authenticator already has a passkey for this account */
+export function isDuplicateRegistrationError(error: unknown): boolean {
+  if (!error) return false
+  if (getErrorCode(error) === 'ERROR_AUTHENTICATOR_PREVIOUSLY_REGISTERED') return true
+  return getErrorName(error) === 'InvalidStateError' || getErrorName(getErrorCause(error)) === 'InvalidStateError'
+}
+
+/** Passkeys can't work on this origin (e.g. RP ID mismatch on preview deploys) */
+export function isUnsupportedOriginError(error: unknown): boolean {
+  if (!error) return false
+  const code = getErrorCode(error)
+  if (code === 'ERROR_INVALID_DOMAIN' || code === 'ERROR_INVALID_RP_ID') return true
+  return getErrorName(error) === 'SecurityError' || getErrorName(getErrorCause(error)) === 'SecurityError'
+}
+
+/** Days until the next banner prompt after the (dismissCount + 1)th dismissal */
+export function getNextSnoozeDays(dismissCount: number): number {
+  const index = Math.min(Math.max(dismissCount, 0), SNOOZE_LADDER_DAYS.length - 1)
+  return SNOOZE_LADDER_DAYS[index]
+}
+
+/** ISO timestamp for when the banner should next appear */
+export function getNextSnoozeDate(dismissCount: number, from: Date = new Date()): string {
+  const next = new Date(from)
+  next.setDate(next.getDate() + getNextSnoozeDays(dismissCount))
+  return next.toISOString()
+}
+
+/** Whether the dashboard banner is eligible to show, based on stored prefs */
+export function isPasskeyPromptEligible(prefs: PasskeyPromptPrefs | undefined | null, now: Date = new Date()): boolean {
+  if (!prefs) return true
+  if (prefs.optedOut) return false
+  if (prefs.snoozedUntil && new Date(prefs.snoozedUntil) > now) return false
+  return true
+}

--- a/src/lib/passkeys.ts
+++ b/src/lib/passkeys.ts
@@ -64,6 +64,21 @@ export function isUnsupportedOriginError(error: unknown): boolean {
   return getErrorName(error) === 'SecurityError' || getErrorName(getErrorCause(error)) === 'SecurityError'
 }
 
+/**
+ * Best-effort guess at where a passkey is stored, from its auto-derived
+ * friendly name (AAGUID-based, e.g. "Apple Passwords"). Renamed passkeys
+ * fall through to the generic hint.
+ */
+export function getPasskeyStorageHint(friendlyName: string | undefined | null): string {
+  const name = (friendlyName || '').toLowerCase()
+  if (name.includes('apple') || name.includes('icloud')) return 'the Apple Passwords app on your iPhone or Mac'
+  if (name.includes('google') || name.includes('chrome')) return 'Google Password Manager'
+  if (name.includes('1password')) return '1Password'
+  if (name.includes('bitwarden')) return 'Bitwarden'
+  if (name.includes('windows') || name.includes('microsoft')) return 'Windows Hello'
+  return 'your password manager'
+}
+
 /** Days until the next banner prompt after the (dismissCount + 1)th dismissal */
 export function getNextSnoozeDays(dismissCount: number): number {
   const index = Math.min(Math.max(dismissCount, 0), SNOOZE_LADDER_DAYS.length - 1)

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -3,6 +3,13 @@ import { createBrowserClient } from '@supabase/ssr'
 export function createClient() {
   return createBrowserClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      auth: {
+        experimental: {
+          passkey: true,
+        },
+      },
+    }
   )
 }


### PR DESCRIPTION
Closes #173

## What changed

Adds passkeys (WebAuthn) as a first-factor sign-in method alongside magic link / 6-digit OTP and Google OAuth, using Supabase's native passkeys feature.

- **Dependency**: `@supabase/supabase-js` 2.50.0 → 2.108.1, with `auth.experimental.passkey: true` on the browser client (`src/lib/supabase/client.ts`). All pre-existing auth calls are stable v2 APIs; full jest suite passes post-upgrade.
- **Login page**: "Sign in with a passkey" button below the Google button (`auth.signInWithPasskey()`, discoverable credentials — no email needed first). Hidden when the browser lacks WebAuthn. User cancellation resets silently; failures show a persistent help box listing common causes (no passkey yet / created on another device / deleted from account) with a "(details)" popup explaining device-side cleanup.
- **Dashboard setup banner**: shown to authenticated users with no passkeys. "Remind me later" snoozes on an escalating 7 → 30 → 90 day ladder (stored in `users.preferences.passkeyPrompt` via the existing preferences endpoint) and confirms via a small dialog pointing to the Account page; a "Don't ask again" opt-out appears after 2 dismissals. Banner disappears permanently once a passkey exists.
- **Account page**: permanent Passkeys card — list (friendly name, added, last used), add, inline rename, delete behind a confirmation dialog. The delete dialog warns that the device's password manager will still list the passkey and recommends removing it there, tailoring the hint to the detected store (Apple Passwords / Google Password Manager / 1Password / etc., guessed from the AAGUID-derived name with a generic fallback).
- **Helpers + tests**: `src/lib/passkeys.ts` (support detection, WebAuthn error classification, snooze ladder, storage hint) with 26 unit tests.

## Why

Faster, phishing-resistant sign-in for members. Passkeys can only be registered by an authenticated user, hence the three-part design (sign-in button, setup nag, management section).

## Reviewer notes

- **No DB migration**: credentials live in Supabase's auth schema; snooze state uses the existing `users.preferences` JSONB.
- **Per-environment dashboard config required** (Authentication → Passkeys): dev project (`qojixnzpfkpteakltdoa`) currently RP ID `localhost`; prod (`fogsphzerhmyjckxhalj`) needs RP ID `my.nycpha.org` before the feature works in production. RP ID changes invalidate existing passkeys.
- Passkeys **cannot work on the bare `*.vercel.app` preview URL** (public-suffix RP ID constraint) — the UI degrades gracefully there. Real-device testing will move to `dev.my.nycpha.org` once its DNS lands.
- Deleting a passkey server-side cannot remove it from the user's keychain (no browser API for that yet) — hence the cleanup guidance in the UI. Stale ghost credentials fail safely at sign-in.
- Manually tested on localhost against the dev project: register (banner + account page), sign out/in with passkey, rename, delete, cancel mid-ceremony, failure paths, snooze persistence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
