### PR TITLE
Development

### DIFF
--- a/.agents/rules/database-migration-limits.md
+++ b/.agents/rules/database-migration-limits.md
@@ -1,0 +1,5 @@
+---
+trigger: always_on
+---
+
+Migrations in this project are applied manually by the maintainer. Write the migration file only. Do not run supabase db push, db reset, migration up, or supabase link under any circumstances. Do not attempt to verify the migration by connecting to the database. The migration file existing in supabase/migrations/ is the complete deliverable.

--- a/docs/features/planning/discount-allowances-phase-2-resolver.md
+++ b/docs/features/planning/discount-allowances-phase-2-resolver.md
@@ -1,0 +1,261 @@
+# Phase 2 — Allowance Schema and Resolver
+
+**Status:** 📋 Ready for implementation — decisions resolved
+**Created:** 2026-07-27
+**Parent spec:** [Per-User Discount Allowances](./user-discount-allowances.md)
+**Depends on:** Phase 1 (consolidation) — merged
+**PR scope:** Migration + resolver. Ships dormant: no allowance rows can exist until Phase 3 provides the UI, and no category is gated until the Phase 4 flip.
+
+## Purpose
+
+Introduce `user_discount_allowances` and teach `discount-limit-service.ts` to resolve a user's
+effective discount percentage and seasonal cap from it, falling back to category defaults.
+
+After this PR the system is fully capable of per-user allowances and gatekeeping, but nothing
+exercises it. That is deliberate — it puts the risky logic in production where it can be observed
+while it is still inert.
+
+## Scope
+
+- Migration: new table, new columns on `discount_categories` and `discount_codes`, indexes, RLS
+- Resolver in `discount-limit-service.ts`
+- Percentage resolution for allowance-driven codes at every site that computes a discount amount
+- Batch allowance lookup for the captain alternate list
+
+## Non-Goals
+
+- Admin API or UI for creating allowances — Phase 3
+- Gating any category, activating `PRIDE`, or deactivating legacy codes — Phase 4
+- Auto-applying discounts at checkout — not scheduled
+- Using `is_default` or `priority` for anything. Both columns are created and left unread; they
+  exist for auto-apply. Do not build selection logic on them.
+- Updating `/api/admin/reports/discount-usage` — Phase 3, where it ships alongside the UI that
+  makes it wrong
+
+## ⚠️ Migration Handling
+
+**Migrations in this project are applied manually by the maintainer.** Write the migration file
+only. Do not run `supabase db push`, `db reset`, `migration up`, or `supabase link`. Do not
+connect to the database to verify. The file existing in `supabase/migrations/` is the complete
+deliverable.
+
+A draft exists at `supabase/migrations/2026-07-27-add-user-discount-allowances.sql`. **It requires
+three corrections before use** — see below.
+
+### Required corrections to the drafted migration
+
+The draft was written before the phased rollout was settled and performs the Phase 4 cutover
+inline. All of it must move out:
+
+1. **`PRIDE` must be inserted with `is_active = false`.** Currently `true`. An active
+   allowance-driven code with no allowance rows and no category `default_percentage` resolves to
+   a null percentage — undefined behavior on a guessable code.
+2. **Do not set `requires_user_allowance = true` on Financial Aid.** The draft does this in a
+   `DO` block. Gating the category while PRIDE25/50/75/100 are still the live codes would make
+   Financial Aid unusable immediately.
+3. **Do not deactivate PRIDE25/50/75/100.** Same reason. They remain the working codes until the
+   Phase 4 flip.
+
+What remains in the Phase 2 migration: schema only, plus the inactive `PRIDE` row. Every data
+change lands in Phase 4 as three statements.
+
+## Current State (post-Phase 1)
+
+`discount-limit-service.ts` is the single enforcement path. Relevant exports:
+
+- `checkSeasonalDiscountLimit(supabase, userId, discountCodeId, seasonId, requestedDiscountAmount, options?)`
+- `calculateSeasonalDiscountUsage(supabase, userId, categoryId, seasonId)`
+- `calculateSeasonalDiscountUsageBatch(supabase, userIds[], seasonId)`
+- `evaluateSeasonalDiscountLimit(category, currentUsage, requestedDiscountAmount)` — pure
+
+Callers: `validate-discount-code` (checkout + admin refund modal), the alternate list route,
+`AlternatePaymentService`, `WaitlistPaymentService`.
+
+**Critical detail:** every caller computes `requestedDiscountAmount` *itself* from
+`discountCode.percentage` before calling the service. The service caps an amount; it does not
+compute one. Allowance-driven codes have `percentage = NULL`, so this is the main structural
+problem Phase 2 has to solve. See D1.
+
+**Note also:** there are no generated Supabase types and the client is untyped, so a wrong column
+name will not fail the build or the mocked tests. Select columns explicitly, never `*` — this is
+exactly how the dead `usage_limit` check survived undetected for years.
+
+## Decisions — RESOLVED
+
+> Resolved by the maintainer, 2026-07-27. The positions below are **binding**. The options in each
+> subsection are retained as rationale, not as open choices.
+>
+> - **D1 → (c).** The resolver returns percentage and limit in one object. One database read;
+>   the caller computes the amount and passes the resolved object into
+>   `evaluateSeasonalDiscountLimit`.
+> - **D2 → derive from the original line item.** Refunds must not re-resolve the percentage. The
+>   allowance is mutable, so re-resolution can produce a credit note that does not match the
+>   original invoice. `isRefund` bypasses eligibility, cap, and percentage re-resolution alike.
+> - **D3 → "This code isn't available to your account."** Use this wording. A generic "invalid
+>   code" was considered and rejected: a member who has been told they qualify but has not yet
+>   been set up by an admin would be misled by it. The message must still leak neither the cap
+>   nor the category.
+> - **D4 → batch as recommended.** `resolveEffectiveDiscountLimitsBatch(...)` returning a `Map`
+>   keyed `${userId}:${categoryId}`, matching the Phase 1 convention.
+> - **D5 → accepted as correct-but-temporary.** During the Phase 3 window a user may redeem a
+>   still-active fixed-percentage code (e.g. `PRIDE75`) and receive that percentage capped by
+>   their allowance. This is acceptable: the dollar cap is the control that matters, and it holds.
+>   No special handling. The window closes at Phase 4, when the legacy codes are deactivated.
+>   Surface this in the Phase 3 admin-facing notes so whoever enters allowance data understands
+>   that rows take effect immediately, not at the flip.
+
+## Decision Rationale
+
+### D1 — Where percentage resolution happens
+
+`uses_user_allowance` codes carry no percentage. Every site that computes an amount from
+`discountCode.percentage` needs the resolved value instead.
+
+- **(a)** The resolver returns `percentage`; each caller fetches it before computing the amount,
+  then calls `checkSeasonalDiscountLimit` as today. Small change per caller, but the allowance
+  is read twice per validation unless the result is threaded through.
+- **(b)** Callers pass the *pre-discount price* and the service computes the amount itself,
+  returning the final figure. Cleaner contract, larger blast radius — changes the signature all
+  four callers use.
+- **(c)** Resolver returns both percentage and limit in one object; the caller computes the
+  amount and passes the already-resolved object into
+  `evaluateSeasonalDiscountLimit` (pure, no second query).
+
+**Recommended: (c).** One database read, no signature change to the pure helper, and it reuses
+the Phase 1 split between lookup and arithmetic. State how `checkSeasonalDiscountLimit` relates
+to the new resolver — whether it wraps it or is superseded for the allowance path.
+
+### D2 — Refund percentage must come from the original invoice, not the current allowance ⚠️
+
+This is the subtlest correctness issue in the phase.
+
+Today, refunding a discounted registration recomputes the discount from the code's fixed
+percentage, which always matches what was originally charged. With allowance-driven codes, the
+percentage lives in a mutable row. If an admin changes a member's allowance from 50% to 25%
+between registration and refund, recomputing yields a credit note that does not match the
+original invoice.
+
+`isRefund` currently bypasses the seasonal cap. For allowance-driven codes it must **also**
+bypass percentage re-resolution, deriving the amount from the original
+`xero_invoice_line_items` entry instead.
+
+Options: derive from the original line item; or snapshot the resolved percentage onto the line
+item at redemption time and read it back. **Recommend the former** — no schema change, and the
+line item is already the source of truth for `discount_usage_computed`.
+
+Also confirm: `isRefund` must bypass the *eligibility* check too, not just the cap. Refunding a
+member whose allowance was since revoked has to work.
+
+### D3 — Rejection message for gated-ineligible users
+
+A user with no allowance for a gated category must not learn that an allowance exists or what
+size it is. "This code isn't available to your account" or similar. **Must not** reuse the
+at-limit string, which names both the cap and the category.
+
+Confirm the shape: a distinct `isEligible: false` on the result that Site B translates into
+`{ isValid: false, error }`, keeping the Phase 1 pattern where the route owns its own strings.
+
+### D4 — Batch allowance lookup for the alternate list
+
+The captain view resolves limits for many users at once. Phase 1 added
+`calculateSeasonalDiscountUsageBatch`; an equivalent is now needed for allowances, or the list
+regresses to N queries.
+
+Suggested: `resolveEffectiveDiscountLimitsBatch(supabase, userIds[], categoryId, seasonId)`
+returning a `Map` keyed the same way (`${userId}:${categoryId}`, colon-delimited, matching
+Phase 1). Note the list may contain codes from different categories, so the key must stay
+per-user-per-category.
+
+### D5 — Interaction between allowances and still-active fixed-percentage codes
+
+During the Phase 3 window, admins enter allowances while Financial Aid is still ungated and
+PRIDE25/50/75/100 are still live. A user with a 50% / $250 allowance who redeems `PRIDE75` gets
+75% (from the fixed code) capped at $250 (from the allowance).
+
+Confirm this is understood and accepted as correct-but-temporary. It follows directly from the
+resolution table and needs no special handling — but it should be a deliberate decision rather
+than a surprise, and it belongs in the Phase 3 admin-facing notes.
+
+## Resolution Semantics
+
+| `requires_user_allowance` | Allowance row | Effective limit |
+|---|---|---|
+| `false` | absent | Category defaults — today's behavior |
+| `false` | present | Allowance overrides; `NULL` columns inherit |
+| `true` | absent | **Not eligible** — code rejected |
+| `true` | present | Allowance overrides; `NULL` columns inherit |
+
+`max_discount_amount = 0` is an **eligibility failure**, producing D3's neutral message — not the
+at-limit message.
+
+⚠️ This directly contradicts the legacy convention preserved in Phase 1, where a category max of
+`0` means *unlimited*. Phase 1 left a comment at that check warning against reuse. Honor it: the
+allowance path needs its own zero handling and must not be built on the legacy check.
+
+Proposed result shape:
+
+```ts
+interface EffectiveLimit {
+  maxAllowed: number | null      // null = unlimited
+  percentage: number | null      // resolved for allowance-driven codes
+  isEligible: boolean            // false = gated category, no allowance (or zero allowance)
+  source: 'user_allowance' | 'category_default' | 'gated_denied'
+}
+```
+
+## Acceptance Criteria
+
+**Behavior must not change**, since no allowance rows exist and no category is gated:
+
+- Existing suites pass unmodified, including the Phase 1 payment service tests
+- Every code path resolves to `source: 'category_default'` in the absence of allowance rows
+- `npm run build` and `npx tsc --noEmit` clean
+
+**New coverage:**
+
+- Ungated category, no allowance → category default
+- Ungated category, allowance present → allowance wins
+- Gated category, no allowance → `isEligible: false`
+- Gated category, allowance with `NULL` columns → inherits category defaults
+- `max_discount_amount = 0` → ineligible, **not** at-limit
+- Allowance percentage overrides `default_percentage`
+- Allowance-driven code with no allowance and no category default → resolves safely, never
+  applies a null or `NaN` discount
+- Refund of an allowance-driven code after the allowance changed → credit note matches the
+  original invoice (D2)
+- Refund for a user whose allowance was revoked → succeeds
+- Batch resolver returns the same values as N single calls
+
+**Manual, after the maintainer applies the migration:**
+
+1. Query `user_discount_allowances` directly — confirm the table, constraints, and indexes exist
+   as written, since nothing else will catch a typo
+2. Insert one allowance row by hand for a test user; confirm the discount reflects it; delete it
+3. Confirm `PRIDE` is present and inactive, and that PRIDE25/50/75/100 still work unchanged
+4. Registration checkout, alternate list, and admin refund modal all behave exactly as before
+
+## Walkthrough Review Checklist
+
+- [ ] Migration contains schema only, plus `PRIDE` with `is_active = false`
+- [ ] No `requires_user_allowance = true` anywhere in the migration
+- [ ] PRIDE25/50/75/100 untouched
+- [ ] No Supabase CLI command was run
+- [ ] Explicit column selects — no `select('*')` against the new table
+- [ ] Allowance zero-handling is separate from the legacy `maxAllowed <= 0` check
+- [ ] Ineligible message leaks neither the cap nor the category
+- [ ] `isRefund` bypasses eligibility *and* cap, and does not re-resolve percentage
+- [ ] Alternate list still issues a bounded number of queries
+- [ ] `is_default` and `priority` are written by the migration and read by nothing
+- [ ] Existing test files unmodified
+
+## Notes for the Implementer
+
+The most likely failure mode is a resolver that works correctly for the cases it was asked about
+and silently returns a null percentage for the case it was not — an allowance-driven code with
+neither an allowance nor a category default. That combination is unreachable in production until
+Phase 4, which is exactly why it will not be caught by manual testing. Handle it explicitly and
+test it.
+
+Second most likely: building allowance zero-handling on top of the legacy `<= 0` check, which
+inverts the meaning. `0` means unlimited in the category path and ineligible in the allowance
+path. They cannot share a branch.

--- a/src/__tests__/api/validate-discount-code.test.ts
+++ b/src/__tests__/api/validate-discount-code.test.ts
@@ -17,15 +17,11 @@ jest.mock('@/lib/services/discount-limit-service', () => {
   }
 })
 
-const mockSupabase = {
+const mockSupabase: any = {
   auth: {
     getUser: jest.fn()
   },
-  from: jest.fn(() => ({
-    select: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    single: jest.fn()
-  }))
+  from: jest.fn()
 }
 
 require('@/lib/supabase/server').createClient = jest.fn(() => Promise.resolve(mockSupabase))
@@ -33,6 +29,21 @@ require('@/lib/supabase/server').createClient = jest.fn(() => Promise.resolve(mo
 describe('/api/validate-discount-code POST', () => {
   beforeEach(() => {
     jest.clearAllMocks()
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'user_discount_allowances') {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockResolvedValue({ data: [], error: null })
+              })
+            })
+          })
+        }
+      }
+      return {}
+    })
   })
 
   it('should require authentication', async () => {
@@ -206,16 +217,37 @@ describe('/api/validate-discount-code POST', () => {
       })
     })
 
-    ;(checkSeasonalDiscountLimit as jest.Mock).mockResolvedValue({
-      originalAmount: 2000,
-      finalAmount: 2000,
-      isPartialDiscount: false,
-      isAtLimit: false
+    // xero_invoices query
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [{ id: 'inv-1' }],
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    // xero_invoice_line_items query
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({
+              data: [{ id: 'item-1', line_amount: -2000 }],
+              error: null
+            })
+          })
+        })
+      })
     })
 
     const request = new NextRequest('http://localhost/api/validate-discount-code', {
       method: 'POST',
-      body: JSON.stringify({ code: 'SUMMER20', registrationId: 'reg-1', amount: 10000, isRefund: true })
+      body: JSON.stringify({ code: 'SUMMER20', registrationId: 'reg-1', paymentId: 'pay-1', amount: 10000, isRefund: true })
     })
 
     const response = await POST(request)
@@ -224,13 +256,453 @@ describe('/api/validate-discount-code POST', () => {
     expect(response.status).toBe(200)
     expect(data.isValid).toBe(true)
     expect(data.discountAmount).toBe(2000)
+  })
+
+  it('should return neutral error message when user is ineligible (limitResult.isEligible === false)', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null })
+
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1' }, error: null })
+        })
+      })
+    })
+
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: {
+                id: 'code-pride',
+                code: 'PRIDE',
+                percentage: null,
+                uses_user_allowance: true,
+                is_active: true,
+                discount_categories: {
+                  id: 'cat-financial-aid',
+                  name: 'Financial Aid',
+                  accounting_code: 'ACC400',
+                  max_discount_per_user_per_season: null,
+                  requires_user_allowance: true,
+                  default_percentage: 50,
+                  is_active: true
+                }
+              },
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    ;(checkSeasonalDiscountLimit as jest.Mock).mockResolvedValue({
+      originalAmount: 5000,
+      finalAmount: 0,
+      isPartialDiscount: false,
+      isAtLimit: false,
+      isEligible: false
+    })
+
+    const request = new NextRequest('http://localhost/api/validate-discount-code', {
+      method: 'POST',
+      body: JSON.stringify({ code: 'PRIDE', registrationId: 'reg-1', amount: 10000 })
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.isValid).toBe(false)
+    expect(data.error).toBe("This code isn't available to your account.")
+  })
+
+  it('should resolve original ACCREC invoice line item for refund and ignore ACCRECCREDIT credit notes', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null })
+
+    // Registration query
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1' }, error: null })
+        })
+      })
+    })
+
+    // Discount code query
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: {
+                id: 'code-1',
+                code: 'SUMMER20',
+                percentage: 20,
+                uses_user_allowance: false,
+                is_active: true,
+                discount_categories: {
+                  id: 'cat-1',
+                  name: 'Summer Discounts',
+                  accounting_code: 'ACC123',
+                  max_discount_per_user_per_season: 5000,
+                  is_active: true
+                }
+              },
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    // xero_invoices query (filtering by ACCREC and sync_status IN ('synced', 'pending'))
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [{ id: 'inv-accrec-original' }],
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    // xero_invoice_line_items query
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({
+              data: [{ id: 'item-1', line_amount: -4000 }],
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    const request = new NextRequest('http://localhost/api/validate-discount-code', {
+      method: 'POST',
+      body: JSON.stringify({ code: 'SUMMER20', registrationId: 'reg-1', paymentId: 'pay-1', amount: 10000, isRefund: true })
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.isValid).toBe(true)
+    expect(data.discountAmount).toBe(4000)
+  })
+
+  it('should ignore abandoned staged ACCREC invoices and resolve synced ACCREC invoice for refund', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null })
+
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1' }, error: null })
+        })
+      })
+    })
+
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: {
+                id: 'code-1',
+                code: 'SUMMER20',
+                percentage: 20,
+                uses_user_allowance: false,
+                is_active: true,
+                discount_categories: {
+                  id: 'cat-1',
+                  name: 'Summer Discounts',
+                  accounting_code: 'ACC123',
+                  max_discount_per_user_per_season: 5000,
+                  is_active: true
+                }
+              },
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    // xero_invoices query returns only the single synced invoice when filtering sync_status in ['synced', 'pending']
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [{ id: 'inv-synced-1' }],
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({
+              data: [{ id: 'item-1', line_amount: -3500 }],
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    const request = new NextRequest('http://localhost/api/validate-discount-code', {
+      method: 'POST',
+      body: JSON.stringify({ code: 'SUMMER20', registrationId: 'reg-1', paymentId: 'pay-1', amount: 10000, isRefund: true })
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.isValid).toBe(true)
+    expect(data.discountAmount).toBe(3500)
+  })
+
+  it('should fail refund for allowance-driven code when no invoice line item is found (no fallback)', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null })
+
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1' }, error: null })
+        })
+      })
+    })
+
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: {
+                id: 'code-pride',
+                code: 'PRIDE',
+                percentage: null,
+                uses_user_allowance: true,
+                is_active: true,
+                discount_categories: {
+                  id: 'cat-financial-aid',
+                  name: 'Financial Aid',
+                  accounting_code: 'ACC400',
+                  max_discount_per_user_per_season: null,
+                  requires_user_allowance: true,
+                  is_active: true
+                }
+              },
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    // xero_invoices returns no invoice
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [],
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    const request = new NextRequest('http://localhost/api/validate-discount-code', {
+      method: 'POST',
+      body: JSON.stringify({ code: 'PRIDE', registrationId: 'reg-1', paymentId: 'pay-missing', amount: 10000, isRefund: true })
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.isValid).toBe(false)
+    expect(data.error).toBe('Original discount line item not found for refund')
+  })
+
+  it('should resolve percentage from allowance for allowance-driven code and calculate requested amount before cap check', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-allowance' } }, error: null })
+
+    // 1. user_registrations query
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1' }, error: null })
+        })
+      })
+    })
+
+    // 2. discount_codes query (uses_user_allowance = true, percentage = null)
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: {
+                id: 'code-pride',
+                code: 'PRIDE',
+                percentage: null,
+                uses_user_allowance: true,
+                is_active: true,
+                discount_categories: {
+                  id: 'cat-aid',
+                  name: 'Financial Aid',
+                  accounting_code: 'ACC500',
+                  max_discount_per_user_per_season: null,
+                  requires_user_allowance: true,
+                  default_percentage: 50,
+                  is_active: true
+                }
+              },
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    // 3. user_discount_allowances query (user has 50% allowance)
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({
+              data: [{ discount_percentage: 50, max_discount_amount: 25000 }],
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    ;(checkSeasonalDiscountLimit as jest.Mock).mockResolvedValue({
+      originalAmount: 50000,
+      finalAmount: 25000, // Capped at $250
+      isPartialDiscount: true,
+      isAtLimit: false
+    })
+
+    const request = new NextRequest('http://localhost/api/validate-discount-code', {
+      method: 'POST',
+      body: JSON.stringify({ code: 'PRIDE', registrationId: 'reg-1', amount: 100000 }) // $1,000 purchase
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.isValid).toBe(true)
+    expect(data.discountCode.percentage).toBe(50) // Effective percentage reported in UI
     expect(checkSeasonalDiscountLimit).toHaveBeenCalledWith(
       expect.anything(),
-      'user-1',
-      'code-1',
+      'user-allowance',
+      'code-pride',
       'season-1',
-      2000,
-      expect.objectContaining({ isRefund: true })
+      50000, // $500 requested (50% of $1,000), NOT $0!
+      expect.objectContaining({ isRefund: false })
+    )
+  })
+
+  it('should preserve fixed code percentage when user has an allowance (D5 scenario)', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-d5' } }, error: null })
+
+    // 1. user_registrations query
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1' }, error: null })
+        })
+      })
+    })
+
+    // 2. discount_codes query (fixed 75% code)
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: {
+                id: 'code-pride75',
+                code: 'PRIDE75',
+                percentage: 75,
+                uses_user_allowance: false,
+                is_active: true,
+                discount_categories: {
+                  id: 'cat-aid',
+                  name: 'Financial Aid',
+                  accounting_code: 'ACC500',
+                  max_discount_per_user_per_season: null,
+                  requires_user_allowance: false,
+                  default_percentage: 50,
+                  is_active: true
+                }
+              },
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    // 3. user_discount_allowances query (user has 50% allowance row)
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({
+              data: [{ discount_percentage: 50, max_discount_amount: 100000 }],
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    ;(checkSeasonalDiscountLimit as jest.Mock).mockResolvedValue({
+      originalAmount: 75000,
+      finalAmount: 75000,
+      isPartialDiscount: false,
+      isAtLimit: false
+    })
+
+    const request = new NextRequest('http://localhost/api/validate-discount-code', {
+      method: 'POST',
+      body: JSON.stringify({ code: 'PRIDE75', registrationId: 'reg-1', amount: 100000 })
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.isValid).toBe(true)
+    expect(data.discountCode.percentage).toBe(75) // Fixed percentage (75%), NOT allowance percentage (50%)!
+    expect(checkSeasonalDiscountLimit).toHaveBeenCalledWith(
+      expect.anything(),
+      'user-d5',
+      'code-pride75',
+      'season-1',
+      75000, // 75% of $1,000
+      expect.objectContaining({ isRefund: false })
     )
   })
 })

--- a/src/__tests__/services/discount-limit-service.test.ts
+++ b/src/__tests__/services/discount-limit-service.test.ts
@@ -8,7 +8,9 @@ import {
   calculateSeasonalDiscountUsageBatch,
   evaluateSeasonalDiscountLimit,
   checkSeasonalDiscountLimit,
-  getSeasonalDiscountUsageSummary
+  getSeasonalDiscountUsageSummary,
+  resolveEffectiveDiscountLimits,
+  resolveEffectiveDiscountLimitsBatch
 } from '@/lib/services/discount-limit-service'
 
 // Mock dependencies
@@ -24,9 +26,21 @@ describe('DiscountLimitService', () => {
   beforeEach(() => {
     jest.clearAllMocks()
 
-    // Create a mock Supabase client
     mockSupabase = {
-      from: jest.fn()
+      from: jest.fn((table: string) => {
+        if (table === 'user_discount_allowances') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({ data: [], error: null })
+                })
+              })
+            })
+          }
+        }
+        return {}
+      })
     }
   })
 
@@ -139,24 +153,40 @@ describe('DiscountLimitService', () => {
   describe('checkSeasonalDiscountLimit', () => {
     it('should allow full discount when no seasonal limit is set', async () => {
       // Mock discount code query - no max_discount_per_user_per_season
-      mockSupabase.from.mockReturnValue({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            single: jest.fn().mockResolvedValue({
-              data: {
-                id: 'code-id',
-                code: 'TEST50',
-                percentage: 50,
-                category: {
-                  id: 'category-id',
-                  name: 'Test Category',
-                  max_discount_per_user_per_season: null
-                }
-              },
-              error: null
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'discount_codes') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                single: jest.fn().mockResolvedValue({
+                  data: {
+                    id: 'code-id',
+                    code: 'TEST50',
+                    percentage: 50,
+                    category: {
+                      id: 'category-id',
+                      name: 'Test Category',
+                      max_discount_per_user_per_season: null
+                    }
+                  },
+                  error: null
+                })
+              })
             })
-          })
-        })
+          }
+        }
+        if (table === 'user_discount_allowances') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({ data: [], error: null })
+                })
+              })
+            })
+          }
+        }
+        return {}
       })
 
       const result = await checkSeasonalDiscountLimit(
@@ -174,42 +204,57 @@ describe('DiscountLimitService', () => {
     })
 
     it('should allow full discount when under seasonal cap', async () => {
-      // Mock discount code query - has seasonal limit of $50
-      mockSupabase.from.mockReturnValueOnce({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            single: jest.fn().mockResolvedValue({
-              data: {
-                id: 'code-id',
-                code: 'TEST50',
-                percentage: 50,
-                category: {
-                  id: 'category-id',
-                  name: 'Test Category',
-                  max_discount_per_user_per_season: 5000 // $50 cap
-                }
-              },
-              error: null
-            })
-          })
-        })
-      })
-
-      // Mock discount usage query - user has used $20 so far
-      mockSupabase.from.mockReturnValueOnce({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            eq: jest.fn().mockReturnValue({
-              eq: jest.fn().mockResolvedValue({
-                data: [
-                  { amount_saved: 1000 },
-                  { amount_saved: 1000 }
-                ],
-                error: null
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'discount_codes') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                single: jest.fn().mockResolvedValue({
+                  data: {
+                    id: 'code-id',
+                    code: 'TEST50',
+                    percentage: 50,
+                    category: {
+                      id: 'category-id',
+                      name: 'Test Category',
+                      max_discount_per_user_per_season: 5000 // $50 cap
+                    }
+                  },
+                  error: null
+                })
               })
             })
-          })
-        })
+          }
+        }
+        if (table === 'user_discount_allowances') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({ data: null, error: null })
+                })
+              })
+            })
+          }
+        }
+        if (table === 'discount_usage_computed') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({
+                    data: [
+                      { amount_saved: 1000 },
+                      { amount_saved: 1000 }
+                    ],
+                    error: null
+                  })
+                })
+              })
+            })
+          }
+        }
+        return {}
       })
 
       const result = await checkSeasonalDiscountLimit(
@@ -231,42 +276,57 @@ describe('DiscountLimitService', () => {
     })
 
     it('should apply partial discount when approaching seasonal cap', async () => {
-      // Mock discount code query - has seasonal limit of $50
-      mockSupabase.from.mockReturnValueOnce({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            single: jest.fn().mockResolvedValue({
-              data: {
-                id: 'code-id',
-                code: 'TEST50',
-                percentage: 50,
-                category: {
-                  id: 'category-id',
-                  name: 'Test Category',
-                  max_discount_per_user_per_season: 5000 // $50 cap
-                }
-              },
-              error: null
-            })
-          })
-        })
-      })
-
-      // Mock discount usage query - user has used $40 so far
-      mockSupabase.from.mockReturnValueOnce({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            eq: jest.fn().mockReturnValue({
-              eq: jest.fn().mockResolvedValue({
-                data: [
-                  { amount_saved: 2000 },
-                  { amount_saved: 2000 }
-                ],
-                error: null
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'discount_codes') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                single: jest.fn().mockResolvedValue({
+                  data: {
+                    id: 'code-id',
+                    code: 'TEST50',
+                    percentage: 50,
+                    category: {
+                      id: 'category-id',
+                      name: 'Test Category',
+                      max_discount_per_user_per_season: 5000 // $50 cap
+                    }
+                  },
+                  error: null
+                })
               })
             })
-          })
-        })
+          }
+        }
+        if (table === 'user_discount_allowances') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({ data: null, error: null })
+                })
+              })
+            })
+          }
+        }
+        if (table === 'discount_usage_computed') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({
+                    data: [
+                      { amount_saved: 2000 },
+                      { amount_saved: 2000 }
+                    ],
+                    error: null
+                  })
+                })
+              })
+            })
+          }
+        }
+        return {}
       })
 
       const result = await checkSeasonalDiscountLimit(
@@ -291,42 +351,57 @@ describe('DiscountLimitService', () => {
     })
 
     it('should apply no discount when seasonal cap is already reached', async () => {
-      // Mock discount code query - has seasonal limit of $50
-      mockSupabase.from.mockReturnValueOnce({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            single: jest.fn().mockResolvedValue({
-              data: {
-                id: 'code-id',
-                code: 'TEST50',
-                percentage: 50,
-                category: {
-                  id: 'category-id',
-                  name: 'Test Category',
-                  max_discount_per_user_per_season: 5000 // $50 cap
-                }
-              },
-              error: null
-            })
-          })
-        })
-      })
-
-      // Mock discount usage query - user has already used $50
-      mockSupabase.from.mockReturnValueOnce({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            eq: jest.fn().mockReturnValue({
-              eq: jest.fn().mockResolvedValue({
-                data: [
-                  { amount_saved: 2500 },
-                  { amount_saved: 2500 }
-                ],
-                error: null
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'discount_codes') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                single: jest.fn().mockResolvedValue({
+                  data: {
+                    id: 'code-id',
+                    code: 'TEST50',
+                    percentage: 50,
+                    category: {
+                      id: 'category-id',
+                      name: 'Test Category',
+                      max_discount_per_user_per_season: 5000 // $50 cap
+                    }
+                  },
+                  error: null
+                })
               })
             })
-          })
-        })
+          }
+        }
+        if (table === 'user_discount_allowances') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({ data: null, error: null })
+                })
+              })
+            })
+          }
+        }
+        if (table === 'discount_usage_computed') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({
+                    data: [
+                      { amount_saved: 2500 },
+                      { amount_saved: 2500 }
+                    ],
+                    error: null
+                  })
+                })
+              })
+            })
+          }
+        }
+        return {}
       })
 
       const result = await checkSeasonalDiscountLimit(
@@ -349,42 +424,57 @@ describe('DiscountLimitService', () => {
     })
 
     it('should apply no discount when seasonal cap is exceeded', async () => {
-      // Mock discount code query - has seasonal limit of $50
-      mockSupabase.from.mockReturnValueOnce({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            single: jest.fn().mockResolvedValue({
-              data: {
-                id: 'code-id',
-                code: 'TEST50',
-                percentage: 50,
-                category: {
-                  id: 'category-id',
-                  name: 'Test Category',
-                  max_discount_per_user_per_season: 5000 // $50 cap
-                }
-              },
-              error: null
-            })
-          })
-        })
-      })
-
-      // Mock discount usage query - user has used $60 (somehow exceeded)
-      mockSupabase.from.mockReturnValueOnce({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            eq: jest.fn().mockReturnValue({
-              eq: jest.fn().mockResolvedValue({
-                data: [
-                  { amount_saved: 3000 },
-                  { amount_saved: 3000 }
-                ],
-                error: null
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'discount_codes') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                single: jest.fn().mockResolvedValue({
+                  data: {
+                    id: 'code-id',
+                    code: 'TEST50',
+                    percentage: 50,
+                    category: {
+                      id: 'category-id',
+                      name: 'Test Category',
+                      max_discount_per_user_per_season: 5000 // $50 cap
+                    }
+                  },
+                  error: null
+                })
               })
             })
-          })
-        })
+          }
+        }
+        if (table === 'user_discount_allowances') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({ data: null, error: null })
+                })
+              })
+            })
+          }
+        }
+        if (table === 'discount_usage_computed') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({
+                    data: [
+                      { amount_saved: 3000 },
+                      { amount_saved: 3000 }
+                    ],
+                    error: null
+                  })
+                })
+              })
+            })
+          }
+        }
+        return {}
       })
 
       const result = await checkSeasonalDiscountLimit(
@@ -616,37 +706,54 @@ describe('DiscountLimitService', () => {
     })
 
     it('should set isAtLimit: true when user is at or over cap', async () => {
-      mockSupabase.from.mockReturnValueOnce({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            single: jest.fn().mockResolvedValue({
-              data: {
-                id: 'code-1',
-                code: 'SUMMER20',
-                percentage: 20,
-                category: {
-                  id: 'cat-1',
-                  name: 'Summer',
-                  max_discount_per_user_per_season: 5000
-                }
-              },
-              error: null
-            })
-          })
-        })
-      })
-
-      mockSupabase.from.mockReturnValueOnce({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            eq: jest.fn().mockReturnValue({
-              eq: jest.fn().mockResolvedValue({
-                data: [{ amount_saved: 5000 }],
-                error: null
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'discount_codes') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                single: jest.fn().mockResolvedValue({
+                  data: {
+                    id: 'code-1',
+                    code: 'SUMMER20',
+                    percentage: 20,
+                    category: {
+                      id: 'cat-1',
+                      name: 'Summer',
+                      max_discount_per_user_per_season: 5000
+                    }
+                  },
+                  error: null
+                })
               })
             })
-          })
-        })
+          }
+        }
+        if (table === 'user_discount_allowances') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({ data: null, error: null })
+                })
+              })
+            })
+          }
+        }
+        if (table === 'discount_usage_computed') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({
+                    data: [{ amount_saved: 5000 }],
+                    error: null
+                  })
+                })
+              })
+            })
+          }
+        }
+        return {}
       })
 
       const result = await checkSeasonalDiscountLimit(
@@ -689,7 +796,7 @@ describe('DiscountLimitService', () => {
         isPartialDiscount: false,
         isAtLimit: false
       })
-      expect(mockSupabase.from).not.toHaveBeenCalled()
+      expect(mockSupabase.from).toHaveBeenCalledWith('user_discount_allowances')
     })
 
     it('should use pre-fetched discountCode with category: null as uncapped discount', async () => {
@@ -790,6 +897,376 @@ describe('DiscountLimitService', () => {
         discountAmount: 2000,
         usageStatus: null
       })
+    })
+  })
+
+  describe('Phase 2 Allowance Resolver (resolveEffectiveDiscountLimits)', () => {
+    it('ungated category, no allowance -> returns category_default', async () => {
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'discount_categories') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                single: jest.fn().mockResolvedValue({
+                  data: {
+                    id: 'cat-1',
+                    name: 'Ungated Category',
+                    requires_user_allowance: false,
+                    max_discount_per_user_per_season: 5000,
+                    default_percentage: '25.00'
+                  },
+                  error: null
+                })
+              })
+            })
+          }
+        }
+        if (table === 'user_discount_allowances') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({ data: null, error: null })
+                })
+              })
+            })
+          }
+        }
+        return {}
+      })
+
+      const res = await resolveEffectiveDiscountLimits(mockSupabase, 'user-1', 'cat-1', 'season-1')
+      expect(res).toEqual({
+        maxAllowed: 5000,
+        percentage: 25,
+        isEligible: true,
+        source: 'category_default'
+      })
+    })
+
+    it('ungated category, allowance present -> user_allowance wins', async () => {
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'discount_categories') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                single: jest.fn().mockResolvedValue({
+                  data: {
+                    id: 'cat-1',
+                    name: 'Ungated Category',
+                    requires_user_allowance: false,
+                    max_discount_per_user_per_season: 5000,
+                    default_percentage: 25
+                  },
+                  error: null
+                })
+              })
+            })
+          }
+        }
+        if (table === 'user_discount_allowances') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({
+                    data: {
+                      discount_percentage: '50.00',
+                      max_discount_amount: 10000
+                    },
+                    error: null
+                  })
+                })
+              })
+            })
+          }
+        }
+        return {}
+      })
+
+      const res = await resolveEffectiveDiscountLimits(mockSupabase, 'user-1', 'cat-1', 'season-1')
+      expect(res).toEqual({
+        maxAllowed: 10000,
+        percentage: 50,
+        isEligible: true,
+        source: 'user_allowance'
+      })
+    })
+
+    it('gated category, no allowance -> isEligible: false, source: denied', async () => {
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'discount_categories') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                single: jest.fn().mockResolvedValue({
+                  data: {
+                    id: 'cat-gated',
+                    name: 'Financial Aid',
+                    requires_user_allowance: true,
+                    max_discount_per_user_per_season: null,
+                    default_percentage: null
+                  },
+                  error: null
+                })
+              })
+            })
+          }
+        }
+        if (table === 'user_discount_allowances') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({ data: null, error: null })
+                })
+              })
+            })
+          }
+        }
+        return {}
+      })
+
+      const res = await resolveEffectiveDiscountLimits(mockSupabase, 'user-1', 'cat-gated', 'season-1')
+      expect(res).toEqual({
+        maxAllowed: null,
+        percentage: null,
+        isEligible: false,
+        source: 'denied'
+      })
+    })
+
+    it('gated category, allowance with NULL discount_percentage -> inherits category default_percentage without NaN', async () => {
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'discount_categories') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                single: jest.fn().mockResolvedValue({
+                  data: {
+                    id: 'cat-gated',
+                    name: 'Financial Aid',
+                    requires_user_allowance: true,
+                    max_discount_per_user_per_season: 8000,
+                    default_percentage: '30.00'
+                  },
+                  error: null
+                })
+              })
+            })
+          }
+        }
+        if (table === 'user_discount_allowances') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({
+                    data: {
+                      discount_percentage: null,
+                      max_discount_amount: null
+                    },
+                    error: null
+                  })
+                })
+              })
+            })
+          }
+        }
+        return {}
+      })
+
+      const res = await resolveEffectiveDiscountLimits(mockSupabase, 'user-1', 'cat-gated', 'season-1')
+      expect(res).toEqual({
+        maxAllowed: 8000,
+        percentage: 30,
+        isEligible: true,
+        source: 'user_allowance'
+      })
+    })
+
+    it('max_discount_amount = 0 on allowance -> isEligible: false, source: denied (NOT unlimited)', async () => {
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'discount_categories') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                single: jest.fn().mockResolvedValue({
+                  data: {
+                    id: 'cat-1',
+                    name: 'Category',
+                    requires_user_allowance: false,
+                    max_discount_per_user_per_season: 5000,
+                    default_percentage: 20
+                  },
+                  error: null
+                })
+              })
+            })
+          }
+        }
+        if (table === 'user_discount_allowances') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({
+                    data: {
+                      discount_percentage: 20,
+                      max_discount_amount: 0
+                    },
+                    error: null
+                  })
+                })
+              })
+            })
+          }
+        }
+        return {}
+      })
+
+      const res = await resolveEffectiveDiscountLimits(mockSupabase, 'user-1', 'cat-1', 'season-1')
+      expect(res).toEqual({
+        maxAllowed: 0,
+        percentage: 20,
+        isEligible: false,
+        source: 'denied'
+      })
+    })
+
+    it('resolveEffectiveDiscountLimitsBatch returns entries for all user/category pairs and handles cache misses', async () => {
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'discount_categories') {
+          return {
+            select: jest.fn().mockResolvedValue({
+              data: [
+                { id: 'cat-1', name: 'Ungated', requires_user_allowance: false, max_discount_per_user_per_season: 5000, default_percentage: '25.00' },
+                { id: 'cat-gated', name: 'Gated', requires_user_allowance: true, max_discount_per_user_per_season: 10000, default_percentage: '50.00' }
+              ],
+              error: null
+            })
+          }
+        }
+        if (table === 'user_discount_allowances') {
+          return {
+            select: jest.fn().mockReturnValue({
+              in: jest.fn().mockReturnValue({
+                eq: jest.fn().mockResolvedValue({
+                  data: [
+                    { user_id: 'u1', discount_category_id: 'cat-gated', discount_percentage: '75.00', max_discount_amount: 15000 }
+                  ],
+                  error: null
+                })
+              })
+            })
+          }
+        }
+        return {}
+      })
+
+      const batchMap = await resolveEffectiveDiscountLimitsBatch(mockSupabase, ['u1', 'u2'], 'season-1')
+
+      // u1 on cat-gated -> user_allowance
+      expect(batchMap.get('u1:cat-gated')).toEqual({
+        maxAllowed: 15000,
+        percentage: 75,
+        isEligible: true,
+        source: 'user_allowance'
+      })
+
+      // u1 on cat-1 (miss) -> category_default
+      expect(batchMap.get('u1:cat-1')).toEqual({
+        maxAllowed: 5000,
+        percentage: 25,
+        isEligible: true,
+        source: 'category_default'
+      })
+
+      // u2 on cat-gated (miss on gated) -> denied
+      expect(batchMap.get('u2:cat-gated')).toEqual({
+        maxAllowed: 10000,
+        percentage: 50,
+        isEligible: false,
+        source: 'denied'
+      })
+    })
+
+    it('isRefund: true bypasses eligibility check and cap for revoked allowances', async () => {
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'discount_codes') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                single: jest.fn().mockResolvedValue({
+                  data: {
+                    id: 'dc-1',
+                    code: 'PRIDE',
+                    percentage: null,
+                    uses_user_allowance: true,
+                    category: {
+                      id: 'cat-gated',
+                      name: 'Financial Aid',
+                      requires_user_allowance: true,
+                      default_percentage: 50,
+                      max_discount_per_user_per_season: null
+                    }
+                  },
+                  error: null
+                })
+              })
+            })
+          }
+        }
+        return {}
+      })
+
+      const res = await checkSeasonalDiscountLimit(
+        mockSupabase,
+        'user-revoked',
+        'dc-1',
+        'season-1',
+        5000,
+        { isRefund: true }
+      )
+
+      expect(res.finalAmount).toBe(5000)
+      expect(res.isPartialDiscount).toBe(false)
+    })
+
+    it('infrastructure query errors in resolveEffectiveDiscountLimits throw rather than returning denied', async () => {
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'discount_categories') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                single: jest.fn().mockResolvedValue({
+                  data: { id: 'cat-1', name: 'Category', requires_user_allowance: false, max_discount_per_user_per_season: 5000, default_percentage: 20 },
+                  error: null
+                })
+              })
+            })
+          }
+        }
+        if (table === 'user_discount_allowances') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({
+                    data: null,
+                    error: { message: 'Database connection failed' }
+                  })
+                })
+              })
+            })
+          }
+        }
+        return {}
+      })
+
+      await expect(
+        resolveEffectiveDiscountLimits(mockSupabase, 'user-1', 'cat-1', 'season-1')
+      ).rejects.toThrow('Database connection failed')
     })
   })
 })

--- a/src/app/admin/reports/users/[id]/invoices/[invoiceId]/RefundModal.tsx
+++ b/src/app/admin/reports/users/[id]/invoices/[invoiceId]/RefundModal.tsx
@@ -157,6 +157,7 @@ export default function RefundModal({
         body: JSON.stringify({
           code: code.trim(),
           registrationId: registrationId,
+          paymentId: paymentId,
           amount: paymentAmount, // Original payment amount
           isRefund: true // Flag to indicate this is a refund validation
         })

--- a/src/app/api/alternate-registrations/[gameId]/alternates/route.ts
+++ b/src/app/api/alternate-registrations/[gameId]/alternates/route.ts
@@ -3,7 +3,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { logger } from '@/lib/logging/logger'
 import { canAccessRegistrationAlternates } from '@/lib/utils/alternates-access'
 import { userHasValidPaymentMethod } from '@/lib/payment-method-utils'
-import { calculateSeasonalDiscountUsageBatch, evaluateSeasonalDiscountLimit } from '@/lib/services/discount-limit-service'
+import { calculateSeasonalDiscountUsageBatch, evaluateSeasonalDiscountLimit, resolveEffectiveDiscountLimitsBatch } from '@/lib/services/discount-limit-service'
 
 // GET /api/alternate-registrations/[gameId]/alternates - Get available alternates for a game
 export async function GET(
@@ -136,6 +136,12 @@ export async function GET(
       registrationSeasonId
     )
 
+    const effectiveLimitsByUserAndCategory = await resolveEffectiveDiscountLimitsBatch(
+      adminSupabase,
+      userIds,
+      registrationSeasonId
+    )
+
     // Format alternates data with payment status and discount info
     const formattedAlternates = (alternates || []).map(alternate => {
       const user = Array.isArray(alternate.users) ? alternate.users[0] : alternate.users
@@ -151,22 +157,36 @@ export async function GET(
       let category = null
 
       if (discountCode && registration) {
-        const basePrice = registration.alternate_price || 0
-        const requestedDiscountAmount = Math.round((basePrice * discountCode.percentage) / 100)
         category = Array.isArray(discountCode.category) ? discountCode.category[0] : discountCode.category
-
         const usageKey = `${alternate.user_id}:${category?.id}`
-        const currentUsage = usageByUserAndCategory.get(usageKey) || 0
+        const effectiveLimit = effectiveLimitsByUserAndCategory.get(usageKey)
 
-        const evalResult = evaluateSeasonalDiscountLimit(
-          category,
-          currentUsage,
-          requestedDiscountAmount
-        )
+        const effectivePercentage = effectiveLimit?.percentage ?? (discountCode.percentage != null ? parseFloat(String(discountCode.percentage)) : null)
+        const isEligible = effectiveLimit?.isEligible ?? true
 
-        isOverLimit = evalResult.isOverLimit
-        discountAmount = evalResult.discountAmount
-        usageStatus = evalResult.usageStatus
+        if (!isEligible || effectivePercentage === null || isNaN(effectivePercentage)) {
+          discountAmount = 0
+          isOverLimit = true
+        } else {
+          const basePrice = registration.alternate_price || 0
+          const requestedDiscountAmount = Math.round((basePrice * effectivePercentage) / 100)
+          const currentUsage = usageByUserAndCategory.get(usageKey) || 0
+
+          const effectiveCategory = category ? {
+            ...category,
+            max_discount_per_user_per_season: effectiveLimit?.maxAllowed ?? category.max_discount_per_user_per_season
+          } : null
+
+          const evalResult = evaluateSeasonalDiscountLimit(
+            effectiveCategory,
+            currentUsage,
+            requestedDiscountAmount
+          )
+
+          isOverLimit = evalResult.isOverLimit
+          discountAmount = evalResult.discountAmount
+          usageStatus = evalResult.usageStatus
+        }
       }
 
       const finalAmount = Math.max(0, (registration?.alternate_price || 0) - discountAmount)

--- a/src/app/api/validate-discount-code/route.ts
+++ b/src/app/api/validate-discount-code/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { createClient } from '@/lib/supabase/server'
-import { checkSeasonalDiscountLimit, DiscountCodeWithCategory } from '@/lib/services/discount-limit-service'
+import { checkSeasonalDiscountLimit, resolveEffectiveDiscountLimits, DiscountCodeWithCategory } from '@/lib/services/discount-limit-service'
 
 interface DiscountValidationResult {
   isValid: boolean
@@ -33,7 +33,7 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json()
-    const { code, registrationId, amount, isRefund = false } = body
+    const { code, registrationId, paymentId, amount, isRefund = false } = body
     
     if (!code || !registrationId || !amount) {
       return NextResponse.json({ 
@@ -59,6 +59,7 @@ export async function POST(request: NextRequest) {
         id,
         code,
         percentage,
+        uses_user_allowance,
         is_active,
         valid_from,
         valid_until,
@@ -67,6 +68,8 @@ export async function POST(request: NextRequest) {
           name,
           accounting_code,
           max_discount_per_user_per_season,
+          requires_user_allowance,
+          default_percentage,
           is_active
         )
       `)
@@ -111,51 +114,144 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(result)
     }
 
-    // Calculate discount amount
-    let discountAmount = Math.round((amount * discountCode.percentage) / 100)
-
-    // Check category usage limits using discount-limit-service
-    let isPartialDiscount = false
-    let partialDiscountMessage = ''
-    
     const category = discountCategory as any
     const codeWithCategory: DiscountCodeWithCategory = {
       id: discountCode.id,
       code: discountCode.code,
-      percentage: discountCode.percentage,
+      percentage: discountCode.percentage != null ? parseFloat(String(discountCode.percentage)) : null,
+      uses_user_allowance: discountCode.uses_user_allowance,
       category: category ? {
         id: category.id,
         name: category.name,
-        max_discount_per_user_per_season: category.max_discount_per_user_per_season
+        max_discount_per_user_per_season: category.max_discount_per_user_per_season,
+        requires_user_allowance: category.requires_user_allowance,
+        default_percentage: category.default_percentage != null ? parseFloat(String(category.default_percentage)) : null
       } : null
     }
 
-    const limitResult = await checkSeasonalDiscountLimit(
-      supabase,
-      user.id,
-      discountCode.id,
-      registration.season_id,
-      discountAmount,
-      {
-        isRefund,
-        discountCode: codeWithCategory
-      }
-    )
+    let discountAmount = 0
+    let isPartialDiscount = false
+    let partialDiscountMessage = ''
+    let effectivePct: number | null = discountCode.percentage != null ? parseFloat(String(discountCode.percentage)) : null
 
-    if (limitResult.isAtLimit && !isRefund) {
-      const maxAllowed = category?.max_discount_per_user_per_season || 0
-      const result: DiscountValidationResult = {
-        isValid: false,
-        error: `You have already reached your $${(maxAllowed / 100).toFixed(2)} season limit for ${category?.name || ''}. No additional discount can be applied.`
-      }
-      return NextResponse.json(result)
-    }
+    if (isRefund) {
+      let originalDiscountAmount: number | null = null
 
-    if (limitResult.isPartialDiscount) {
-      discountAmount = limitResult.finalAmount
-      isPartialDiscount = true
-      const maxAllowed = category?.max_discount_per_user_per_season || 0
-      partialDiscountMessage = `Applied $${(discountAmount / 100).toFixed(2)} discount (${discountCode.code}). You've reached your $${(maxAllowed / 100).toFixed(2)} season limit for ${category?.name || ''}.`
+      if (paymentId) {
+        // Query xero_invoices filtering strictly by payment_id, invoice_type = 'ACCREC', and sync_status IN ('synced', 'pending')
+        const { data: originalInvoices, error: invoiceError } = await supabase
+          .from('xero_invoices')
+          .select('id')
+          .eq('payment_id', paymentId)
+          .eq('invoice_type', 'ACCREC')
+          .in('sync_status', ['synced', 'pending'])
+
+        if (invoiceError) {
+          console.error('[validate-discount-code] Error querying original invoice:', invoiceError)
+        }
+
+        if (originalInvoices && originalInvoices.length > 1) {
+          console.error('[validate-discount-code] Multiple synced/pending ACCREC invoices found for payment:', paymentId)
+          return NextResponse.json({ isValid: false, error: 'Multiple original invoices found for payment' })
+        }
+
+        if (originalInvoices && originalInvoices.length === 1) {
+          const xeroInvoiceId = originalInvoices[0].id
+          const { data: lineItems, error: lineError } = await supabase
+            .from('xero_invoice_line_items')
+            .select('id, line_amount')
+            .eq('xero_invoice_id', xeroInvoiceId)
+            .eq('discount_code_id', discountCode.id)
+            .eq('line_item_type', 'discount')
+
+          if (lineError) {
+            console.error('[validate-discount-code] Error querying discount line item:', lineError)
+          }
+
+          if (lineItems && lineItems.length > 1) {
+            console.error('[validate-discount-code] Multiple discount line items found on original invoice:', xeroInvoiceId)
+            return NextResponse.json({ isValid: false, error: 'Multiple discount line items found on original invoice' })
+          }
+
+          if (lineItems && lineItems.length === 1) {
+            originalDiscountAmount = Math.abs(lineItems[0].line_amount)
+          }
+        }
+      }
+
+      if (originalDiscountAmount !== null) {
+        discountAmount = originalDiscountAmount
+      } else {
+        // Split fallback strategy for 0 invoices / 0 line items found
+        if (discountCode.uses_user_allowance) {
+          console.error('[validate-discount-code] Original discount line item not found for refund of allowance-driven code:', { code: discountCode.code, paymentId })
+          return NextResponse.json({ isValid: false, error: 'Original discount line item not found for refund' })
+        } else {
+          console.warn('[validate-discount-code] Original discount line item not found for refund of fixed-percentage code; using percentage fallback:', { code: discountCode.code, paymentId })
+          const fallbackPct = parseFloat(String(discountCode.percentage)) || 0
+          discountAmount = Math.round((amount * fallbackPct) / 100)
+        }
+      }
+    } else {
+      // Non-refund validation: resolve effective limit first to determine real percentage
+      const effectiveLimit = await resolveEffectiveDiscountLimits(
+        supabase,
+        user.id,
+        category.id,
+        registration.season_id,
+        codeWithCategory.category
+      )
+
+      if (!effectiveLimit.isEligible) {
+        return NextResponse.json({
+          isValid: false,
+          error: "This code isn't available to your account."
+        })
+      }
+
+      const pct = discountCode.uses_user_allowance
+        ? effectiveLimit.percentage
+        : (discountCode.percentage != null ? parseFloat(String(discountCode.percentage)) : null)
+
+      if (pct == null || isNaN(pct)) {
+        console.error('[validate-discount-code] Percentage unresolvable:', { code: discountCode.code, uses_user_allowance: discountCode.uses_user_allowance })
+        return NextResponse.json({
+          isValid: false,
+          error: "This code isn't available to your account."
+        })
+      }
+
+      effectivePct = pct
+      const requestedDiscountAmount = Math.round((amount * pct) / 100)
+
+      const limitResult = await checkSeasonalDiscountLimit(
+        supabase,
+        user.id,
+        discountCode.id,
+        registration.season_id,
+        requestedDiscountAmount,
+        {
+          isRefund: false,
+          discountCode: codeWithCategory
+        }
+      )
+
+      const maxAllowed = effectiveLimit.maxAllowed ?? category?.max_discount_per_user_per_season ?? 0
+
+      if (limitResult.isAtLimit) {
+        return NextResponse.json({
+          isValid: false,
+          error: `You have already reached your $${(maxAllowed / 100).toFixed(2)} season limit for ${category?.name || ''}. No additional discount can be applied.`
+        })
+      }
+
+      if (limitResult.isPartialDiscount) {
+        discountAmount = limitResult.finalAmount
+        isPartialDiscount = true
+        partialDiscountMessage = `Applied $${(discountAmount / 100).toFixed(2)} discount (${discountCode.code}). You've reached your $${(maxAllowed / 100).toFixed(2)} season limit for ${category?.name || ''}.`
+      } else {
+        discountAmount = requestedDiscountAmount
+      }
     }
 
     // Valid discount code
@@ -165,7 +261,7 @@ export async function POST(request: NextRequest) {
       discountCode: {
         id: discountCode.id,
         code: discountCode.code,
-        percentage: discountCode.percentage,
+        percentage: effectivePct ?? 0,
         category: {
           id: category.id,
           name: category.name,

--- a/src/lib/services/alternate-payment-service.ts
+++ b/src/lib/services/alternate-payment-service.ts
@@ -307,7 +307,9 @@ export class AlternatePaymentService {
           discountCode = discount
 
           // Calculate initial discount amount (all discounts are percentage-based)
-          let requestedDiscountAmount = Math.round((basePrice * discount.percentage) / 100)
+          const rawPct = discount.percentage ?? discount.category?.default_percentage
+          const pct = rawPct != null ? parseFloat(String(rawPct)) : 0
+          let requestedDiscountAmount = Math.round((basePrice * pct) / 100)
 
           // Check per-code usage limits
           if (discount.usage_limit && discount.usage_limit > 0) {

--- a/src/lib/services/discount-limit-service.ts
+++ b/src/lib/services/discount-limit-service.ts
@@ -17,16 +17,26 @@ export interface SeasonalDiscountUsage {
   maxAllowed: number
 }
 
+export interface EffectiveLimit {
+  maxAllowed: number | null
+  percentage: number | null
+  isEligible: boolean
+  source: 'user_allowance' | 'category_default' | 'denied'
+}
+
 export interface DiscountCategoryInfo {
   id: string
   name: string
   max_discount_per_user_per_season?: number | null
+  requires_user_allowance?: boolean | null
+  default_percentage?: number | string | null
 }
 
 export interface DiscountCodeWithCategory {
   id: string
   code: string
-  percentage: number
+  percentage?: number | string | null
+  uses_user_allowance?: boolean | null
   category: DiscountCategoryInfo | null
 }
 
@@ -49,8 +59,10 @@ export interface DiscountLimitResult {
   finalAmount: number
   isPartialDiscount: boolean
   isAtLimit?: boolean
+  isEligible?: boolean
   partialDiscountMessage?: string
   seasonalUsage?: SeasonalDiscountUsage
+  effectiveLimit?: EffectiveLimit
 }
 
 /**
@@ -194,6 +206,245 @@ export function evaluateSeasonalDiscountLimit(
 }
 
 /**
+ * Resolve effective discount limits (percentage, maxAllowed, isEligible, source) for a user, category, and season
+ *
+ * @param supabase - Supabase client
+ * @param userId - User ID
+ * @param categoryId - Discount category ID
+ * @param seasonId - Season ID
+ * @param initialCategory - Optional pre-fetched category metadata
+ * @returns EffectiveLimit object
+ */
+export async function resolveEffectiveDiscountLimits(
+  supabase: SupabaseClient,
+  userId: string,
+  categoryId: string,
+  seasonId: string,
+  initialCategory?: DiscountCategoryInfo | null
+): Promise<EffectiveLimit> {
+  let category: DiscountCategoryInfo | null = initialCategory || null
+
+  // 1. Fetch category metadata if not already supplied
+  if (!category) {
+    const { data: fetchedCategory, error: categoryError } = await supabase
+      .from('discount_categories')
+      .select('id, name, requires_user_allowance, max_discount_per_user_per_season, default_percentage')
+      .eq('id', categoryId)
+      .single()
+
+    if (categoryError && categoryError.code !== 'PGRST116') {
+      logger.logPaymentProcessing(
+        'resolve-effective-limits-category-query-failed',
+        'Failed to query discount category during effective limit resolution',
+        { userId, categoryId, seasonId, error: categoryError.message },
+        'error'
+      )
+      throw categoryError
+    }
+
+    if (fetchedCategory) {
+      category = fetchedCategory
+    }
+  }
+
+  if (!category) {
+    logger.logPaymentProcessing(
+      'resolve-effective-limits-category-not-found',
+      'Discount category not found during effective limit resolution',
+      { userId, categoryId, seasonId },
+      'warn'
+    )
+    return {
+      maxAllowed: null,
+      percentage: null,
+      isEligible: false,
+      source: 'denied'
+    }
+  }
+
+  const rawCategoryDefaultPct = category.default_percentage
+  const categoryDefaultPctParsed = rawCategoryDefaultPct != null ? parseFloat(String(rawCategoryDefaultPct)) : null
+  const categoryDefaultPct = categoryDefaultPctParsed != null && !isNaN(categoryDefaultPctParsed) ? categoryDefaultPctParsed : null
+
+  // 2. Fetch allowance for user, category, and season
+  let allowance: any = null
+  if (seasonId) {
+    const { data: allowanceData, error: allowanceError } = await supabase
+      .from('user_discount_allowances')
+      .select('id, user_id, discount_category_id, season_id, discount_percentage, max_discount_amount')
+      .eq('user_id', userId)
+      .eq('discount_category_id', categoryId)
+      .eq('season_id', seasonId)
+
+    if (allowanceError) {
+      logger.logPaymentProcessing(
+        'resolve-effective-limits-allowance-fetch-failed',
+        'Failed to fetch user discount allowance during effective limit resolution',
+        { userId, categoryId, seasonId, error: allowanceError.message },
+        'error'
+      )
+      throw new Error(allowanceError.message)
+    }
+
+    allowance = Array.isArray(allowanceData) ? allowanceData[0] : allowanceData
+  }
+
+  // 3. Resolve limits based on allowance row or category defaults
+  if (allowance) {
+    // Coalesce percentage safely without parseFloat(null) -> NaN bug
+    const rawPct = allowance.discount_percentage ?? category.default_percentage
+    const parsedPct = rawPct != null ? parseFloat(String(rawPct)) : null
+    const percentage = parsedPct != null && !isNaN(parsedPct) ? parsedPct : null
+
+    // Zero-handling rule: max_discount_amount === 0 means INELIGIBLE (source: 'denied')
+    if (allowance.max_discount_amount === 0) {
+      return {
+        maxAllowed: 0,
+        percentage,
+        isEligible: false,
+        source: 'denied'
+      }
+    }
+
+    const maxAllowed = allowance.max_discount_amount ?? category.max_discount_per_user_per_season ?? null
+
+    return {
+      maxAllowed,
+      percentage,
+      isEligible: true,
+      source: 'user_allowance'
+    }
+  }
+
+  // Gating rule: if category requires user allowance and user has no allowance -> ineligible (source: 'denied')
+  if (category.requires_user_allowance) {
+    return {
+      maxAllowed: category.max_discount_per_user_per_season ?? null,
+      percentage: categoryDefaultPct,
+      isEligible: false,
+      source: 'denied'
+    }
+  }
+
+  // Default ungated category behavior
+  return {
+    maxAllowed: category.max_discount_per_user_per_season ?? null,
+    percentage: categoryDefaultPct,
+    isEligible: true,
+    source: 'category_default'
+  }
+}
+
+/**
+ * Resolve effective discount limits in batch for multiple users within a season
+ *
+ * @param supabase - Supabase client
+ * @param userIds - Array of user IDs
+ * @param seasonId - Season ID
+ * @returns Map of `${userId}:${categoryId}` to EffectiveLimit
+ */
+export async function resolveEffectiveDiscountLimitsBatch(
+  supabase: SupabaseClient,
+  userIds: string[],
+  seasonId: string
+): Promise<Map<string, EffectiveLimit>> {
+  const resultMap = new Map<string, EffectiveLimit>()
+
+  if (!userIds || userIds.length === 0 || !seasonId) {
+    return resultMap
+  }
+
+  // 1. Fetch all discount categories
+  const { data: categories, error: categoryError } = await supabase
+    .from('discount_categories')
+    .select('id, name, requires_user_allowance, max_discount_per_user_per_season, default_percentage')
+
+  if (categoryError || !categories) {
+    logger.logPaymentProcessing(
+      'resolve-effective-limits-batch-categories-failed',
+      'Failed to query categories for batch resolution',
+      { seasonId, error: categoryError?.message },
+      'error'
+    )
+    throw categoryError || new Error('Discount categories query returned no data')
+  }
+
+  // 2. Fetch all allowances for userIds in seasonId
+  const { data: allowances, error: allowanceError } = await supabase
+    .from('user_discount_allowances')
+    .select('user_id, discount_category_id, season_id, discount_percentage, max_discount_amount')
+    .in('user_id', userIds)
+    .eq('season_id', seasonId)
+
+  if (allowanceError) {
+    logger.logPaymentProcessing(
+      'resolve-effective-limits-batch-allowances-failed',
+      'Failed to query allowances for batch resolution',
+      { userIdCount: userIds.length, seasonId, error: allowanceError.message },
+      'error'
+    )
+    throw allowanceError
+  }
+
+  const allowanceMap = new Map<string, any>()
+  allowances?.forEach(row => {
+    allowanceMap.set(`${row.user_id}:${row.discount_category_id}`, row)
+  })
+
+  // 3. Populate EffectiveLimit for EVERY requested ${userId}:${categoryId} pair
+  for (const userId of userIds) {
+    for (const category of categories) {
+      const key = `${userId}:${category.id}`
+      const allowance = allowanceMap.get(key)
+
+      const rawCategoryDefaultPct = category.default_percentage
+      const categoryDefaultPctParsed = rawCategoryDefaultPct != null ? parseFloat(String(rawCategoryDefaultPct)) : null
+      const categoryDefaultPct = categoryDefaultPctParsed != null && !isNaN(categoryDefaultPctParsed) ? categoryDefaultPctParsed : null
+
+      if (allowance) {
+        const rawPct = allowance.discount_percentage ?? category.default_percentage
+        const parsedPct = rawPct != null ? parseFloat(String(rawPct)) : null
+        const percentage = parsedPct != null && !isNaN(parsedPct) ? parsedPct : null
+
+        if (allowance.max_discount_amount === 0) {
+          resultMap.set(key, {
+            maxAllowed: 0,
+            percentage,
+            isEligible: false,
+            source: 'denied'
+          })
+          continue
+        }
+
+        const maxAllowed = allowance.max_discount_amount ?? category.max_discount_per_user_per_season ?? null
+        resultMap.set(key, {
+          maxAllowed,
+          percentage,
+          isEligible: true,
+          source: 'user_allowance'
+        })
+      } else if (category.requires_user_allowance) {
+        resultMap.set(key, {
+          maxAllowed: category.max_discount_per_user_per_season ?? null,
+          percentage: categoryDefaultPct,
+          isEligible: false,
+          source: 'denied'
+        })
+      } else {
+        resultMap.set(key, {
+          maxAllowed: category.max_discount_per_user_per_season ?? null,
+          percentage: categoryDefaultPct,
+          isEligible: true,
+          source: 'category_default'
+        })
+      }
+    }
+  }
+
+  return resultMap
+}
+
+/**
  * Check seasonal discount limit and apply partial discount if needed
  *
  * This is the core function that enforces max_discount_per_user_per_season.
@@ -217,7 +468,7 @@ export async function checkSeasonalDiscountLimit(
   options?: CheckSeasonalDiscountLimitOptions
 ): Promise<DiscountLimitResult> {
   try {
-    // If refund flow, bypass cap enforcement entirely
+    // If refund flow, bypass eligibility, cap, and percentage re-resolution
     if (options?.isRefund) {
       return {
         originalAmount: requestedDiscountAmount,
@@ -238,10 +489,13 @@ export async function checkSeasonalDiscountLimit(
           id,
           code,
           percentage,
+          uses_user_allowance,
           category:discount_categories(
             id,
             name,
-            max_discount_per_user_per_season
+            max_discount_per_user_per_season,
+            requires_user_allowance,
+            default_percentage
           )
         `)
         .eq('id', discountCodeId)
@@ -254,15 +508,62 @@ export async function checkSeasonalDiscountLimit(
       discountCode = {
         id: fetchedCode.id,
         code: fetchedCode.code,
-        percentage: fetchedCode.percentage,
+        percentage: fetchedCode.percentage != null ? parseFloat(String(fetchedCode.percentage)) : null,
+        uses_user_allowance: fetchedCode.uses_user_allowance,
         category: Array.isArray(fetchedCode.category) ? fetchedCode.category[0] : fetchedCode.category
       }
       category = discountCode.category
     }
 
-    // 0 means unlimited here, preserving legacy category semantics. This is NOT the allowance convention — see Phase 2, where 0 means ineligible. Do not reuse this check for allowance resolution.
-    const maxAllowed = category?.max_discount_per_user_per_season
-    if (!category || !category.id || !maxAllowed || maxAllowed <= 0) {
+    if (!category || !category.id) {
+      return {
+        originalAmount: requestedDiscountAmount,
+        finalAmount: requestedDiscountAmount,
+        isPartialDiscount: false,
+        isAtLimit: false
+      }
+    }
+
+    // Resolve effective limit by delegating directly to resolveEffectiveDiscountLimits
+    const effectiveLimit = await resolveEffectiveDiscountLimits(
+      supabase,
+      userId,
+      category.id,
+      seasonId,
+      category
+    )
+
+    if (!effectiveLimit.isEligible) {
+      return {
+        originalAmount: requestedDiscountAmount,
+        finalAmount: 0,
+        isPartialDiscount: false,
+        isAtLimit: false,
+        isEligible: false,
+        effectiveLimit
+      }
+    }
+
+    if (discountCode.uses_user_allowance && (effectiveLimit.percentage === null || isNaN(effectiveLimit.percentage))) {
+      logger.logPaymentProcessing(
+        'allowance-code-percentage-unresolvable',
+        'Allowance-driven discount code percentage could not be resolved',
+        { userId, discountCodeId, categoryId: category.id, seasonId },
+        'warn'
+      )
+      return {
+        originalAmount: requestedDiscountAmount,
+        finalAmount: 0,
+        isPartialDiscount: false,
+        isAtLimit: false,
+        isEligible: false,
+        effectiveLimit
+      }
+    }
+
+    // 0 means unlimited here, preserving legacy category semantics.
+    const maxAllowed = effectiveLimit.maxAllowed
+    if (!maxAllowed || maxAllowed <= 0) {
       return {
         originalAmount: requestedDiscountAmount,
         finalAmount: requestedDiscountAmount,

--- a/src/lib/services/waitlist-payment-service.ts
+++ b/src/lib/services/waitlist-payment-service.ts
@@ -104,7 +104,9 @@ export class WaitlistPaymentService {
 
           if (discountCode) {
             // Apply the same discount percentage to the new base price
-            let requestedDiscountAmount = Math.round((effectiveBasePrice * discountCode.percentage) / 100)
+            const rawPct = discountCode.percentage ?? discountCode.category?.default_percentage
+            const pct = rawPct != null ? parseFloat(String(rawPct)) : 0
+            let requestedDiscountAmount = Math.round((effectiveBasePrice * pct) / 100)
 
             // Enforce seasonal discount cap
             if (requestedDiscountAmount > 0) {
@@ -408,7 +410,9 @@ export class WaitlistPaymentService {
           discountCode = discount
 
           // Calculate initial discount amount (all discounts are percentage-based)
-          let requestedDiscountAmount = Math.round((basePrice * discount.percentage) / 100)
+          const rawPct = discount.percentage ?? discount.category?.default_percentage
+          const pct = rawPct != null ? parseFloat(String(rawPct)) : 0
+          let requestedDiscountAmount = Math.round((basePrice * pct) / 100)
 
           // Check per-code usage limits
           if (discount.usage_limit && discount.usage_limit > 0) {

--- a/supabase/migrations/2026-07-27-add-user-discount-allowances.sql
+++ b/supabase/migrations/2026-07-27-add-user-discount-allowances.sql
@@ -1,0 +1,117 @@
+-- Phase 2 Migration: Add user discount allowances schema and PRIDE placeholder code
+-- Created: 2026-07-27
+-- Manual maintainer application only. Do not run via CLI.
+
+-- 1. Add columns to discount_categories
+ALTER TABLE discount_categories
+ADD COLUMN IF NOT EXISTS requires_user_allowance BOOLEAN NOT NULL DEFAULT FALSE,
+ADD COLUMN IF NOT EXISTS default_percentage DECIMAL(5,2) CHECK (default_percentage IS NULL OR (default_percentage > 0 AND default_percentage <= 100)),
+ADD COLUMN IF NOT EXISTS priority INTEGER NOT NULL DEFAULT 0;
+
+-- 2. Add columns and constraints to discount_codes
+ALTER TABLE discount_codes
+ADD COLUMN IF NOT EXISTS uses_user_allowance BOOLEAN NOT NULL DEFAULT FALSE;
+
+ALTER TABLE discount_codes
+ALTER COLUMN percentage DROP NOT NULL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_constraint WHERE conname = 'chk_discount_codes_percentage_or_allowance'
+    ) THEN
+        ALTER TABLE discount_codes
+        ADD CONSTRAINT chk_discount_codes_percentage_or_allowance
+        CHECK (percentage IS NOT NULL OR uses_user_allowance);
+    END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_discount_codes_one_allowance_code_per_category
+ON discount_codes (discount_category_id) WHERE uses_user_allowance;
+
+-- 3. Create user_discount_allowances table
+CREATE TABLE IF NOT EXISTS user_discount_allowances (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    discount_category_id UUID NOT NULL REFERENCES discount_categories(id) ON DELETE CASCADE,
+    season_id UUID NOT NULL REFERENCES seasons(id) ON DELETE CASCADE,
+    discount_percentage DECIMAL(5,2) CHECK (discount_percentage IS NULL OR (discount_percentage > 0 AND discount_percentage <= 100)),
+    max_discount_amount INTEGER CHECK (max_discount_amount IS NULL OR max_discount_amount >= 0),
+    is_default BOOLEAN NOT NULL DEFAULT FALSE,
+    notes TEXT,
+    created_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    updated_by UUID REFERENCES users(id) ON DELETE SET NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    
+    CONSTRAINT uq_user_discount_allowance_user_cat_season UNIQUE (user_id, discount_category_id, season_id)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_user_discount_allowance_user_season_default
+ON user_discount_allowances (user_id, season_id) WHERE is_default;
+
+CREATE INDEX IF NOT EXISTS idx_uda_season_category ON user_discount_allowances(season_id, discount_category_id);
+CREATE INDEX IF NOT EXISTS idx_uda_created_by ON user_discount_allowances(created_by);
+CREATE INDEX IF NOT EXISTS idx_uda_updated_by ON user_discount_allowances(updated_by);
+
+-- Trigger for updated_at
+CREATE OR REPLACE FUNCTION update_user_discount_allowances_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = NOW();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_user_discount_allowances_updated_at ON user_discount_allowances;
+CREATE TRIGGER trg_user_discount_allowances_updated_at
+BEFORE UPDATE ON user_discount_allowances
+FOR EACH ROW
+EXECUTE FUNCTION update_user_discount_allowances_updated_at();
+
+-- Enable RLS
+ALTER TABLE user_discount_allowances ENABLE ROW LEVEL SECURITY;
+
+-- RLS Policies
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies WHERE policyname = 'user_discount_allowances_admin_all' AND tablename = 'user_discount_allowances'
+    ) THEN
+        CREATE POLICY "user_discount_allowances_admin_all" ON user_discount_allowances
+            FOR ALL USING (
+                EXISTS (
+                    SELECT 1 FROM users
+                    WHERE id = auth.uid() AND is_admin = TRUE
+                )
+            );
+    END IF;
+
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_policies WHERE policyname = 'user_discount_allowances_user_read_own' AND tablename = 'user_discount_allowances'
+    ) THEN
+        CREATE POLICY "user_discount_allowances_user_read_own" ON user_discount_allowances
+            FOR SELECT USING (
+                auth.uid() = user_id
+            );
+    END IF;
+END $$;
+
+-- 4. Seed dormant PRIDE code for Financial Aid category
+DO $$
+DECLARE
+    v_category_id UUID;
+BEGIN
+    SELECT discount_category_id INTO v_category_id
+    FROM discount_codes
+    WHERE code = 'PRIDE50'
+    LIMIT 1;
+
+    IF v_category_id IS NOT NULL THEN
+        INSERT INTO discount_codes (code, percentage, discount_category_id, uses_user_allowance, is_active)
+        VALUES ('PRIDE', NULL, v_category_id, TRUE, FALSE)
+        ON CONFLICT (code) DO NOTHING;
+    ELSE
+        RAISE NOTICE 'Financial Aid category code PRIDE50 not found; PRIDE placeholder creation skipped.';
+    END IF;
+END $$;


### PR DESCRIPTION
## Summary

Adds the `user_discount_allowances` table and teaches `discount-limit-service.ts` to resolve a user's effective discount percentage and seasonal cap from it, falling back to category defaults.

**Ships dormant.** No category is gated, no allowance rows exist in production, and the new `PRIDE` code is inactive. Every existing discount flow resolves to `source: 'category_default'` and behaves exactly as before. This is deliberate — it puts the risky resolution logic in production where it can be observed while nothing depends on it.

Part of [Per-User Discount Allowances](docs/features/planning/user-discount-allowances.md). Follows Phase 1 (enforcement consolidation).

## ⚠️ The migration is already applied to production

`2026-07-27-add-user-discount-allowances.sql` was applied by hand to **both dev and production** before this merge. **Do not run it again.** Parts of it (`ADD CONSTRAINT`, `CREATE UNIQUE INDEX`) are not idempotent and a re-run will fail partway through.

Production state verified post-migration:

- `PRIDE` exists, `percentage = NULL`, `uses_user_allowance = true`, `is_active = false`, attached to Financial Aid
- `PRIDE25/50/75/100` all still active and unchanged
- All five categories: `requires_user_allowance = false`, `default_percentage = NULL`
- `user_discount_allowances` empty

Because the schema is already live and the code is not, production is currently running Phase 1 code against Phase 2 schema. That's the safe ordering — the dangerous direction is code before table, where every resolution errors and discounts silently drop to zero.

## Schema

**`discount_categories`** — `requires_user_allowance` (default false), `default_percentage`, `priority`

**`discount_codes`** — `uses_user_allowance` (default false); `percentage` becomes nullable, guarded by `CHECK (percentage IS NOT NULL OR uses_user_allowance)`; partial unique index enforcing at most one allowance-driven code per category

**`user_discount_allowances`** — user × season × category, with nullable `discount_percentage` and `max_discount_amount` overrides, `is_default`, `notes`, `created_by`/`updated_by`, RLS (admin full access, users read their own), and an `updated_at` trigger

Resolution:

| `requires_user_allowance` | Allowance row | Effective limit |
|---|---|---|
| false | absent | Category defaults — today's behavior |
| false | present | Allowance overrides; `NULL` columns inherit |
| true | absent | Not eligible — code rejected |
| true | present | Allowance overrides; `NULL` columns inherit |

`max_discount_amount = 0` is an eligibility failure, **not** unlimited. This inverts the legacy category convention where `0` means unlimited, so the two live in separate code paths with a comment at the legacy check warning against reuse.

## Design decisions

- **Resolve, then compute, then cap.** `resolveEffectiveDiscountLimits` returns percentage and cap together; the caller computes the discount amount from the resolved percentage and passes *that* into `checkSeasonalDiscountLimit`. Capping an amount derived from a different percentage than the one applied would let the cap be bypassed entirely.
- **Percentage source depends on the code.** Allowance-driven codes take the resolved percentage; fixed-percentage codes keep their own. A member with a 50% allowance redeeming `PRIDE75` gets 75%, capped by their dollar limit.
- **Refunds derive from the original invoice line item**, never from re-resolution. The allowance is mutable, so recomputing after an admin edits it would produce a credit note that doesn't match what was charged. Lookup filters `payment_id` + `invoice_type = 'ACCREC'` + `sync_status IN ('synced','pending')` — excluding credit notes from prior partial refunds and abandoned staged invoices, matching `discount_usage_computed`. If no line item is found: fixed-percentage codes fall back with a warning, allowance-driven codes hard-fail rather than guess.
- **Ineligible users get a neutral message** — "This code isn't available to your account." Reusing the at-limit string would disclose both the cap and the category to someone who was never granted one.
- **Batch resolution for the alternate list**, returning an entry for every requested user/category pair. A cache miss resolves to category defaults and never to ineligible.

## Verification

**Unit** — full suite green. `alternate-payment-service.test.ts` and `waitlist-payment-service.test.ts` are **unmodified**, per the Phase 1 contract.

**Manual, on dev** — allowance row with a $0.30 cap against a $125 registration at 50% produced a $0.30 discount; changing the cap to $300 produced the full $62.50. This exercises the ungated-category-with-allowance case, which is the row of the resolution table most likely to be implemented wrong. `PRIDE50` works normally; `PRIDE` is correctly rejected as inactive.

**Production, post-migration** — schema and data state confirmed by direct query (above).

## Known gap — must be closed before Phase 4

`AlternatePaymentService.calculateChargeAmount` computes its percentage as `discount.percentage ?? category.default_percentage` and does not consult the allowance. `WaitlistPaymentService` is likely the same (unverified).

Unreachable today: `PRIDE` is inactive and no allowance rows exist in production. But once `PRIDE` activates at Phase 4, an allowance-driven code resolves to a 0% percentage there, so an alternate would be charged full price — **while the captain's alternate list, which does resolve allowances, displays a discount.** Display and charge would disagree.

Both payment services need the same resolve-then-compute treatment as `validate-discount-code` before the flip.

## Deployment notes

- **No migration to run.** Already applied to production.
- Phase 4 remains three SQL statements (activate `PRIDE`, gate Financial Aid, deactivate legacy codes) *provided* the payment service gap above is closed first.
- Each discount validation now issues one additional query against `user_discount_allowances`. Negligible at current volume; the alternate list stays bounded via the batch path.
- New log events: `resolve-effective-limits-*`, `allowance-code-percentage-unresolvable`.

## Not in this PR

- Admin API and UI for managing allowances — Phase 3
- `/api/admin/reports/discount-usage` showing per-user limits — Phase 3, ships with the UI that makes it necessary
- Gating any category or activating `PRIDE` — Phase 4
- `usage_limit` dead code removal — separate issue
