### PR TITLE
Development

### DIFF
--- a/docs/features/planning/consolidate-discount-enforcement-phase-1.md
+++ b/docs/features/planning/consolidate-discount-enforcement-phase-1.md
@@ -1,0 +1,203 @@
+# Phase 1 — Consolidate Discount Limit Enforcement
+
+**Status:** 📋 Ready for implementation
+**Created:** 2026-07-27
+**Parent spec:** [Per-User Discount Allowances](./user-discount-allowances.md)
+**PR scope:** Standalone. Must merge before the allowances migration runs.
+
+## Purpose
+
+Seasonal discount cap logic currently exists in three independent implementations. Phase 2
+introduces per-user allowances by extending `discount-limit-service.ts`; if the other two
+implementations still read `discount_categories.max_discount_per_user_per_season` directly at
+that point, they become gatekeeping bypasses — including on the main registration checkout path.
+
+This PR consolidates all three onto the service. **It is a refactor. No user-visible behavior
+should change.**
+
+## Non-Goals
+
+Explicitly out of scope — do not implement any of the following in this PR:
+
+- Allowances, gatekeeping, or any per-user limit concept
+- Schema changes of any kind
+- New columns, tables, migrations, or RLS policies
+- Changes to discount percentages, accounting codes, or Xero staging
+- Improvements to the logic, beyond what reconciliation requires
+
+If the implementation plan proposes any of these, reject it.
+
+## Current State
+
+> **Verify each of the following against the repository before planning.** This section was
+> assembled from code review and may be stale or incomplete. Discrepancies are findings, not
+> obstacles — report them.
+
+### Site A — `src/lib/services/discount-limit-service.ts` (canonical)
+
+The target. Exports:
+
+```ts
+calculateSeasonalDiscountUsage(supabase, userId, categoryId, seasonId): Promise<number>
+checkSeasonalDiscountLimit(supabase, userId, discountCodeId, seasonId, requestedDiscountAmount)
+  : Promise<DiscountLimitResult>
+```
+
+`DiscountLimitResult` = `{ originalAmount, finalAmount, isPartialDiscount, partialDiscountMessage?, seasonalUsage? }`.
+
+Usage is read from the `discount_usage_computed` view. Consumers today are
+`AlternatePaymentService` and `WaitlistPaymentService`.
+
+Behavior at the cap: returns `finalAmount: 0` with an explanatory message. **It does not signal
+an error** — the caller decides what to do with a zero discount.
+
+### Site B — `src/app/api/validate-discount-code/route.ts`
+
+Reimplements the cap check inline. Powers the main registration checkout and the admin refund
+modal. Known divergences from Site A:
+
+| Behavior | Site A | Site B |
+|---|---|---|
+| User is at/over the cap | `finalAmount: 0`, no error | **`isValid: false`** — hard rejection with an error string |
+| Message wording | Service-specific phrasing | Different phrasing |
+| Per-code `usage_limit` | Checked by callers *before* the seasonal check | Appears not to be checked at all — **verify** |
+| Refunds | No concept of refunds | `isRefund` flag bypasses cap enforcement entirely |
+
+The at-the-cap divergence is the significant one: Site B rejects the whole code, Site A returns a
+zero discount. These produce materially different user experiences and cannot both be preserved
+by a single call. See [Decisions Required](#decisions-required).
+
+### Site C — `src/app/api/alternate-registrations/[gameId]/alternates/route.ts`
+
+A third inline copy driving the captain-facing alternate preview list. Builds a
+`usageByUserAndCategory` map and computes, per alternate, `isOverLimit`, a capped
+`discountAmount`, and a `usageStatus` object. Never rejects — it only caps, since it is a
+display path.
+
+**This site is a list, not a single user.** It processes every alternate for a game. The service
+signature is per-user, so a naive call-in-a-loop introduces an N+1 query. See
+[Decisions Required](#decisions-required).
+
+### Also Affected
+
+`src/app/api/admin/reports/discount-usage/route.ts` computes `remaining` and `isFullyUtilized`
+from `category.maxPerUser`. It is **out of scope for this PR** (Phase 5) because per-user limits
+do not exist yet and the report is correct today. Do not modify it. Note it in the PR description
+so it is not forgotten.
+
+## Decisions Required
+
+The implementation plan must state a position on each of these before writing code. They are the
+places where a mechanical consolidation silently changes behavior.
+
+### D1 — Refund handling (`isRefund`)
+
+Site B deliberately bypasses cap enforcement when `isRefund: true`, on the reasoning that a
+refund returns allowance rather than consuming it. Site A has no equivalent.
+
+Options:
+
+- **(a)** Add an `isRefund?: boolean` option to `checkSeasonalDiscountLimit`, which short-circuits
+  and returns the full requested amount. Preserves behavior exactly.
+- **(b)** Keep the refund branch in the route, calling the service only on the non-refund path.
+  Preserves behavior, leaves a small amount of logic outside the service.
+
+**Recommended: (a).** The service becomes the single place that knows the rule. But (b) is
+acceptable if (a) makes the signature awkward. What is *not* acceptable is dropping the branch —
+that would start enforcing caps on refunds, which would break the admin refund modal for any
+user at their seasonal limit.
+
+### D2 — At-the-cap semantics
+
+Site A returns a zero discount; Site B rejects the code outright. Pick one and apply it
+consistently:
+
+- **(a)** Service gains a discriminator (e.g. `isAtLimit: boolean`) and each caller keeps its
+  current presentation — Site B still returns `isValid: false`, Site A's callers still see
+  `finalAmount: 0`. **No user-visible change.**
+- **(b)** Unify on one behavior. **This changes user-visible behavior** and violates the goal of
+  this PR.
+
+**Recommended: (a).** Reconciling the UX is a legitimate discussion, but not in a refactor PR
+that is meant to be verifiable by "the existing tests still pass."
+
+### D3 — Batch usage lookup for Site C
+
+Site C needs usage for many users at once. Options:
+
+- **(a)** Add `calculateSeasonalDiscountUsageBatch(supabase, userIds[], categoryId, seasonId)`
+  returning a `Map<userId, number>`, and have Site C build its display logic on top of it.
+- **(b)** Call the per-user function in a loop.
+
+**Recommended: (a).** (b) is an N+1 against a view that joins six tables, on a path that renders
+a full alternate list. Note that Site C is a *display* path — it may only need the usage figure
+and the cap, not the full `checkSeasonalDiscountLimit` result.
+
+### D4 — Redundant code fetch
+
+`checkSeasonalDiscountLimit` takes a `discountCodeId` and fetches the code record itself. Site B
+has already fetched that record by the time it would call the service. Either accept the extra
+query for now (simplest, and this is not a hot path) or add an overload accepting a pre-fetched
+code. State which, and why.
+
+## Target End State
+
+- `discount-limit-service.ts` is the only module that reads
+  `discount_categories.max_discount_per_user_per_season` or queries `discount_usage_computed`
+  for enforcement purposes.
+- Sites B and C contain no cap arithmetic — they call the service and present the result.
+- Per-code `usage_limit` checks continue to run *before* seasonal cap checks wherever they run
+  today. This ordering is asserted by existing tests; do not change it.
+- All user-facing message strings are byte-identical to today's, unless D2 is resolved
+  otherwise and the change is called out explicitly in the PR description.
+
+## Acceptance Criteria
+
+**Primary: the existing jest suite passes unchanged.** Do not modify these files to make them
+pass — if they fail, the refactor changed behavior:
+
+- `src/__tests__/services/alternate-payment-service.test.ts`
+- `src/__tests__/services/waitlist-payment-service.test.ts`
+
+These already assert the seasonal-cap semantics, the partial-discount path, and the
+per-code-limit-before-seasonal-check ordering. They are the contract.
+
+**Additional:**
+
+- New unit tests covering Sites B and C going through the service, since neither has direct
+  coverage today
+- If D1 resolves to (a): a test that `isRefund: true` bypasses the cap
+- If D3 resolves to (a): a test that the batch function returns the same totals as N individual
+  calls
+- `npm run build` and typecheck clean
+- No new queries introduced on the alternate list path — confirm query count is unchanged or
+  lower
+
+**Manual verification:**
+
+1. Registration checkout with a valid code → discount applies as before
+2. Registration checkout by a user at their seasonal cap → same message as before the change
+3. Registration checkout by a user near the cap → same partial-discount message and amount
+4. Alternate list as a captain → same discount amounts and over-limit flags as before
+5. Admin refund modal with a discount code for a user at their cap → still works (this is the
+   D1 regression case)
+
+## Walkthrough Review Checklist
+
+For reviewing the agent's output before merge. The walkthrough is a self-report; read the diff.
+
+- [ ] No schema files, migrations, or new columns in the diff
+- [ ] `max_discount_per_user_per_season` appears in exactly one source file
+- [ ] `discount_usage_computed` is queried for enforcement in exactly one source file
+- [ ] No user-facing string changed, or each change is listed explicitly
+- [ ] The `isRefund` branch still exists somewhere and is exercised by a test
+- [ ] Existing test files are unmodified
+- [ ] Site C did not gain a per-user query inside a loop
+- [ ] Per-code `usage_limit` still evaluated before seasonal caps
+
+## Notes for the Implementer
+
+The most likely failure mode is a walkthrough that reads "consolidated duplicated discount limit
+logic into the shared service" while having quietly dropped the refund branch or flipped the
+at-the-cap behavior. Both are invisible in a summary and obvious in a diff. D1 and D2 exist
+precisely because those two branches do not survive mechanical deduplication.

--- a/src/__tests__/api/validate-discount-code.test.ts
+++ b/src/__tests__/api/validate-discount-code.test.ts
@@ -1,0 +1,236 @@
+/**
+ * Unit tests for /api/validate-discount-code route
+ * Verifies discount limit consolidation through checkSeasonalDiscountLimit
+ */
+
+import { POST } from '@/app/api/validate-discount-code/route'
+import { NextRequest } from 'next/server'
+import { checkSeasonalDiscountLimit } from '@/lib/services/discount-limit-service'
+
+// Mock dependencies
+jest.mock('@/lib/supabase/server')
+jest.mock('@/lib/services/discount-limit-service', () => {
+  const original = jest.requireActual('@/lib/services/discount-limit-service')
+  return {
+    ...original,
+    checkSeasonalDiscountLimit: jest.fn()
+  }
+})
+
+const mockSupabase = {
+  auth: {
+    getUser: jest.fn()
+  },
+  from: jest.fn(() => ({
+    select: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    single: jest.fn()
+  }))
+}
+
+require('@/lib/supabase/server').createClient = jest.fn(() => Promise.resolve(mockSupabase))
+
+describe('/api/validate-discount-code POST', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('should require authentication', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null }, error: { message: 'Unauthorized' } })
+
+    const request = new NextRequest('http://localhost/api/validate-discount-code', {
+      method: 'POST',
+      body: JSON.stringify({ code: 'DISCOUNT10', registrationId: 'reg-1', amount: 10000 })
+    })
+
+    const response = await POST(request)
+    expect(response.status).toBe(401)
+  })
+
+  it('should return isValid: true when seasonal limit is not exceeded', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null })
+
+    // Mock registration lookup
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1' }, error: null })
+        })
+      })
+    })
+
+    // Mock discount code query
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: {
+                id: 'code-1',
+                code: 'SUMMER20',
+                percentage: 20,
+                is_active: true,
+                discount_categories: {
+                  id: 'cat-1',
+                  name: 'Summer Discounts',
+                  accounting_code: 'ACC123',
+                  max_discount_per_user_per_season: 5000,
+                  is_active: true
+                }
+              },
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    // Mock checkSeasonalDiscountLimit
+    ;(checkSeasonalDiscountLimit as jest.Mock).mockResolvedValue({
+      originalAmount: 2000,
+      finalAmount: 2000,
+      isPartialDiscount: false,
+      isAtLimit: false
+    })
+
+    const request = new NextRequest('http://localhost/api/validate-discount-code', {
+      method: 'POST',
+      body: JSON.stringify({ code: 'SUMMER20', registrationId: 'reg-1', amount: 10000 })
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.isValid).toBe(true)
+    expect(data.discountAmount).toBe(2000)
+    expect(checkSeasonalDiscountLimit).toHaveBeenCalledWith(
+      expect.anything(),
+      'user-1',
+      'code-1',
+      'season-1',
+      2000,
+      expect.objectContaining({ isRefund: false })
+    )
+  })
+
+  it('should return isValid: false hard rejection when user is at seasonal limit', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null })
+
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1' }, error: null })
+        })
+      })
+    })
+
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: {
+                id: 'code-1',
+                code: 'SUMMER20',
+                percentage: 20,
+                is_active: true,
+                discount_categories: {
+                  id: 'cat-1',
+                  name: 'Summer Discounts',
+                  accounting_code: 'ACC123',
+                  max_discount_per_user_per_season: 5000,
+                  is_active: true
+                }
+              },
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    ;(checkSeasonalDiscountLimit as jest.Mock).mockResolvedValue({
+      originalAmount: 2000,
+      finalAmount: 0,
+      isPartialDiscount: false,
+      isAtLimit: true
+    })
+
+    const request = new NextRequest('http://localhost/api/validate-discount-code', {
+      method: 'POST',
+      body: JSON.stringify({ code: 'SUMMER20', registrationId: 'reg-1', amount: 10000 })
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.isValid).toBe(false)
+    expect(data.error).toBe('You have already reached your $50.00 season limit for Summer Discounts. No additional discount can be applied.')
+  })
+
+  it('should pass isRefund: true to service and return full discount when isRefund is true', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null })
+
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1' }, error: null })
+        })
+      })
+    })
+
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: {
+                id: 'code-1',
+                code: 'SUMMER20',
+                percentage: 20,
+                is_active: true,
+                discount_categories: {
+                  id: 'cat-1',
+                  name: 'Summer Discounts',
+                  accounting_code: 'ACC123',
+                  max_discount_per_user_per_season: 5000,
+                  is_active: true
+                }
+              },
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    ;(checkSeasonalDiscountLimit as jest.Mock).mockResolvedValue({
+      originalAmount: 2000,
+      finalAmount: 2000,
+      isPartialDiscount: false,
+      isAtLimit: false
+    })
+
+    const request = new NextRequest('http://localhost/api/validate-discount-code', {
+      method: 'POST',
+      body: JSON.stringify({ code: 'SUMMER20', registrationId: 'reg-1', amount: 10000, isRefund: true })
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.isValid).toBe(true)
+    expect(data.discountAmount).toBe(2000)
+    expect(checkSeasonalDiscountLimit).toHaveBeenCalledWith(
+      expect.anything(),
+      'user-1',
+      'code-1',
+      'season-1',
+      2000,
+      expect.objectContaining({ isRefund: true })
+    )
+  })
+})

--- a/src/__tests__/services/discount-limit-service.test.ts
+++ b/src/__tests__/services/discount-limit-service.test.ts
@@ -5,6 +5,8 @@
 
 import {
   calculateSeasonalDiscountUsage,
+  calculateSeasonalDiscountUsageBatch,
+  evaluateSeasonalDiscountLimit,
   checkSeasonalDiscountLimit,
   getSeasonalDiscountUsageSummary
 } from '@/lib/services/discount-limit-service'
@@ -589,6 +591,205 @@ describe('DiscountLimitService', () => {
       )
 
       expect(result).toBeNull()
+    })
+  })
+
+  describe('Phase 1 Refactor Extensions', () => {
+    it('should bypass seasonal cap when isRefund is true', async () => {
+      const result = await checkSeasonalDiscountLimit(
+        mockSupabase,
+        'user-id',
+        'code-id',
+        'season-id',
+        2500,
+        { isRefund: true }
+      )
+
+      expect(result).toEqual({
+        originalAmount: 2500,
+        finalAmount: 2500,
+        isPartialDiscount: false,
+        isAtLimit: false
+      })
+      // Supabase should not be queried when isRefund is true
+      expect(mockSupabase.from).not.toHaveBeenCalled()
+    })
+
+    it('should set isAtLimit: true when user is at or over cap', async () => {
+      mockSupabase.from.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: {
+                id: 'code-1',
+                code: 'SUMMER20',
+                percentage: 20,
+                category: {
+                  id: 'cat-1',
+                  name: 'Summer',
+                  max_discount_per_user_per_season: 5000
+                }
+              },
+              error: null
+            })
+          })
+        })
+      })
+
+      mockSupabase.from.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              eq: jest.fn().mockResolvedValue({
+                data: [{ amount_saved: 5000 }],
+                error: null
+              })
+            })
+          })
+        })
+      })
+
+      const result = await checkSeasonalDiscountLimit(
+        mockSupabase,
+        'user-1',
+        'code-1',
+        'season-1',
+        1000
+      )
+
+      expect(result.finalAmount).toBe(0)
+      expect(result.isAtLimit).toBe(true)
+      expect(result.isPartialDiscount).toBe(false)
+    })
+
+    it('should set isAtLimit: false when maxAllowed is null or 0', async () => {
+      const preFetchedCode = {
+        id: 'code-1',
+        code: 'NOCAP',
+        percentage: 10,
+        category: {
+          id: 'cat-nocap',
+          name: 'No Cap',
+          max_discount_per_user_per_season: null
+        }
+      }
+
+      const result = await checkSeasonalDiscountLimit(
+        mockSupabase,
+        'user-1',
+        'code-1',
+        'season-1',
+        2000,
+        { discountCode: preFetchedCode }
+      )
+
+      expect(result).toEqual({
+        originalAmount: 2000,
+        finalAmount: 2000,
+        isPartialDiscount: false,
+        isAtLimit: false
+      })
+      expect(mockSupabase.from).not.toHaveBeenCalled()
+    })
+
+    it('should use pre-fetched discountCode with category: null as uncapped discount', async () => {
+      const preFetchedCodeNullCat = {
+        id: 'code-1',
+        code: 'UNCATEGORIZED',
+        percentage: 15,
+        category: null
+      }
+
+      const result = await checkSeasonalDiscountLimit(
+        mockSupabase,
+        'user-1',
+        'code-1',
+        'season-1',
+        1500,
+        { discountCode: preFetchedCodeNullCat }
+      )
+
+      expect(result).toEqual({
+        originalAmount: 1500,
+        finalAmount: 1500,
+        isPartialDiscount: false,
+        isAtLimit: false
+      })
+      expect(mockSupabase.from).not.toHaveBeenCalled()
+    })
+
+    it('calculateSeasonalDiscountUsageBatch should key usage map with colon separator (userId:categoryId)', async () => {
+      mockSupabase.from.mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          in: jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({
+              data: [
+                { user_id: 'u1', discount_category_id: 'c1', amount_saved: 1000 },
+                { user_id: 'u1', discount_category_id: 'c1', amount_saved: 500 },
+                { user_id: 'u2', discount_category_id: 'c2', amount_saved: 2000 }
+              ],
+              error: null
+            })
+          })
+        })
+      })
+
+      const map = await calculateSeasonalDiscountUsageBatch(
+        mockSupabase,
+        ['u1', 'u2'],
+        'season-1'
+      )
+
+      expect(map.get('u1:c1')).toBe(1500)
+      expect(map.get('u2:c2')).toBe(2000)
+      expect(map.get('u1:c2')).toBeUndefined()
+    })
+
+    it('calculateSeasonalDiscountUsageBatch should throw if seasonId is missing', async () => {
+      await expect(
+        calculateSeasonalDiscountUsageBatch(mockSupabase, ['u1'], '')
+      ).rejects.toThrow('Season ID is required for batch seasonal discount usage calculation')
+    })
+
+    it('evaluateSeasonalDiscountLimit should return exact 6-field usageStatus shape', () => {
+      const category = {
+        id: 'cat-1',
+        name: 'Test Category',
+        max_discount_per_user_per_season: 5000
+      }
+
+      const result = evaluateSeasonalDiscountLimit(category, 4000, 2000)
+
+      expect(result.isOverLimit).toBe(true)
+      expect(result.discountAmount).toBe(1000) // Capped at remaining 1000
+      expect(result.usageStatus).toEqual({
+        currentUsage: 4000,
+        limit: 5000,
+        wouldExceed: true,
+        remainingAmount: 1000,
+        requestedAmount: 2000,
+        appliedAmount: 1000
+      })
+    })
+
+    it('evaluateSeasonalDiscountLimit should handle null/unlimited category cleanly', () => {
+      const resultNull = evaluateSeasonalDiscountLimit(null, 1000, 2000)
+      expect(resultNull).toEqual({
+        isOverLimit: false,
+        discountAmount: 2000,
+        usageStatus: null
+      })
+
+      const resultUnlimited = evaluateSeasonalDiscountLimit(
+        { id: 'c1', name: 'Free', max_discount_per_user_per_season: null },
+        1000,
+        2000
+      )
+      expect(resultUnlimited).toEqual({
+        isOverLimit: false,
+        discountAmount: 2000,
+        usageStatus: null
+      })
     })
   })
 })

--- a/src/app/admin/registrations/[id]/games/page.tsx
+++ b/src/app/admin/registrations/[id]/games/page.tsx
@@ -88,12 +88,16 @@ export default function RegistrationGamesPage() {
     
     // Show appropriate toast notifications
     const { summary } = results
+    const failureDetails = (results.results || [])
+      .filter((r: any) => !r.success && r.error)
+      .map((r: any) => (r.userName ? `${r.userName}: ${r.error}` : r.error))
+      .join('\n') || undefined
     if (summary.failedSelections > 0 && summary.successfulSelections === 0) {
       // All selections failed
-      showError(`All ${summary.failedSelections} alternate selections failed. Check payment methods and try again.`)
+      showError(`All ${summary.failedSelections} alternate selections failed.`, failureDetails)
     } else if (summary.failedSelections > 0) {
-      // Some succeeded, some failed  
-      showError(`${summary.failedSelections} of ${summary.totalProcessed} selections failed. ${summary.successfulSelections} were successful.`)
+      // Some succeeded, some failed
+      showError(`${summary.failedSelections} of ${summary.totalProcessed} selections failed. ${summary.successfulSelections} were successful.`, failureDetails)
     } else {
       // All succeeded
       showSuccess(`Successfully selected ${summary.successfulSelections} alternates. Total charged: $${(summary.totalAmountCharged / 100).toFixed(2)}`)

--- a/src/app/api/alternate-registrations/[gameId]/alternates/route.ts
+++ b/src/app/api/alternate-registrations/[gameId]/alternates/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { logger } from '@/lib/logging/logger'
 import { canAccessRegistrationAlternates } from '@/lib/utils/alternates-access'
 import { userHasValidPaymentMethod } from '@/lib/payment-method-utils'
+import { calculateSeasonalDiscountUsageBatch, evaluateSeasonalDiscountLimit } from '@/lib/services/discount-limit-service'
 
 // GET /api/alternate-registrations/[gameId]/alternates - Get available alternates for a game
 export async function GET(
@@ -125,30 +126,15 @@ export async function GET(
 
     const selectedUserIds = new Set(existingSelections?.map(s => s.user_id) || [])
 
-    // Get discount usage for each user to check limits
-    // IMPORTANT: Filter by season_id to only count usage for THIS season
+    // Get discount usage for each user to check limits via discount-limit-service
     const userIds = alternates?.map(alt => alt.user_id) || []
     const registrationSeasonId = registration?.season_id
 
-    let discountUsageQuery = adminSupabase
-      .from('discount_usage_computed')
-      .select('user_id, discount_category_id, amount_saved')
-      .in('user_id', userIds)
-
-    // Filter by the registration's season to get correct seasonal usage
-    if (registrationSeasonId) {
-      discountUsageQuery = discountUsageQuery.eq('season_id', registrationSeasonId)
-    }
-
-    const { data: discountUsage } = await discountUsageQuery
-
-    // Group usage by user and category
-    const usageByUserAndCategory = new Map()
-    discountUsage?.forEach(usage => {
-      const key = `${usage.user_id}-${usage.discount_category_id}`
-      const current = usageByUserAndCategory.get(key) || 0
-      usageByUserAndCategory.set(key, current + usage.amount_saved)
-    })
+    const usageByUserAndCategory = await calculateSeasonalDiscountUsageBatch(
+      adminSupabase,
+      userIds,
+      registrationSeasonId
+    )
 
     // Format alternates data with payment status and discount info
     const formattedAlternates = (alternates || []).map(alternate => {
@@ -158,7 +144,7 @@ export async function GET(
       // Check if user has valid payment method
       const hasValidPaymentMethod = userHasValidPaymentMethod(user)
       
-      // Calculate discount amount and check usage limits
+      // Calculate discount amount and check usage limits using discount-limit-service
       let discountAmount = 0
       let isOverLimit = false
       let usageStatus = null
@@ -166,39 +152,21 @@ export async function GET(
 
       if (discountCode && registration) {
         const basePrice = registration.alternate_price || 0
-
-        // Calculate discount amount (discount codes are always percentage-based)
-        let requestedDiscountAmount = Math.round((basePrice * discountCode.percentage) / 100)
-
-        // Check usage limits and apply seasonal cap
+        const requestedDiscountAmount = Math.round((basePrice * discountCode.percentage) / 100)
         category = Array.isArray(discountCode.category) ? discountCode.category[0] : discountCode.category
-        if (category && category.max_discount_per_user_per_season) {
-          const usageKey = `${user?.id}-${category.id}`
-          const currentUsage = usageByUserAndCategory.get(usageKey) || 0
-          const limit = category.max_discount_per_user_per_season
-          const remainingAmount = Math.max(0, limit - currentUsage)
 
-          isOverLimit = (currentUsage + requestedDiscountAmount) > limit
+        const usageKey = `${alternate.user_id}:${category?.id}`
+        const currentUsage = usageByUserAndCategory.get(usageKey) || 0
 
-          // Apply seasonal cap - use remaining amount if would exceed
-          if (isOverLimit) {
-            discountAmount = remainingAmount
-          } else {
-            discountAmount = requestedDiscountAmount
-          }
+        const evalResult = evaluateSeasonalDiscountLimit(
+          category,
+          currentUsage,
+          requestedDiscountAmount
+        )
 
-          usageStatus = {
-            currentUsage,
-            limit,
-            wouldExceed: isOverLimit,
-            remainingAmount,
-            requestedAmount: requestedDiscountAmount,
-            appliedAmount: discountAmount
-          }
-        } else {
-          // No seasonal cap - use full discount
-          discountAmount = requestedDiscountAmount
-        }
+        isOverLimit = evalResult.isOverLimit
+        discountAmount = evalResult.discountAmount
+        usageStatus = evalResult.usageStatus
       }
 
       const finalAmount = Math.max(0, (registration?.alternate_price || 0) - discountAmount)

--- a/src/app/api/validate-discount-code/route.ts
+++ b/src/app/api/validate-discount-code/route.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
+import { checkSeasonalDiscountLimit, DiscountCodeWithCategory } from '@/lib/services/discount-limit-service'
 
 interface DiscountValidationResult {
   isValid: boolean
@@ -113,56 +114,48 @@ export async function POST(request: NextRequest) {
     // Calculate discount amount
     let discountAmount = Math.round((amount * discountCode.percentage) / 100)
 
-    // Check category usage limits if applicable
+    // Check category usage limits using discount-limit-service
     let isPartialDiscount = false
     let partialDiscountMessage = ''
     
     const category = discountCategory as any
-    
-    if (category?.max_discount_per_user_per_season) {
-      const { data: usageData, error: usageError } = await supabase
-        .from('discount_usage_computed')
-        .select('amount_saved')
-        .eq('user_id', user.id)
-        .eq('discount_category_id', category.id)
-        .eq('season_id', registration.season_id)
+    const codeWithCategory: DiscountCodeWithCategory = {
+      id: discountCode.id,
+      code: discountCode.code,
+      percentage: discountCode.percentage,
+      category: category ? {
+        id: category.id,
+        name: category.name,
+        max_discount_per_user_per_season: category.max_discount_per_user_per_season
+      } : null
+    }
 
-      if (usageError) {
-        console.error('Error checking discount usage:', usageError)
-        return NextResponse.json({ error: 'Error validating discount limits' }, { status: 500 })
+    const limitResult = await checkSeasonalDiscountLimit(
+      supabase,
+      user.id,
+      discountCode.id,
+      registration.season_id,
+      discountAmount,
+      {
+        isRefund,
+        discountCode: codeWithCategory
       }
+    )
 
-      const totalUsed = usageData?.reduce((sum, usage) => sum + usage.amount_saved, 0) || 0
-      const maxAllowed = category.max_discount_per_user_per_season
-      
-      if (isRefund) {
-        // For refunds, we're giving back usage - check if adding this refund would exceed the original limit
-        // But we don't need to prevent it since it's already been used before
-        // Just validate that the discount code and amount are reasonable
-        console.log(`Refund validation: User has used $${(totalUsed / 100).toFixed(2)} of $${(maxAllowed / 100).toFixed(2)} limit. Adding $${(discountAmount / 100).toFixed(2)} back.`)
-        
-        // For refunds, we allow the full discount amount as long as it doesn't exceed what they could have originally used
-        // This handles the case where someone got a partial discount originally and now wants a refund
-      } else {
-        // Original logic for purchases
-        const remaining = Math.max(0, maxAllowed - totalUsed)
-        
-        if (totalUsed >= maxAllowed) {
-          // User has already reached their limit
-          const result: DiscountValidationResult = {
-            isValid: false,
-            error: `You have already reached your $${(maxAllowed / 100).toFixed(2)} season limit for ${category.name}. No additional discount can be applied.`
-          }
-          return NextResponse.json(result)
-        }
-        
-        if (totalUsed + discountAmount > maxAllowed) {
-          // Apply partial discount up to the remaining limit
-          discountAmount = remaining
-          isPartialDiscount = true
-          partialDiscountMessage = `Applied $${(discountAmount / 100).toFixed(2)} discount (${discountCode.code}). You've reached your $${(maxAllowed / 100).toFixed(2)} season limit for ${category.name}.`
-        }
+    if (limitResult.isAtLimit && !isRefund) {
+      const maxAllowed = category?.max_discount_per_user_per_season || 0
+      const result: DiscountValidationResult = {
+        isValid: false,
+        error: `You have already reached your $${(maxAllowed / 100).toFixed(2)} season limit for ${category?.name || ''}. No additional discount can be applied.`
       }
+      return NextResponse.json(result)
+    }
+
+    if (limitResult.isPartialDiscount) {
+      discountAmount = limitResult.finalAmount
+      isPartialDiscount = true
+      const maxAllowed = category?.max_discount_per_user_per_season || 0
+      partialDiscountMessage = `Applied $${(discountAmount / 100).toFixed(2)} discount (${discountCode.code}). You've reached your $${(maxAllowed / 100).toFixed(2)} season limit for ${category?.name || ''}.`
     }
 
     // Valid discount code

--- a/src/components/GameAlternatesCard.tsx
+++ b/src/components/GameAlternatesCard.tsx
@@ -197,9 +197,13 @@ export default function GameAlternatesCard({
         const failed = data.results.filter((r: any) => !r.success).length
         
         if (failed > 0) {
+          const failureDetails = data.results
+            .filter((r: any) => !r.success && r.error)
+            .map((r: any) => (r.userName ? `${r.userName}: ${r.error}` : r.error))
+            .join('\n')
           showError(
-            'Some Alternates Failed', 
-            `${successful} alternates charged successfully, ${failed} failed`
+            `${successful} charged successfully, ${failed} failed`,
+            failureDetails || undefined
           )
         } else if (successful > 0) {
           showSuccess(

--- a/src/lib/services/discount-limit-service.ts
+++ b/src/lib/services/discount-limit-service.ts
@@ -17,10 +17,38 @@ export interface SeasonalDiscountUsage {
   maxAllowed: number
 }
 
+export interface DiscountCategoryInfo {
+  id: string
+  name: string
+  max_discount_per_user_per_season?: number | null
+}
+
+export interface DiscountCodeWithCategory {
+  id: string
+  code: string
+  percentage: number
+  category: DiscountCategoryInfo | null
+}
+
+export interface CheckSeasonalDiscountLimitOptions {
+  isRefund?: boolean
+  discountCode?: DiscountCodeWithCategory
+}
+
+export interface SeasonalDiscountUsageStatus {
+  currentUsage: number
+  limit: number
+  wouldExceed: boolean
+  remainingAmount: number
+  requestedAmount: number
+  appliedAmount: number
+}
+
 export interface DiscountLimitResult {
   originalAmount: number
   finalAmount: number
   isPartialDiscount: boolean
+  isAtLimit?: boolean
   partialDiscountMessage?: string
   seasonalUsage?: SeasonalDiscountUsage
 }
@@ -66,6 +94,106 @@ export async function calculateSeasonalDiscountUsage(
 }
 
 /**
+ * Calculate seasonal discount usage in batch for multiple users within a season
+ *
+ * @param supabase - Supabase client
+ * @param userIds - Array of user IDs
+ * @param seasonId - Season ID
+ * @returns Map of `${userId}:${categoryId}` to total discount amount used
+ */
+export async function calculateSeasonalDiscountUsageBatch(
+  supabase: SupabaseClient,
+  userIds: string[],
+  seasonId: string
+): Promise<Map<string, number>> {
+  const usageMap = new Map<string, number>()
+
+  if (!userIds || userIds.length === 0) {
+    return usageMap
+  }
+
+  if (!seasonId) {
+    throw new Error('Season ID is required for batch seasonal discount usage calculation')
+  }
+
+  const { data: discountUsage, error } = await supabase
+    .from('discount_usage_computed')
+    .select('user_id, discount_category_id, amount_saved')
+    .in('user_id', userIds)
+    .eq('season_id', seasonId)
+
+  if (error) {
+    logger.logPaymentProcessing(
+      'seasonal-discount-usage-batch-query-failed',
+      'Failed to query batch seasonal discount usage',
+      {
+        userIdCount: userIds.length,
+        seasonId,
+        error: error.message
+      },
+      'error'
+    )
+    throw new Error(`Failed to query batch seasonal discount usage: ${error.message}`)
+  }
+
+  discountUsage?.forEach(usage => {
+    const key = `${usage.user_id}:${usage.discount_category_id}`
+    const current = usageMap.get(key) || 0
+    usageMap.set(key, current + (usage.amount_saved || 0))
+  })
+
+  return usageMap
+}
+
+/**
+ * Evaluate seasonal discount limit for a category and given usage
+ * Helper function for list displays (e.g. Site C alternates) to avoid inline cap arithmetic
+ *
+ * @param category - Category metadata
+ * @param currentUsage - Current usage amount (in cents)
+ * @param requestedDiscountAmount - Requested discount amount (in cents)
+ * @returns Calculation result with isOverLimit, discountAmount, and usageStatus
+ */
+export function evaluateSeasonalDiscountLimit(
+  category: DiscountCategoryInfo | null | undefined,
+  currentUsage: number,
+  requestedDiscountAmount: number
+): {
+  isOverLimit: boolean
+  discountAmount: number
+  usageStatus: SeasonalDiscountUsageStatus | null
+} {
+  // 0 means unlimited here, preserving legacy category semantics. This is NOT the allowance convention — see Phase 2, where 0 means ineligible. Do not reuse this check for allowance resolution.
+  const limit = category?.max_discount_per_user_per_season
+  if (!limit || limit <= 0) {
+    return {
+      isOverLimit: false,
+      discountAmount: requestedDiscountAmount,
+      usageStatus: null
+    }
+  }
+
+  const remainingAmount = Math.max(0, limit - currentUsage)
+  const isOverLimit = (currentUsage + requestedDiscountAmount) > limit
+  const discountAmount = isOverLimit ? remainingAmount : requestedDiscountAmount
+
+  const usageStatus: SeasonalDiscountUsageStatus = {
+    currentUsage,
+    limit,
+    wouldExceed: isOverLimit,
+    remainingAmount,
+    requestedAmount: requestedDiscountAmount,
+    appliedAmount: discountAmount
+  }
+
+  return {
+    isOverLimit,
+    discountAmount,
+    usageStatus
+  }
+}
+
+/**
  * Check seasonal discount limit and apply partial discount if needed
  *
  * This is the core function that enforces max_discount_per_user_per_season.
@@ -77,6 +205,7 @@ export async function calculateSeasonalDiscountUsage(
  * @param discountCodeId - Discount code ID
  * @param seasonId - Season ID
  * @param requestedDiscountAmount - The discount amount being requested (in cents)
+ * @param options - Optional refund flag or pre-fetched discount code
  * @returns Result with final discount amount and partial discount info
  */
 export async function checkSeasonalDiscountLimit(
@@ -84,34 +213,61 @@ export async function checkSeasonalDiscountLimit(
   userId: string,
   discountCodeId: string,
   seasonId: string,
-  requestedDiscountAmount: number
+  requestedDiscountAmount: number,
+  options?: CheckSeasonalDiscountLimitOptions
 ): Promise<DiscountLimitResult> {
   try {
-    // Get discount code and category with seasonal limit
-    const { data: discountCode, error: discountError } = await supabase
-      .from('discount_codes')
-      .select(`
-        *,
-        category:discount_categories(
-          id,
-          name,
-          max_discount_per_user_per_season
-        )
-      `)
-      .eq('id', discountCodeId)
-      .single()
-
-    if (discountError || !discountCode) {
-      throw new Error('Discount code not found')
-    }
-
-    // If no seasonal limit is set, allow full discount
-    const maxAllowed = discountCode.category?.max_discount_per_user_per_season
-    if (!maxAllowed || maxAllowed <= 0) {
+    // If refund flow, bypass cap enforcement entirely
+    if (options?.isRefund) {
       return {
         originalAmount: requestedDiscountAmount,
         finalAmount: requestedDiscountAmount,
-        isPartialDiscount: false
+        isPartialDiscount: false,
+        isAtLimit: false
+      }
+    }
+
+    let discountCode = options?.discountCode
+    let category: DiscountCategoryInfo | null | undefined = discountCode?.category
+
+    // If pre-fetched code wasn't supplied, fetch discount code and category from DB
+    if (!discountCode) {
+      const { data: fetchedCode, error: discountError } = await supabase
+        .from('discount_codes')
+        .select(`
+          id,
+          code,
+          percentage,
+          category:discount_categories(
+            id,
+            name,
+            max_discount_per_user_per_season
+          )
+        `)
+        .eq('id', discountCodeId)
+        .single()
+
+      if (discountError || !fetchedCode) {
+        throw new Error('Discount code not found')
+      }
+
+      discountCode = {
+        id: fetchedCode.id,
+        code: fetchedCode.code,
+        percentage: fetchedCode.percentage,
+        category: Array.isArray(fetchedCode.category) ? fetchedCode.category[0] : fetchedCode.category
+      }
+      category = discountCode.category
+    }
+
+    // 0 means unlimited here, preserving legacy category semantics. This is NOT the allowance convention — see Phase 2, where 0 means ineligible. Do not reuse this check for allowance resolution.
+    const maxAllowed = category?.max_discount_per_user_per_season
+    if (!category || !category.id || !maxAllowed || maxAllowed <= 0) {
+      return {
+        originalAmount: requestedDiscountAmount,
+        finalAmount: requestedDiscountAmount,
+        isPartialDiscount: false,
+        isAtLimit: false
       }
     }
 
@@ -119,7 +275,7 @@ export async function checkSeasonalDiscountLimit(
     const totalUsed = await calculateSeasonalDiscountUsage(
       supabase,
       userId,
-      discountCode.category.id,
+      category.id,
       seasonId
     )
 
@@ -133,8 +289,8 @@ export async function checkSeasonalDiscountLimit(
         {
           userId,
           discountCodeId,
-          categoryId: discountCode.category.id,
-          categoryName: discountCode.category.name,
+          categoryId: category.id,
+          categoryName: category.name,
           seasonId,
           totalUsed,
           maxAllowed,
@@ -147,7 +303,8 @@ export async function checkSeasonalDiscountLimit(
         originalAmount: requestedDiscountAmount,
         finalAmount: 0,
         isPartialDiscount: false,
-        partialDiscountMessage: `You have already reached your $${(maxAllowed / 100).toFixed(2)} season limit for ${discountCode.category.name} discounts.`,
+        isAtLimit: true,
+        partialDiscountMessage: `You have already reached your $${(maxAllowed / 100).toFixed(2)} season limit for ${category.name} discounts.`,
         seasonalUsage: {
           totalUsed,
           remaining: 0,
@@ -164,8 +321,8 @@ export async function checkSeasonalDiscountLimit(
         {
           userId,
           discountCodeId,
-          categoryId: discountCode.category.id,
-          categoryName: discountCode.category.name,
+          categoryId: category.id,
+          categoryName: category.name,
           seasonId,
           totalUsed,
           maxAllowed,
@@ -180,7 +337,9 @@ export async function checkSeasonalDiscountLimit(
         originalAmount: requestedDiscountAmount,
         finalAmount: remaining,
         isPartialDiscount: true,
-        partialDiscountMessage: `Applied $${(remaining / 100).toFixed(2)} discount (you have $${(remaining / 100).toFixed(2)} remaining of your $${(maxAllowed / 100).toFixed(2)} ${discountCode.category.name} season limit). You have already used $${(totalUsed / 100).toFixed(2)} in discounts this season.`,
+        isAtLimit: false,
+        // Note: Site B (validate-discount-code route) constructs its own UX message for checkout. Changes to this string will not alter Site B's response.
+        partialDiscountMessage: `Applied $${(remaining / 100).toFixed(2)} discount (you have $${(remaining / 100).toFixed(2)} remaining of your $${(maxAllowed / 100).toFixed(2)} ${category.name} season limit). You have already used $${(totalUsed / 100).toFixed(2)} in discounts this season.`,
         seasonalUsage: {
           totalUsed,
           remaining,
@@ -194,6 +353,7 @@ export async function checkSeasonalDiscountLimit(
       originalAmount: requestedDiscountAmount,
       finalAmount: requestedDiscountAmount,
       isPartialDiscount: false,
+      isAtLimit: false,
       seasonalUsage: {
         totalUsed,
         remaining,


### PR DESCRIPTION
## Summary

Consolidates seasonal discount limit enforcement onto `src/lib/services/discount-limit-service.ts`. The logic previously existed in three independent implementations, which would have become gatekeeping bypasses once per-user discount allowances land.

**This is a behavior-preserving refactor.** No schema changes, no migration, no user-visible change. It is groundwork for [Per-User Discount Allowances](docs/features/planning/user-discount-allowances.md); nothing in this PR is user-facing on its own.

## What changed

| Site | Before | After |
|---|---|---|
| `discount-limit-service.ts` | Canonical implementation, used by alternate + waitlist payment services | Extended and now the single enforcement path |
| `validate-discount-code/route.ts` | Inline cap check (registration checkout + admin refund modal) | Calls the service |
| `alternate-registrations/[gameId]/alternates/route.ts` | Inline batch cap check (captain alternate list) | Calls the service |

New service exports:

- `calculateSeasonalDiscountUsageBatch()` — bulk usage lookup keyed `${userId}:${categoryId}`, so the alternate list stays a single query rather than N
- `evaluateSeasonalDiscountLimit()` — pure cap arithmetic for display paths
- `CheckSeasonalDiscountLimitOptions` — `isRefund` and an optional pre-fetched `discountCode`
- `isAtLimit` on `DiscountLimitResult`

The service also now selects explicit columns instead of `select('*')`.

## Design decisions

- **Refunds** — `isRefund` bypasses cap enforcement, matching current behavior. Previously implemented inline in the route; now the service owns the rule. Dropping this would break the admin refund modal for any member at their seasonal limit.
- **At-the-cap** — the two implementations disagreed: the route rejected the code outright, the service returned a zero discount. Preserved both via `isAtLimit`, so each caller keeps its existing presentation. Reconciling the UX is a separate discussion, not a refactor.
- **Pre-fetched code** — `DiscountCodeWithCategory.category` is a required key with a nullable value. Compile-time safety against a caller omitting it; `null` still behaves as uncapped, exactly as today.
- **Message strings** — byte-identical to before. The route keeps constructing its own copy rather than using the service's, to guarantee no wording change.

## Findings surfaced during review

- **`usage_limit` is dead code.** Both payment services check `discount.usage_limit`, but the column does not exist on `discount_codes`. Because the query used `select('*')`, the field reads as `undefined` and the branch has never executed. Two tests assert enforcement ordering that cannot occur. Left in place deliberately — removing it would break this PR's "existing tests pass unchanged" criterion. Cleanup tracked separately.
- **Two defects caught in review and fixed here:** the batch function applied its `season_id` filter conditionally (a falsy season would have summed usage across *all* seasons, silently under-discounting members); and the alternate list built its lookup key from the joined `users` row rather than the value the batch was queried with. Both corrected before merge.

## Testing

- Existing payment service test suites pass **unmodified** — these assert the seasonal cap semantics, partial-discount path, and check ordering, and are the contract for this refactor
- New coverage: batch usage, `evaluateSeasonalDiscountLimit` shape, `isRefund` bypass, `isAtLimit` flag, null-category handling
- New route-level tests for `/api/validate-discount-code`
- Manual, on dev: admin refund modal for a member at their cap (full and partial refunds, both proportionally scaled and correct to the cent); verified via the discount usage report that a refund restores allowance — a member at $200/$200 correctly read $59.15 used with $140.85 remaining after a partial refund

Alternate and waitlist flows were not manually exercised — harder to set up, and both are read-only display or re-validated at payment time. Monitoring in production instead.

## Deployment notes

- No migration. Nothing to apply.
- Registration checkout now emits `seasonal-discount-limit-reached` and `seasonal-discount-partial-applied` log events, which it did not before. This is the consolidation working, not an anomaly.
- A registration with a null `season_id` now returns a 500 on the alternate list instead of silently rendering cross-season usage. Unreachable in practice; fail-fast by design.

## Not in this PR

- Per-user allowances, gatekeeping, schema changes — Phase 2
- `discount-usage` report showing per-user limits — later phase; correct today
- `usage_limit` dead code removal — separate issue
