### PR TITLE
fixing discount allowances percentage resolution gap

### DIFF
--- a/docs/features/planning/discount-allowances-phase-3-admin-and-reporting.md
+++ b/docs/features/planning/discount-allowances-phase-3-admin-and-reporting.md
@@ -1,0 +1,256 @@
+# Phase 3 — Admin Management and Reporting
+
+**Status:** 📋 Ready for implementation — decisions resolved
+**Created:** 2026-07-27
+**Updated:** 2026-07-27
+**Parent spec:** [Per-User Discount Allowances](./user-discount-allowances.md)
+**Depends on:** Phase 2 (schema + resolver) and the [percentage resolution gap fix](./discount-allowances-percentage-resolution-gap.md) — both merged
+**PR scope:** One PR covering admin API, admin UI, and reporting.
+
+> **Numbering note.** The parent spec originally split this into Phases 3, 4 and 5. Committed code
+> and production migration comments now use "Phase 4" to mean the flip, so the numbering has been
+> collapsed to match what is already written down: **Phase 3 = admin management + reporting**,
+> **Phase 4 = the flip**. Update the parent spec accordingly.
+
+## Purpose
+
+Give admins a way to grant, edit, and revoke per-user discount allowances, and make the reporting
+surfaces reflect per-user limits rather than category defaults.
+
+This is the phase that makes allowances real. Every prior phase was inert; the moment this ships,
+allowance rows exist and take effect immediately.
+
+## Scope
+
+- Admin API for reading and writing allowances
+- Allowance editor on the user detail page, alongside discount usage
+- `requires_user_allowance` control on the category admin page
+- New discount **eligibility** report
+- Per-user resolution in the existing discount **usage** report and in
+  `getSeasonalDiscountUsageSummary`
+- Minor fix: the alternates list flags ineligible users as "over limit"
+
+## Non-Goals
+
+- Gating any category, activating `PRIDE`, deactivating legacy codes — Phase 4
+- Bulk or CSV allowance entry. Aid is approved case by case, so entry is single-user by design
+- Auto-applying discounts at checkout
+- Member-facing balance display. RLS already permits it; the UI is not in scope
+- Copying allowances between seasons
+- Any use of `is_default` or `priority`. Both columns exist and are read by nothing. They are for
+  auto-apply, which is unscheduled. **Do not build UI or selection logic on them.**
+- **Any UI for `discount_categories.default_percentage`** — see D1. The column stays in the schema
+  but nothing sets or reads it.
+
+## Decisions — RESOLVED
+
+Confirmed by the maintainer. Binding.
+
+### D1 — Explicit values only; no state expressed by emptiness
+
+`default_percentage` is `NULL` on all five production categories and has never been settable. An
+"inherit the default" mode would inherit nothing — a trap rather than a feature. Therefore:
+
+- **Percentage is required, 1–100.** The UI never writes a `NULL` percentage.
+- **The category's `max_discount_per_user_per_season` is NOT inherited** as a per-user cap. It is
+  not per-season, which is the reason the cap moved onto the allowance in the first place.
+- **An uncapped allowance is set by an explicit "No dollar cap" toggle**, not by leaving a field
+  blank. This is needed for gated-but-uncapped categories such as Board Member.
+- **Revocation writes `max_discount_amount = 0`** and leaves the row intact.
+
+| UI state | `discount_percentage` | `max_discount_amount` |
+|---|---|---|
+| Active, capped | 1–100 (required) | dollars → cents, `> 0` |
+| Active, uncapped | 1–100 (required) | `NULL`, via explicit toggle |
+| Revoked | unchanged | `0` |
+
+No state is expressed by an empty field. The resolver's existing handling of a `NULL` percentage
+(allowance-driven code becomes ineligible — fail closed) remains as a safety net for rows created
+by direct SQL.
+
+Also: **remove `default_percentage` from the category admin UI scope.** Nothing reads it once
+every allowance carries its own percentage, and offering a control would reintroduce the ambiguity
+this decision removes.
+
+### D2 — Cents in the database, dollars and cents in the UI
+
+`max_discount_amount` is integer cents, consistent with the rest of the schema. The UI displays and
+accepts dollars and cents. Specify where conversion happens and validate it: `$250.00` must store
+`25000`. This error fails in the generous direction and is invisible until someone gets a
+hundred-fold discount.
+
+### D3 — Existing allowances plus an "Add allowance" control
+
+The editor lists the user's existing allowance rows for the current and upcoming seasons. A
+separate "Add allowance" action picks a season and a category from combinations not yet used.
+
+Rejected: listing every category × season with empty states. With 5 categories and 2 seasons that
+is 10 permanently-empty rows on a page that already carries payment plan, admin access, and
+discount usage sections, and the overwhelming majority of users have no allowances at all.
+
+The tradeoff is that an admin cannot tell from the user page which categories are gated. That is
+what the eligibility report is for.
+
+### D4 — A separate eligibility report, not a category-page tab
+
+Add a **discount eligibility** report under `/admin/reports/`, grouped by season like the existing
+discount usage report, showing per user: category, percentage, limit, amount used, and remaining.
+
+This is not a duplicate of `discount-usage`. The two answer different questions from different
+sources, and the populations differ:
+
+- **Usage** — who spent what, derived from `discount_usage_computed` (invoices)
+- **Eligibility** — who was granted what, derived from `user_discount_allowances`
+
+A member granted $750 who has not yet registered appears in eligibility and not in usage. That
+person is exactly who the Phase 4 pre-flight check needs to find.
+
+Both reports must read limits through `resolveEffectiveDiscountLimits` so they cannot drift.
+
+Additionally, surface **both usage and eligibility** on `/admin/reports/users/[id]`.
+
+### D5 — Show the resolution source
+
+Include `source` (`'user_allowance'` / `'category_default'` / `'denied'`) in the eligibility report.
+It is also a diagnostic: once Financial Aid is gated, any row there showing `category_default` is a
+bug.
+
+## Current State
+
+**Schema** (live in production, unused): `user_discount_allowances` with `discount_percentage` and
+`max_discount_amount` both nullable, plus `notes`, `created_by`, `updated_by`, `is_default`.
+`discount_categories` has `requires_user_allowance`, `default_percentage`, `priority`.
+
+**Resolver:** `resolveEffectiveDiscountLimits` and `resolveEffectiveDiscountLimitsBatch` in
+`discount-limit-service.ts` are the single source of resolution truth. **No UI or report may
+reimplement the rules.**
+
+**Pattern to follow:** `/api/admin/users/[id]/payment-plan-eligibility` and
+`PaymentPlanSection.tsx` on `/admin/reports/users/[id]`. Same auth shape, same section layout.
+
+**Note:** there are no generated Supabase types and the client is untyped. A wrong column name will
+not fail the build or the mocked tests. Select columns explicitly, never `*`.
+
+## API
+
+### `/api/admin/users/[id]/discount-allowances`
+
+- **GET** — allowance rows for the current and upcoming seasons, each with computed used and
+  remaining from `discount_usage_computed`, plus the list of season/category combinations still
+  available to add
+- **PUT** — upsert one allowance for a `(user, season, category)` triple
+- **DELETE** — not used for revocation (D1). Include only if there is a genuine created-in-error
+  case, and say so explicitly.
+
+Requirements:
+
+- `is_admin` check before anything, matching `payment-plan-eligibility`
+- `createAdminClient()` for writes
+- `logger.logAdminAction` on every mutation, recording before and after values
+- `created_by` on insert, `updated_by` on update, both from the acting admin
+- Validation mirroring the DB constraints, with usable error messages rather than raw constraint
+  violations: percentage required and `> 0 and <= 100`; cap either `NULL` (uncapped) or `>= 0`
+- Reject writes to past seasons. Current is `start_date <= now() <= end_date`; upcoming is
+  `start_date > now()`
+
+### Season scope
+
+Current and upcoming seasons only, everywhere in this phase. Past seasons are neither listed nor
+writable.
+
+## UI
+
+### `DiscountAllowanceSection.tsx` — `/admin/reports/users/[id]`
+
+Modeled on `PaymentPlanSection.tsx`. Lists existing allowances grouped by season:
+
+- Category, percentage, and cap — or "No dollar cap"
+- Used and remaining for the season, from `discount_usage_computed`
+- `notes` — matters for the aid conversation and survives revocation
+- Who last changed it and when, from `updated_by` / `updated_at`
+- Revoke action (writes `0`, row stays visible and restorable)
+- "Add allowance" action for unused season/category combinations
+
+Place adjacent to the existing `DiscountUsage` component, or absorb it, so grant and consumption
+read together.
+
+### `/admin/discount-categories`
+
+Add `requires_user_allowance` only. The checkbox needs a warning: enabling it denies every user
+without an allowance for that category, immediately.
+
+Do **not** add a `default_percentage` control (D1).
+
+### Alternates list fix
+
+`src/app/api/alternate-registrations/[gameId]/alternates/route.ts` sets `isOverLimit = true` for
+ineligible users, so a captain sees an "over limit" badge on someone who was never eligible.
+Separate the two states in the response and in the UI.
+
+## Reporting
+
+- **New:** discount eligibility report (D4), grouped by season, showing user, category, percentage,
+  limit, used, remaining, and `source`
+- **⚠️ Register the new report in navigation.** There is no `/admin/reports/page.tsx` index — report
+  links are maintained by hand, so a new report page is unreachable until it is added. Do not guess
+  the location: grep for `reports/discount-usage` across `src/` and add the eligibility report
+  everywhere that path is linked (the admin dashboard at `src/app/admin/page.tsx`, plus any shared
+  nav or menu component). This step is routinely missed.
+- **Fix:** `/api/admin/reports/discount-usage` computes `remaining` and `isFullyUtilized` from
+  `category.maxPerUser`. Must resolve per user
+- **Fix:** `getSeasonalDiscountUsageSummary` in `discount-limit-service.ts` reads only
+  `max_discount_per_user_per_season`. Must resolve per user
+- Both reports resolve through `resolveEffectiveDiscountLimits`
+
+## Operational Notes for the Data-Entry Window
+
+The gap between this PR and Phase 4 is when admins enter every allowance while the old codes still
+work and nothing is gated. Two things whoever does that entry must know, and which belong in the UI
+as help text:
+
+1. **Allowance rows take effect immediately, not at the flip.** A member granted 50% / $250 is
+   capped at $250 from the moment it saves, while everyone else still has the category's $750.
+2. **During this window a member may redeem a legacy fixed-percentage code** (`PRIDE75`) and
+   receive 75% capped by their allowance dollar limit. This is expected and was accepted as
+   correct-but-temporary (decision D5 of the parent spec). It ends when Phase 4 deactivates the
+   legacy codes.
+
+## Acceptance Criteria
+
+- Admin can create, edit, and revoke an allowance for current and upcoming seasons
+- Past seasons are neither listed nor writable
+- Percentage is required and constrained to 1–100; the UI cannot write a `NULL` percentage
+- "No dollar cap" writes `NULL`; no state is expressed by an empty field
+- `$250.00` entered stores `25000`; verified by a round-trip test
+- Revocation writes `0` and preserves `notes`, `created_by`, `updated_at`; the row stays visible
+- Every mutation appears in the admin action log with before/after values
+- Non-admins receive 403 from every endpoint
+- Used and remaining on the user page match `discount_usage_computed`
+- The usage report and `getSeasonalDiscountUsageSummary` resolve limits per user
+- The eligibility report lists every allowance holder for a season, including those with no usage
+- The eligibility report is reachable by clicking through the admin UI from the dashboard — not
+  only by typing the URL
+- Ineligible users are visually distinct from over-limit users on the alternates list
+- **No UI or report reimplements resolution.** Effective values come from
+  `resolveEffectiveDiscountLimits`
+- Existing test suites pass unmodified, including both payment services and the cross-path
+  integration suite
+
+## Testing
+
+- Round-trip: `$250.00` → `25000` → displays `$250.00`
+- Percentage validation rejects `0`, `101`, and empty
+- "No dollar cap" round-trips as `NULL` and resolves as unlimited
+- Revocation leaves the row with `0` and intact notes; a revoked member is denied at checkout
+- Granting an allowance on an ungated category caps a fixed-percentage code — the case verified
+  manually in Phase 2 at $0.30 and $300
+- Non-admin access returns 403 on GET, PUT, and DELETE
+- Report figures match the resolver for a user with an allowance and for one without
+- Eligibility report includes a user with an allowance and zero usage
+- Usage and eligibility reports agree on limit and remaining for the same user and season
+
+## Phase 4 Pre-Flight (produced by this phase)
+
+Before the flip, the eligibility report must confirm that every intended Financial Aid recipient
+has an allowance row for the season with a resolvable percentage. A gated category with a missing
+row means a member who received aid last season silently gets none.

--- a/src/__tests__/api/admin/discount-allowances.test.ts
+++ b/src/__tests__/api/admin/discount-allowances.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Tests for /api/admin/users/[id]/discount-allowances
+ */
+
+// Mock dependencies BEFORE imports
+jest.mock('@/lib/logging/logger', () => ({
+  logger: {
+    logAdminAction: jest.fn()
+  }
+}))
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(),
+  createAdminClient: jest.fn()
+}))
+
+jest.mock('@/lib/services/discount-limit-service', () => ({
+  resolveEffectiveDiscountLimitsBatch: jest.fn(),
+  calculateSeasonalDiscountUsageBatch: jest.fn()
+}))
+
+import { GET, PUT } from '@/app/api/admin/users/[id]/discount-allowances/route'
+import { createClient, createAdminClient } from '@/lib/supabase/server'
+import { logger } from '@/lib/logging/logger'
+import {
+  resolveEffectiveDiscountLimitsBatch,
+  calculateSeasonalDiscountUsageBatch
+} from '@/lib/services/discount-limit-service'
+import { NextRequest } from 'next/server'
+
+describe('/api/admin/users/[id]/discount-allowances', () => {
+  let mockSupabase: any
+  let mockAdminSupabase: any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockSupabase = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: { id: 'admin-id' } },
+          error: null
+        })
+      },
+      from: jest.fn()
+    }
+
+    mockAdminSupabase = {
+      from: jest.fn()
+    }
+
+    ;(createClient as jest.Mock).mockResolvedValue(mockSupabase)
+    ;(createAdminClient as jest.Mock).mockReturnValue(mockAdminSupabase)
+  })
+
+  describe('GET', () => {
+    it('returns 401 when unauthorized', async () => {
+      mockSupabase.auth.getUser.mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error('Not authenticated')
+      })
+
+      const req = new NextRequest('http://localhost/api/admin/users/target-id/discount-allowances')
+      const params = Promise.resolve({ id: 'target-id' })
+      const res = await GET(req, { params })
+
+      expect(res.status).toBe(401)
+    })
+
+    it('returns 403 when user is not admin', async () => {
+      mockSupabase.from.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: { is_admin: false }, error: null })
+          })
+        })
+      })
+
+      const req = new NextRequest('http://localhost/api/admin/users/target-id/discount-allowances')
+      const params = Promise.resolve({ id: 'target-id' })
+      const res = await GET(req, { params })
+
+      expect(res.status).toBe(403)
+    })
+
+    it('returns formatted allowances with resolved remaining and available options for active/upcoming seasons', async () => {
+      // Mock admin check
+      mockSupabase.from.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: { is_admin: true }, error: null })
+          })
+        })
+      })
+
+      // Mock active seasons query
+      mockSupabase.from.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          gte: jest.fn().mockReturnValue({
+            order: jest.fn().mockResolvedValue({
+              data: [
+                { id: 'season-current', name: 'Spring 2026', start_date: '2026-03-01', end_date: '2026-12-31' }
+              ],
+              error: null
+            })
+          })
+        })
+      })
+
+      // Mock user_discount_allowances query
+      mockSupabase.from.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [
+                {
+                  id: 'allowance-1',
+                  user_id: 'target-id',
+                  discount_category_id: 'cat-fa',
+                  season_id: 'season-current',
+                  discount_percentage: 50,
+                  max_discount_amount: 25000,
+                  notes: 'Financial aid 50%',
+                  created_by: 'admin-id',
+                  updated_by: 'admin-id',
+                  created_at: '2026-03-01T00:00:00Z',
+                  updated_at: '2026-03-01T00:00:00Z',
+                  category: { id: 'cat-fa', name: 'Financial Aid', requires_user_allowance: true },
+                  season: { id: 'season-current', name: 'Spring 2026', start_date: '2026-03-01', end_date: '2026-12-31' }
+                }
+              ],
+              error: null
+            })
+          })
+        })
+      })
+
+      // Mock all discount categories query for available options
+      mockSupabase.from.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          order: jest.fn().mockResolvedValue({
+            data: [
+              { id: 'cat-fa', name: 'Financial Aid' },
+              { id: 'cat-bm', name: 'Board Member' }
+            ],
+            error: null
+          })
+        })
+      })
+
+      // Mock resolver and usage batch functions
+      const effectiveMap = new Map()
+      effectiveMap.set('target-id:cat-fa', {
+        maxAllowed: 25000,
+        percentage: 50,
+        isEligible: true,
+        source: 'user_allowance'
+      })
+      ;(resolveEffectiveDiscountLimitsBatch as jest.Mock).mockResolvedValue(effectiveMap)
+
+      const usageMap = new Map()
+      usageMap.get = jest.fn((key: string) => (key === 'target-id:cat-fa' ? 10000 : 0))
+      ;(calculateSeasonalDiscountUsageBatch as jest.Mock).mockResolvedValue(usageMap)
+
+      const req = new NextRequest('http://localhost/api/admin/users/target-id/discount-allowances')
+      const params = Promise.resolve({ id: 'target-id' })
+      const res = await GET(req, { params })
+
+      expect(res.status).toBe(200)
+      const data = await res.json()
+      expect(data.allowances).toHaveLength(1)
+      expect(data.allowances[0].remaining).toBe(15000) // $250 - $100 = $150 (15000 cents)
+      expect(data.allowances[0].totalUsed).toBe(10000)
+      expect(data.availableOptions).toHaveLength(1)
+      expect(data.availableOptions[0].categoryId).toBe('cat-bm')
+    })
+  })
+
+  describe('PUT', () => {
+    it('validates discountPercentage (1-100 required)', async () => {
+      mockSupabase.from.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: { is_admin: true }, error: null })
+          })
+        })
+      })
+
+      const req = new NextRequest('http://localhost/api/admin/users/target-id/discount-allowances', {
+        method: 'PUT',
+        body: JSON.stringify({
+          seasonId: 'season-current',
+          categoryId: 'cat-fa',
+          discountPercentage: 0, // invalid (must be >= 1)
+          maxDiscountAmount: 25000
+        })
+      })
+      const params = Promise.resolve({ id: 'target-id' })
+      const res = await PUT(req, { params })
+
+      expect(res.status).toBe(400)
+      const data = await res.json()
+      expect(data.error).toContain('discountPercentage must be a number between 1 and 100')
+    })
+
+    it('rejects writes to past seasons (end_date < now)', async () => {
+      mockSupabase.from.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: { is_admin: true }, error: null })
+          })
+        })
+      })
+
+      // Mock season query returning a past season
+      mockSupabase.from.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: {
+                id: 'season-past',
+                name: 'Past Season 2020',
+                end_date: '2020-12-31T23:59:59Z'
+              },
+              error: null
+            })
+          })
+        })
+      })
+
+      const req = new NextRequest('http://localhost/api/admin/users/target-id/discount-allowances', {
+        method: 'PUT',
+        body: JSON.stringify({
+          seasonId: 'season-past',
+          categoryId: 'cat-fa',
+          discountPercentage: 50,
+          maxDiscountAmount: 25000
+        })
+      })
+      const params = Promise.resolve({ id: 'target-id' })
+      const res = await PUT(req, { params })
+
+      expect(res.status).toBe(400)
+      const data = await res.json()
+      expect(data.error).toBe('Writes to past seasons are not allowed')
+    })
+
+    it('successfully upserts allowance, round-trips cents, and logs admin action with before/after values', async () => {
+      // Mock admin check
+      mockSupabase.from.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({ data: { is_admin: true }, error: null })
+          })
+        })
+      })
+
+      // Mock season query (current/upcoming)
+      mockSupabase.from.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: {
+                id: 'season-current',
+                name: 'Spring 2026',
+                end_date: '2026-12-31T23:59:59Z'
+              },
+              error: null
+            })
+          })
+        })
+      })
+
+      // Mock existing row query (before value)
+      mockSupabase.from.mockReturnValueOnce({
+        select: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                maybeSingle: jest.fn().mockResolvedValue({
+                  data: {
+                    id: 'allowance-1',
+                    discount_percentage: 20,
+                    max_discount_amount: 10000
+                  },
+                  error: null
+                })
+              })
+            })
+          })
+        })
+      })
+
+      // Mock adminSupabase upsert
+      const updatedRecord = {
+        id: 'allowance-1',
+        user_id: 'target-id',
+        season_id: 'season-current',
+        discount_category_id: 'cat-fa',
+        discount_percentage: 50,
+        max_discount_amount: 25000, // $250.00 in cents
+        notes: 'Updated to 50%',
+        created_by: 'admin-id',
+        updated_by: 'admin-id',
+        updated_at: '2026-03-01T00:00:00Z'
+      }
+
+      mockAdminSupabase.from.mockReturnValueOnce({
+        upsert: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: updatedRecord,
+              error: null
+            })
+          })
+        })
+      })
+
+      const req = new NextRequest('http://localhost/api/admin/users/target-id/discount-allowances', {
+        method: 'PUT',
+        body: JSON.stringify({
+          seasonId: 'season-current',
+          categoryId: 'cat-fa',
+          discountPercentage: 50,
+          maxDiscountAmount: 25000, // $250.00 in cents
+          notes: 'Updated to 50%'
+        })
+      })
+      const params = Promise.resolve({ id: 'target-id' })
+      const res = await PUT(req, { params })
+
+      expect(res.status).toBe(200)
+      const data = await res.json()
+      expect(data.success).toBe(true)
+      expect(data.allowance.max_discount_amount).toBe(25000)
+
+      // Verify admin action log
+      expect(logger.logAdminAction).toHaveBeenCalledWith(
+        'discount-allowance-updated',
+        'Discount allowance updated for user',
+        expect.objectContaining({
+          targetUserId: 'target-id',
+          adminUserId: 'admin-id',
+          before: expect.objectContaining({ discount_percentage: 20 }),
+          after: expect.objectContaining({ discount_percentage: 50, max_discount_amount: 25000 })
+        }),
+        'info'
+      )
+    })
+  })
+})

--- a/src/__tests__/api/admin/discount-eligibility-report.test.ts
+++ b/src/__tests__/api/admin/discount-eligibility-report.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Unit test suite for GET /api/admin/reports/discount-eligibility
+ */
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn()
+}))
+
+jest.mock('@/lib/services/discount-limit-service', () => ({
+  resolveEffectiveDiscountLimitsBatch: jest.fn(),
+  calculateSeasonalDiscountUsageBatch: jest.fn()
+}))
+
+import { GET } from '@/app/api/admin/reports/discount-eligibility/route'
+import { createClient } from '@/lib/supabase/server'
+import {
+  resolveEffectiveDiscountLimitsBatch,
+  calculateSeasonalDiscountUsageBatch
+} from '@/lib/services/discount-limit-service'
+import { NextRequest } from 'next/server'
+
+describe('/api/admin/reports/discount-eligibility', () => {
+  let mockSupabase: any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockSupabase = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: { id: 'admin-id' } },
+          error: null
+        })
+      },
+      from: jest.fn()
+    }
+
+    ;(createClient as jest.Mock).mockResolvedValue(mockSupabase)
+  })
+
+  it('returns 401 when unauthenticated', async () => {
+    mockSupabase.auth.getUser.mockResolvedValueOnce({ data: { user: null }, error: new Error('Auth required') })
+    const req = new NextRequest('http://localhost/api/admin/reports/discount-eligibility')
+    const res = await GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 for non-admin user', async () => {
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { is_admin: false }, error: null })
+        })
+      })
+    })
+
+    const req = new NextRequest('http://localhost/api/admin/reports/discount-eligibility')
+    const res = await GET(req)
+    expect(res.status).toBe(403)
+  })
+
+  it('returns formatted eligibility list including users with zero usage and 2-state source badge', async () => {
+    // 1. Admin check
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { is_admin: true }, error: null })
+        })
+      })
+    })
+
+    // 2. Seasons query
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        order: jest.fn().mockResolvedValue({
+          data: [
+            { id: 'season-current', name: 'Spring 2026', start_date: '2026-03-01', end_date: '2026-12-31' }
+          ],
+          error: null
+        })
+      })
+    })
+
+    // 3. User discount allowances query
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockResolvedValue({
+          data: [
+            {
+              id: 'allowance-active',
+              user_id: 'user-zero-usage',
+              discount_category_id: 'cat-fa',
+              season_id: 'season-current',
+              discount_percentage: 50,
+              max_discount_amount: 25000,
+              notes: 'Active allowance with 0 usage',
+              created_at: '2026-03-01T00:00:00Z',
+              updated_at: '2026-03-01T00:00:00Z',
+              user: { id: 'user-zero-usage', first_name: 'Alice', last_name: 'Smith', email: 'alice@example.com', member_id: 'M100' },
+              category: { id: 'cat-fa', name: 'Financial Aid', requires_user_allowance: true }
+            },
+            {
+              id: 'allowance-revoked',
+              user_id: 'user-revoked',
+              discount_category_id: 'cat-fa',
+              season_id: 'season-current',
+              discount_percentage: 50,
+              max_discount_amount: 0,
+              notes: 'Revoked allowance',
+              created_at: '2026-03-01T00:00:00Z',
+              updated_at: '2026-03-01T00:00:00Z',
+              user: { id: 'user-revoked', first_name: 'Bob', last_name: 'Jones', email: 'bob@example.com', member_id: 'M101' },
+              category: { id: 'cat-fa', name: 'Financial Aid', requires_user_allowance: true }
+            }
+          ],
+          error: null
+        })
+      })
+    })
+
+    // Batch mocks
+    const effectiveMap = new Map()
+    effectiveMap.set('user-zero-usage:cat-fa', {
+      maxAllowed: 25000,
+      percentage: 50,
+      isEligible: true,
+      source: 'user_allowance'
+    })
+    effectiveMap.set('user-revoked:cat-fa', {
+      maxAllowed: 0,
+      percentage: null,
+      isEligible: false,
+      source: 'denied'
+    })
+    ;(resolveEffectiveDiscountLimitsBatch as jest.Mock).mockResolvedValue(effectiveMap)
+
+    const usageMap = new Map()
+    // Notice user-zero-usage is NOT in usageMap -> map lookup miss = 0 usage
+    ;(calculateSeasonalDiscountUsageBatch as jest.Mock).mockResolvedValue(usageMap)
+
+    const req = new NextRequest('http://localhost/api/admin/reports/discount-eligibility?seasonId=season-current')
+    const res = await GET(req)
+
+    expect(res.status).toBe(200)
+    const data = await res.json()
+
+    expect(data.eligibility).toHaveLength(2)
+
+    // Check user with zero usage
+    const activeRow = data.eligibility.find((r: any) => r.userId === 'user-zero-usage')
+    expect(activeRow).toBeDefined()
+    expect(activeRow.totalUsed).toBe(0)
+    expect(activeRow.remaining).toBe(25000)
+    expect(activeRow.source).toBe('user_allowance')
+    expect(activeRow.isRevoked).toBe(false)
+
+    // Check revoked user
+    const revokedRow = data.eligibility.find((r: any) => r.userId === 'user-revoked')
+    expect(revokedRow).toBeDefined()
+    expect(revokedRow.remaining).toBe(0)
+    expect(revokedRow.source).toBe('denied')
+    expect(revokedRow.isRevoked).toBe(true)
+  })
+})

--- a/src/__tests__/api/alternate-registrations/alternates-ineligible.test.ts
+++ b/src/__tests__/api/alternate-registrations/alternates-ineligible.test.ts
@@ -1,0 +1,140 @@
+/**
+ * Test for alternates list endpoint separating isIneligible vs isOverLimit
+ */
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(),
+  createAdminClient: jest.fn()
+}))
+
+jest.mock('@/lib/services/discount-limit-service', () => ({
+  resolveEffectiveDiscountLimitsBatch: jest.fn(),
+  calculateSeasonalDiscountUsageBatch: jest.fn(),
+  resolveDiscountPercentage: jest.fn(),
+  evaluateSeasonalDiscountLimit: jest.fn()
+}))
+
+jest.mock('@/lib/utils/alternates-access', () => ({
+  canAccessRegistrationAlternates: jest.fn().mockResolvedValue(true)
+}))
+
+jest.mock('@/lib/payment-method-utils', () => ({
+  userHasValidPaymentMethod: jest.fn().mockReturnValue(true)
+}))
+
+import { GET } from '@/app/api/alternate-registrations/[gameId]/alternates/route'
+import { createClient, createAdminClient } from '@/lib/supabase/server'
+import { canAccessRegistrationAlternates } from '@/lib/utils/alternates-access'
+import {
+  resolveEffectiveDiscountLimitsBatch,
+  calculateSeasonalDiscountUsageBatch,
+  resolveDiscountPercentage
+} from '@/lib/services/discount-limit-service'
+import { NextRequest } from 'next/server'
+
+describe('/api/alternate-registrations/[gameId]/alternates ineligible vs over-limit separation', () => {
+  let mockSupabase: any
+  let mockAdminSupabase: any
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+
+    mockSupabase = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: { id: 'admin-id' } },
+          error: null
+        })
+      },
+      from: jest.fn()
+    }
+
+    mockAdminSupabase = {
+      from: jest.fn()
+    }
+
+    ;(createClient as jest.Mock).mockResolvedValue(mockSupabase)
+    ;(createAdminClient as jest.Mock).mockReturnValue(mockAdminSupabase)
+    ;(canAccessRegistrationAlternates as jest.Mock).mockResolvedValue(true)
+  })
+
+  it('sets isIneligible: true and isOverLimit: false for ineligible users on gated categories', async () => {
+    // 1. Game query
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: {
+              id: 'game-1',
+              registration_id: 'reg-1',
+              registrations: {
+                id: 'reg-1',
+                season_id: 'season-1',
+                alternate_price: 2000,
+                allow_alternates: true
+              }
+            },
+            error: null
+          })
+        })
+      })
+    })
+
+    // 2. Alternates query on adminSupabase
+    mockAdminSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockResolvedValue({
+          data: [
+            {
+              id: 'alt-1',
+              user_id: 'user-ineligible',
+              discount_code_id: 'code-gated',
+              created_at: '2026-03-01T00:00:00Z',
+              users: { id: 'user-ineligible', first_name: 'Jane', last_name: 'Doe', email: 'jane@example.com' },
+              discount_codes: {
+                id: 'code-gated',
+                code: 'FA50',
+                percentage: null,
+                category: { id: 'cat-gated', name: 'Financial Aid', max_discount_per_user_per_season: null }
+              }
+            }
+          ],
+          error: null
+        })
+      })
+    })
+
+    // 3. Alternate selections query on adminSupabase
+    mockAdminSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockResolvedValue({ data: [], error: null })
+      })
+    })
+
+    // Mock batch limit resolution returning isEligible: false for user-ineligible
+    const effectiveMap = new Map()
+    effectiveMap.set('user-ineligible:cat-gated', {
+      maxAllowed: 0,
+      percentage: null,
+      isEligible: false,
+      source: 'denied'
+    })
+    ;(resolveEffectiveDiscountLimitsBatch as jest.Mock).mockResolvedValue(effectiveMap)
+
+    const usageMap = new Map()
+    ;(calculateSeasonalDiscountUsageBatch as jest.Mock).mockResolvedValue(usageMap)
+    ;(resolveDiscountPercentage as jest.Mock).mockReturnValue(null)
+
+    const req = new NextRequest('http://localhost/api/alternate-registrations/game-1/alternates')
+    const params = Promise.resolve({ gameId: 'game-1' })
+    const res = await GET(req, { params })
+    const data = await res.json()
+
+    expect(data).toEqual(expect.objectContaining({ alternates: expect.any(Array) }))
+    expect(res.status).toBe(200)
+    expect(data.alternates).toHaveLength(1)
+    expect(data.alternates[0].discountCode.isIneligible).toBe(true)
+    expect(data.alternates[0].discountCode.isOverLimit).toBe(false)
+    expect(data.alternates[0].discountCode.discountAmount).toBe(0)
+  })
+})

--- a/src/__tests__/integration/cross-path-discount-consistency.test.ts
+++ b/src/__tests__/integration/cross-path-discount-consistency.test.ts
@@ -785,7 +785,8 @@ describe('Cross-Path Discount Consistency (Alternates List vs Alternate Charge)'
 
     expect(response.status).toBe(200)
     const listAlternate = listData.alternates[0]
-    expect(listAlternate.discountCode.isOverLimit).toBe(true)
+    expect(listAlternate.discountCode.isIneligible).toBe(true)
+    expect(listAlternate.discountCode.isOverLimit).toBe(false)
     expect(listAlternate.pricing.discountAmount).toBe(0)
 
     // Path B: AlternatePaymentService charge calculation

--- a/src/__tests__/integration/report-consistency.test.ts
+++ b/src/__tests__/integration/report-consistency.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Non-tautological Integration Test: Cross-report consistency between Discount Usage
+ * and Discount Eligibility reports.
+ *
+ * Verifies that GET /api/admin/reports/discount-usage and
+ * GET /api/admin/reports/discount-eligibility run real per-user limit resolution
+ * end-to-end and compute identical remaining balances for the same user and season.
+ *
+ * Underlying DB state sets category default cap = $750 (75000 cents) and allowance cap = $250 (25000 cents).
+ * If either route reads raw category limits directly instead of using the resolver,
+ * it will return $650 remaining (75000 - 10000) instead of $150 remaining (25000 - 10000), failing the test.
+ */
+
+import { GET as getUsageReport } from '@/app/api/admin/reports/discount-usage/route'
+import { GET as getEligibilityReport } from '@/app/api/admin/reports/discount-eligibility/route'
+import { NextRequest } from 'next/server'
+
+// Mock Supabase Server Clients - Real discount-limit-service runs against this mocked client
+var mockSupabase: any = {
+  auth: {
+    getUser: jest.fn()
+  },
+  from: jest.fn()
+}
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(() => Promise.resolve(mockSupabase)),
+  createAdminClient: jest.fn(() => mockSupabase)
+}))
+
+describe('Report Consistency Integration (End-to-End Resolution)', () => {
+  const userId = 'user-fa-1'
+  const seasonId = 'season-2026'
+  const categoryId = 'cat-fa'
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'admin-id' } }, error: null })
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'users') {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              single: jest.fn().mockResolvedValue({ data: { is_admin: true }, error: null })
+            })
+          })
+        }
+      }
+
+      if (table === 'seasons') {
+        return {
+          select: jest.fn().mockReturnValue({
+            order: jest.fn().mockResolvedValue({
+              data: [
+                { id: seasonId, name: 'Spring 2026', start_date: '2026-03-01', end_date: '2026-12-31' }
+              ],
+              error: null
+            })
+          })
+        }
+      }
+
+      if (table === 'discount_categories') {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              single: jest.fn().mockResolvedValue({
+                data: {
+                  id: categoryId,
+                  name: 'Financial Aid',
+                  requires_user_allowance: true,
+                  max_discount_per_user_per_season: 75000, // $750 category cap (DIFFERENT from allowance cap!)
+                  default_percentage: null
+                },
+                error: null
+              }),
+              in: jest.fn().mockResolvedValue({
+                data: [
+                  {
+                    id: categoryId,
+                    name: 'Financial Aid',
+                    requires_user_allowance: true,
+                    max_discount_per_user_per_season: 75000,
+                    default_percentage: null
+                  }
+                ],
+                error: null
+              })
+            }),
+            in: jest.fn().mockResolvedValue({
+              data: [
+                {
+                  id: categoryId,
+                  name: 'Financial Aid',
+                  requires_user_allowance: true,
+                  max_discount_per_user_per_season: 75000,
+                  default_percentage: null
+                }
+              ],
+              error: null
+            }),
+            data: [
+              {
+                id: categoryId,
+                name: 'Financial Aid',
+                requires_user_allowance: true,
+                max_discount_per_user_per_season: 75000,
+                default_percentage: null
+              }
+            ],
+            error: null
+          })
+        }
+      }
+
+      if (table === 'user_discount_allowances') {
+        const allowanceRow = {
+          id: 'allowance-1',
+          user_id: userId,
+          discount_category_id: categoryId,
+          season_id: seasonId,
+          discount_percentage: 50,
+          max_discount_amount: 25000, // $250 allowance cap (overrides $750 category default cap!)
+          notes: 'FA Aid 50%',
+          created_at: '2026-03-01T00:00:00Z',
+          updated_at: '2026-03-01T00:00:00Z',
+          user: { id: userId, first_name: 'Charlie', last_name: 'Brown', email: 'charlie@example.com', member_id: 'M200' },
+          category: { id: categoryId, name: 'Financial Aid', requires_user_allowance: true }
+        }
+
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockImplementation(() => ({
+              eq: jest.fn().mockImplementation(() => ({
+                eq: jest.fn().mockResolvedValue({
+                  data: [allowanceRow],
+                  error: null
+                }),
+                data: [allowanceRow],
+                error: null
+              })),
+              in: jest.fn().mockResolvedValue({
+                data: [allowanceRow],
+                error: null
+              }),
+              data: [allowanceRow],
+              error: null
+            })),
+            in: jest.fn().mockImplementation(() => ({
+              eq: jest.fn().mockResolvedValue({
+                data: [allowanceRow],
+                error: null
+              }),
+              in: jest.fn().mockResolvedValue({
+                data: [allowanceRow],
+                error: null
+              }),
+              data: [allowanceRow],
+              error: null
+            }))
+          })
+        }
+      }
+
+      if (table === 'discount_usage_computed') {
+        const usageRow = {
+          id: 'usage-1',
+          user_id: userId,
+          user_first_name: 'Charlie',
+          user_last_name: 'Brown',
+          user_email: 'charlie@example.com',
+          user_member_id: 'M200',
+          amount_saved: 10000, // $100 used
+          used_at: '2026-03-02T00:00:00Z',
+          season_id: seasonId,
+          season_name: 'Spring 2026',
+          season_start_date: '2026-03-01',
+          season_end_date: '2026-12-31',
+          discount_category_id: categoryId,
+          discount_category_name: 'Financial Aid',
+          discount_category_max_per_season: 75000, // $750 raw category default cap in view
+          discount_code_id: 'code-1',
+          discount_code: 'FA50',
+          registration_name: 'Spring League'
+        }
+
+        return {
+          select: jest.fn().mockReturnValue({
+            order: jest.fn().mockResolvedValue({
+              data: [usageRow],
+              error: null
+            }),
+            in: jest.fn().mockReturnValue({
+              eq: jest.fn().mockResolvedValue({
+                data: [{ user_id: userId, discount_category_id: categoryId, amount_saved: 10000 }],
+                error: null
+              })
+            })
+          })
+        }
+      }
+
+      return {}
+    })
+  })
+
+  it('Discount Usage and Discount Eligibility reports agree on remaining balance ($150) driven by allowance cap ($250), not category cap ($750)', async () => {
+    // 1. Call Usage Report GET
+    const reqUsage = new NextRequest('http://localhost/api/admin/reports/discount-usage')
+    const resUsage = await getUsageReport(reqUsage)
+    expect(resUsage.status).toBe(200)
+    const usageData = await resUsage.json()
+
+    // 2. Call Eligibility Report GET
+    const reqEligibility = new NextRequest(`http://localhost/api/admin/reports/discount-eligibility?seasonId=${seasonId}`)
+    const resEligibility = await getEligibilityReport(reqEligibility)
+    expect(resEligibility.status).toBe(200)
+    const eligibilityData = await resEligibility.json()
+
+    // Extract user record from Usage Report
+    const seasonUsage = usageData.seasons.find((s: any) => s.seasonId === seasonId)
+    const catUsage = seasonUsage.categories.find((c: any) => c.categoryId === categoryId)
+    const userUsage = catUsage.users.find((u: any) => u.userId === userId)
+
+    // Extract user record from Eligibility Report
+    const userEligibility = eligibilityData.eligibility.find((e: any) => e.userId === userId && e.categoryId === categoryId)
+
+    // Verify both reports read the $100 total used
+    expect(userUsage.totalAmount).toBe(10000)
+    expect(userEligibility.totalUsed).toBe(10000)
+
+    // VERIFY NON-TAUTOLOGICAL RESOLUTION:
+    // Allowance cap = $250 (25000 cents). Used = $100 (10000 cents).
+    // Remaining MUST be $150 (15000 cents) on BOTH reports.
+    // If either report read the category default cap ($750), remaining would be $650 (65000 cents) and fail here.
+    expect(userUsage.remaining).toBe(15000)
+    expect(userEligibility.remaining).toBe(15000)
+    expect(userUsage.remaining).toBe(userEligibility.remaining)
+  })
+})

--- a/src/__tests__/services/discount-limit-service.test.ts
+++ b/src/__tests__/services/discount-limit-service.test.ts
@@ -571,35 +571,54 @@ describe('DiscountLimitService', () => {
     })
 
     it('should return correct summary with remaining amount', async () => {
-      // Mock category query
-      mockSupabase.from.mockReturnValueOnce({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            single: jest.fn().mockResolvedValue({
-              data: {
-                max_discount_per_user_per_season: 5000 // $50 cap
-              },
-              error: null
-            })
-          })
-        })
-      })
-
-      // Mock discount usage query
-      mockSupabase.from.mockReturnValueOnce({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            eq: jest.fn().mockReturnValue({
-              eq: jest.fn().mockResolvedValue({
-                data: [
-                  { amount_saved: 2000 },
-                  { amount_saved: 1500 }
-                ],
-                error: null
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'discount_categories') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                single: jest.fn().mockResolvedValue({
+                  data: {
+                    id: 'category-id',
+                    name: 'Test Category',
+                    requires_user_allowance: false,
+                    max_discount_per_user_per_season: 5000,
+                    default_percentage: 50
+                  },
+                  error: null
+                })
               })
             })
-          })
-        })
+          }
+        }
+        if (table === 'user_discount_allowances') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({ data: [], error: null })
+                })
+              })
+            })
+          }
+        }
+        if (table === 'discount_usage_computed') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({
+                    data: [
+                      { amount_saved: 2000 },
+                      { amount_saved: 1500 }
+                    ],
+                    error: null
+                  })
+                })
+              })
+            })
+          }
+        }
+        return {}
       })
 
       const result = await getSeasonalDiscountUsageSummary(
@@ -617,35 +636,54 @@ describe('DiscountLimitService', () => {
     })
 
     it('should return 0 remaining when at cap', async () => {
-      // Mock category query
-      mockSupabase.from.mockReturnValueOnce({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            single: jest.fn().mockResolvedValue({
-              data: {
-                max_discount_per_user_per_season: 5000 // $50 cap
-              },
-              error: null
-            })
-          })
-        })
-      })
-
-      // Mock discount usage query - exactly at cap
-      mockSupabase.from.mockReturnValueOnce({
-        select: jest.fn().mockReturnValue({
-          eq: jest.fn().mockReturnValue({
-            eq: jest.fn().mockReturnValue({
-              eq: jest.fn().mockResolvedValue({
-                data: [
-                  { amount_saved: 2500 },
-                  { amount_saved: 2500 }
-                ],
-                error: null
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'discount_categories') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                single: jest.fn().mockResolvedValue({
+                  data: {
+                    id: 'category-id',
+                    name: 'Test Category',
+                    requires_user_allowance: false,
+                    max_discount_per_user_per_season: 5000,
+                    default_percentage: 50
+                  },
+                  error: null
+                })
               })
             })
-          })
-        })
+          }
+        }
+        if (table === 'user_discount_allowances') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({ data: [], error: null })
+                })
+              })
+            })
+          }
+        }
+        if (table === 'discount_usage_computed') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({
+                    data: [
+                      { amount_saved: 2500 },
+                      { amount_saved: 2500 }
+                    ],
+                    error: null
+                  })
+                })
+              })
+            })
+          }
+        }
+        return {}
       })
 
       const result = await getSeasonalDiscountUsageSummary(
@@ -659,6 +697,67 @@ describe('DiscountLimitService', () => {
         totalUsed: 5000,
         remaining: 0,
         maxAllowed: 5000
+      })
+    })
+
+    it('should check ineligibility before uncapped check on gated category', async () => {
+      // Gated category with null category cap
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'discount_categories') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                single: jest.fn().mockResolvedValue({
+                  data: {
+                    id: 'gated-cat-id',
+                    name: 'Gated Category',
+                    requires_user_allowance: true,
+                    max_discount_per_user_per_season: null,
+                    default_percentage: 50
+                  },
+                  error: null
+                })
+              })
+            })
+          }
+        }
+        if (table === 'user_discount_allowances') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({ data: [], error: null })
+                })
+              })
+            })
+          }
+        }
+        if (table === 'discount_usage_computed') {
+          return {
+            select: jest.fn().mockReturnValue({
+              eq: jest.fn().mockReturnValue({
+                eq: jest.fn().mockReturnValue({
+                  eq: jest.fn().mockResolvedValue({ data: [], error: null })
+                })
+              })
+            })
+          }
+        }
+        return {}
+      })
+
+      const result = await getSeasonalDiscountUsageSummary(
+        mockSupabase,
+        'user-id',
+        'gated-cat-id',
+        'season-id'
+      )
+
+      // Must return maxAllowed: 0 and remaining: 0 (ineligible), NOT null
+      expect(result).toEqual({
+        totalUsed: 0,
+        remaining: 0,
+        maxAllowed: 0
       })
     })
 

--- a/src/app/admin/discount-categories/[id]/edit/page.tsx
+++ b/src/app/admin/discount-categories/[id]/edit/page.tsx
@@ -20,6 +20,7 @@ export default function EditDiscountCategoryPage() {
     accounting_code: '',
     max_discount_per_user_per_season: '',
     is_active: true,
+    requires_user_allowance: false,
   })
   const [limitDisplay, setLimitDisplay] = useState('')
   
@@ -50,6 +51,7 @@ export default function EditDiscountCategoryPage() {
           accounting_code: categoryData.accounting_code || '',
           max_discount_per_user_per_season: categoryData.max_discount_per_user_per_season ? categoryData.max_discount_per_user_per_season.toString() : '',
           is_active: categoryData.is_active ?? true,
+          requires_user_allowance: categoryData.requires_user_allowance ?? false,
         })
         
         // Set limit display
@@ -89,6 +91,7 @@ export default function EditDiscountCategoryPage() {
         accounting_code: formData.accounting_code.trim().toUpperCase(),
         max_discount_per_user_per_season: formData.max_discount_per_user_per_season ? parseInt(formData.max_discount_per_user_per_season) : null,
         is_active: formData.is_active,
+        requires_user_allowance: formData.requires_user_allowance,
       }
 
       const response = await fetch(`/api/admin/discount-categories/${categoryId}`, {
@@ -281,6 +284,29 @@ export default function EditDiscountCategoryPage() {
                 <label htmlFor="is_active" className="ml-2 block text-sm text-gray-900">
                   Category is active (codes can be created and used)
                 </label>
+              </div>
+
+              {/* Require User Allowance Checkbox */}
+              <div className="border border-amber-200 bg-amber-50 rounded-md p-4">
+                <div className="flex items-start">
+                  <div className="flex items-center h-5">
+                    <input
+                      id="requires_user_allowance"
+                      type="checkbox"
+                      checked={formData.requires_user_allowance}
+                      onChange={(e) => setFormData(prev => ({ ...prev, requires_user_allowance: e.target.checked }))}
+                      className="focus:ring-amber-500 h-4 w-4 text-amber-600 border-gray-300 rounded"
+                    />
+                  </div>
+                  <div className="ml-3 text-sm">
+                    <label htmlFor="requires_user_allowance" className="font-medium text-amber-900">
+                      Require User Allowance (Gated Category)
+                    </label>
+                    <p className="text-amber-800 text-xs mt-1">
+                      ⚠️ <strong>Warning:</strong> Enabling this denies every user without an explicit allowance for this category immediately.
+                    </p>
+                  </div>
+                </div>
               </div>
 
               {/* Duplicate Warnings */}

--- a/src/app/admin/discount-categories/new/page.tsx
+++ b/src/app/admin/discount-categories/new/page.tsx
@@ -227,6 +227,8 @@ export default function NewDiscountCategoryPage() {
                 <label htmlFor="is_active" className="ml-2 block text-sm text-gray-900">
                   Category is active (discount codes in this category can be used)
                 </label>
+              </div>
+
               {/* Require User Allowance Checkbox */}
               <div className="border border-amber-200 bg-amber-50 rounded-md p-4">
                 <div className="flex items-start">

--- a/src/app/admin/discount-categories/new/page.tsx
+++ b/src/app/admin/discount-categories/new/page.tsx
@@ -16,6 +16,7 @@ export default function NewDiscountCategoryPage() {
     accounting_code: '',
     max_discount_per_user_per_season: '', // in dollars, will convert to cents
     is_active: true,
+    requires_user_allowance: false,
   })
   
   const [existingCategories, setExistingCategories] = useState<any[]>([])
@@ -66,6 +67,7 @@ export default function NewDiscountCategoryPage() {
         accounting_code: formData.accounting_code.trim().toUpperCase(),
         max_discount_per_user_per_season: maxDiscountInCents,
         is_active: formData.is_active,
+        requires_user_allowance: formData.requires_user_allowance,
       }
 
       const response = await fetch('/api/admin/discount-categories', {
@@ -225,6 +227,27 @@ export default function NewDiscountCategoryPage() {
                 <label htmlFor="is_active" className="ml-2 block text-sm text-gray-900">
                   Category is active (discount codes in this category can be used)
                 </label>
+              {/* Require User Allowance Checkbox */}
+              <div className="border border-amber-200 bg-amber-50 rounded-md p-4">
+                <div className="flex items-start">
+                  <div className="flex items-center h-5">
+                    <input
+                      id="requires_user_allowance"
+                      type="checkbox"
+                      checked={formData.requires_user_allowance}
+                      onChange={(e) => setFormData({ ...formData, requires_user_allowance: e.target.checked })}
+                      className="focus:ring-amber-500 h-4 w-4 text-amber-600 border-gray-300 rounded"
+                    />
+                  </div>
+                  <div className="ml-3 text-sm">
+                    <label htmlFor="requires_user_allowance" className="font-medium text-amber-900">
+                      Require User Allowance (Gated Category)
+                    </label>
+                    <p className="text-amber-800 text-xs mt-1">
+                      ⚠️ <strong>Warning:</strong> Enabling this denies every user without an explicit allowance for this category immediately.
+                    </p>
+                  </div>
+                </div>
               </div>
 
               {/* Duplicate Warnings */}

--- a/src/app/admin/reports/discount-eligibility/page.tsx
+++ b/src/app/admin/reports/discount-eligibility/page.tsx
@@ -1,0 +1,258 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import Link from 'next/link'
+import AdminHeader from '@/components/AdminHeader'
+import BreadcrumbNav from '@/components/BreadcrumbNav'
+import { formatAmount } from '@/lib/format-utils'
+import { formatDate } from '@/lib/date-utils'
+
+interface Season {
+  id: string
+  name: string
+  start_date: string
+  end_date: string
+}
+
+interface EligibilityRow {
+  allowanceId: string
+  userId: string
+  userName: string
+  userEmail: string
+  memberId: string | null
+  categoryId: string
+  categoryName: string
+  discountPercentage: number
+  maxDiscountAmount: number | null
+  effectiveMaxAllowed: number | null
+  totalUsed: number
+  remaining: number | null
+  isRevoked: boolean
+  source: 'user_allowance' | 'denied'
+  notes: string | null
+  updatedAt: string
+}
+
+export default function DiscountEligibilityReportPage() {
+  const [seasons, setSeasons] = useState<Season[]>([])
+  const [selectedSeasonId, setSelectedSeasonId] = useState<string>('')
+  const [eligibility, setEligibility] = useState<EligibilityRow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    fetchReport(selectedSeasonId)
+  }, [selectedSeasonId])
+
+  const fetchReport = async (seasonId?: string) => {
+    setLoading(true)
+    setError(null)
+
+    try {
+      const url = seasonId
+        ? `/api/admin/reports/discount-eligibility?seasonId=${seasonId}`
+        : '/api/admin/reports/discount-eligibility'
+
+      const res = await fetch(url)
+      const data = await res.json()
+
+      if (res.ok) {
+        setSeasons(data.seasons || [])
+        setSelectedSeasonId(data.selectedSeasonId || '')
+        setEligibility(data.eligibility || [])
+      } else {
+        setError(data.error || 'Failed to fetch eligibility report')
+      }
+    } catch (err) {
+      setError('Error loading discount eligibility report')
+      console.error('Error fetching discount eligibility report:', err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // Summary Metrics
+  const activeRows = eligibility.filter(r => !r.isRevoked)
+  const totalEligibleUsers = activeRows.length
+  const totalUsedCents = eligibility.reduce((sum, r) => sum + r.totalUsed, 0)
+
+  const breadcrumbs = [
+    { label: 'Admin Dashboard', href: '/admin' },
+    { label: 'Reports', href: '/admin/reports' },
+    { label: 'Discount Eligibility', href: '/admin/reports/discount-eligibility' }
+  ]
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <AdminHeader />
+
+      <div className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div className="px-4 py-6 sm:px-0">
+          <BreadcrumbNav breadcrumbs={breadcrumbs} position="top" />
+
+          {/* Page Header */}
+          <div className="mb-6 flex flex-col sm:flex-row justify-between sm:items-center gap-4">
+            <div>
+              <h1 className="text-2xl font-bold text-gray-900">Discount Eligibility Report</h1>
+              <p className="mt-1 text-sm text-gray-600">
+                View all per-user seasonal discount allowances, cap resolution, and remaining balances
+              </p>
+            </div>
+
+            {/* Season Filter Dropdown */}
+            {seasons.length > 0 && (
+              <div className="flex items-center space-x-2">
+                <label htmlFor="season-select" className="text-sm font-medium text-gray-700">
+                  Season:
+                </label>
+                <select
+                  id="season-select"
+                  value={selectedSeasonId}
+                  onChange={(e) => setSelectedSeasonId(e.target.value)}
+                  className="border border-gray-300 rounded-md px-3 py-1.5 text-sm font-medium focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+                >
+                  {seasons.map(s => (
+                    <option key={s.id} value={s.id}>
+                      {s.name}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            )}
+          </div>
+
+          {/* Summary Cards */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-6">
+            <div className="bg-white p-4 rounded-lg shadow border border-gray-200">
+              <span className="text-xs font-medium text-gray-500 block">Eligible Allowance Holders</span>
+              <span className="text-2xl font-bold text-gray-900">{totalEligibleUsers}</span>
+            </div>
+            <div className="bg-white p-4 rounded-lg shadow border border-gray-200">
+              <span className="text-xs font-medium text-gray-500 block">Total Used</span>
+              <span className="text-2xl font-bold text-blue-600">{formatAmount(totalUsedCents)}</span>
+            </div>
+            <div className="bg-white p-4 rounded-lg shadow border border-gray-200">
+              <span className="text-xs font-medium text-gray-500 block">Revoked / Ineligible</span>
+              <span className="text-2xl font-bold text-red-600">
+                {eligibility.length - totalEligibleUsers}
+              </span>
+            </div>
+          </div>
+
+          {/* Report Content */}
+          {loading ? (
+            <div className="bg-white p-8 rounded-lg shadow text-center">
+              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 mx-auto mb-2"></div>
+              <p className="text-sm text-gray-500">Loading eligibility report...</p>
+            </div>
+          ) : error ? (
+            <div className="bg-red-50 border border-red-200 p-4 rounded-lg text-sm text-red-700">
+              {error}
+            </div>
+          ) : eligibility.length === 0 ? (
+            <div className="bg-white p-8 rounded-lg shadow text-center text-gray-500 text-sm">
+              No discount allowances found for this season.
+            </div>
+          ) : (
+            <div className="bg-white shadow rounded-lg overflow-hidden border border-gray-200">
+              <div className="overflow-x-auto">
+                <table className="min-w-full divide-y divide-gray-200 text-sm">
+                  <thead className="bg-gray-50">
+                    <tr>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Member
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Category
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Status
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Percentage
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Cap
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Used
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Remaining
+                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
+                        Notes
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody className="bg-white divide-y divide-gray-200">
+                    {eligibility.map((row) => (
+                      <tr key={row.allowanceId} className={row.isRevoked ? 'bg-red-50/30' : undefined}>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          <Link
+                            href={`/admin/reports/users/${row.userId}`}
+                            className="font-medium text-blue-600 hover:text-blue-800"
+                          >
+                            {row.userName}
+                          </Link>
+                          <div className="text-xs text-gray-500">
+                            {row.userEmail} {row.memberId ? `• #${row.memberId}` : ''}
+                          </div>
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap font-medium text-gray-900">
+                          {row.categoryName}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap">
+                          {row.source === 'denied' || row.isRevoked ? (
+                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-red-100 text-red-800">
+                              Revoked
+                            </span>
+                          ) : (
+                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">
+                              Active
+                            </span>
+                          )}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-gray-900 font-medium">
+                          {row.discountPercentage}%
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-gray-900">
+                          {row.isRevoked ? (
+                            <span className="text-gray-500">Revoked ($0.00)</span>
+                          ) : row.maxDiscountAmount === null ? (
+                            <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-purple-100 text-purple-800">
+                              No dollar cap
+                            </span>
+                          ) : (
+                            formatAmount(row.maxDiscountAmount)
+                          )}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap text-blue-600 font-medium">
+                          {formatAmount(row.totalUsed)}
+                        </td>
+                        <td className="px-6 py-4 whitespace-nowrap font-medium">
+                          {row.isRevoked ? (
+                            <span className="text-red-600">Not eligible</span>
+                          ) : row.remaining === null ? (
+                            <span className="text-purple-600">Unlimited</span>
+                          ) : (
+                            <span className="text-green-600">{formatAmount(row.remaining)}</span>
+                          )}
+                        </td>
+                        <td className="px-6 py-4 text-xs text-gray-500 max-w-xs truncate">
+                          {row.notes || '-'}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          )}
+
+          <BreadcrumbNav breadcrumbs={breadcrumbs} position="bottom" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/app/admin/reports/users/[id]/DiscountAllowanceSection.tsx
+++ b/src/app/admin/reports/users/[id]/DiscountAllowanceSection.tsx
@@ -46,6 +46,7 @@ export default function DiscountAllowanceSection({
   const [allowances, setAllowances] = useState<Allowance[]>([])
   const [availableOptions, setAvailableOptions] = useState<AvailableOption[]>([])
   const [loading, setLoading] = useState(true)
+  const [loadError, setLoadError] = useState(false)
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   // Modal State
@@ -74,11 +75,16 @@ export default function DiscountAllowanceSection({
       if (res.ok) {
         setAllowances(data.allowances || [])
         setAvailableOptions(data.availableOptions || [])
+        setLoadError(false)
       } else {
         console.error('Error fetching discount allowances:', data.error)
+        setLoadError(true)
+        showError(data.error || 'Failed to load discount allowances')
       }
     } catch (err) {
       console.error('Error fetching discount allowances:', err)
+      setLoadError(true)
+      showError('Failed to load discount allowances')
     } finally {
       setLoading(false)
     }
@@ -248,6 +254,19 @@ export default function DiscountAllowanceSection({
 
         {loading ? (
           <div className="text-sm text-gray-500 py-4">Loading discount allowances...</div>
+        ) : loadError ? (
+          <div className="text-sm text-red-600 py-4 text-center border-2 border-dashed border-red-200 rounded-lg space-y-2">
+            <p>Failed to load discount allowances.</p>
+            <button
+              onClick={() => {
+                setLoading(true)
+                fetchAllowances()
+              }}
+              className="px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-xs font-medium transition-colors"
+            >
+              Retry
+            </button>
+          </div>
         ) : allowances.length === 0 ? (
           <div className="text-sm text-gray-500 py-4 text-center border-2 border-dashed border-gray-200 rounded-lg">
             No active or upcoming discount allowances for this user.

--- a/src/app/admin/reports/users/[id]/DiscountAllowanceSection.tsx
+++ b/src/app/admin/reports/users/[id]/DiscountAllowanceSection.tsx
@@ -1,0 +1,467 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import { useToast } from '@/contexts/ToastContext'
+import { useRouter } from 'next/navigation'
+import { formatAmount } from '@/lib/format-utils'
+import { formatDate } from '@/lib/date-utils'
+
+interface Allowance {
+  id: string
+  userId: string
+  seasonId: string
+  seasonName: string
+  categoryId: string
+  categoryName: string
+  discountPercentage: number
+  maxDiscountAmount: number | null
+  notes: string | null
+  createdBy: string
+  updatedBy: string
+  createdAt: string
+  updatedAt: string
+  totalUsed: number
+  remaining: number | null
+  effectiveMaxAllowed: number | null
+  isEligible: boolean
+  isRevoked: boolean
+}
+
+interface AvailableOption {
+  seasonId: string
+  seasonName: string
+  categoryId: string
+  categoryName: string
+}
+
+interface DiscountAllowanceSectionProps {
+  userId: string
+  userName: string
+}
+
+export default function DiscountAllowanceSection({
+  userId,
+  userName
+}: DiscountAllowanceSectionProps) {
+  const [allowances, setAllowances] = useState<Allowance[]>([])
+  const [availableOptions, setAvailableOptions] = useState<AvailableOption[]>([])
+  const [loading, setLoading] = useState(true)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  // Modal State
+  const [isModalOpen, setIsModalOpen] = useState(false)
+  const [editingAllowance, setEditingAllowance] = useState<Allowance | null>(null)
+
+  // Form State
+  const [selectedOptionIndex, setSelectedOptionIndex] = useState<number>(0)
+  const [percentageInput, setPercentageInput] = useState<string>('')
+  const [isUncapped, setIsUncapped] = useState<boolean>(false)
+  const [dollarsInput, setDollarsInput] = useState<string>('')
+  const [notesInput, setNotesInput] = useState<string>('')
+
+  const { showSuccess, showError } = useToast()
+  const router = useRouter()
+
+  useEffect(() => {
+    fetchAllowances()
+  }, [userId])
+
+  const fetchAllowances = async () => {
+    try {
+      const res = await fetch(`/api/admin/users/${userId}/discount-allowances`)
+      const data = await res.json()
+
+      if (res.ok) {
+        setAllowances(data.allowances || [])
+        setAvailableOptions(data.availableOptions || [])
+      } else {
+        console.error('Error fetching discount allowances:', data.error)
+      }
+    } catch (err) {
+      console.error('Error fetching discount allowances:', err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const openAddModal = () => {
+    setEditingAllowance(null)
+    setSelectedOptionIndex(0)
+    setPercentageInput('50')
+    setIsUncapped(false)
+    setDollarsInput('250.00')
+    setNotesInput('')
+    setIsModalOpen(true)
+  }
+
+  const openEditModal = (allowance: Allowance) => {
+    setEditingAllowance(allowance)
+    setPercentageInput(String(allowance.discountPercentage))
+    if (allowance.maxDiscountAmount === null) {
+      setIsUncapped(true)
+      setDollarsInput('')
+    } else {
+      setIsUncapped(false)
+      setDollarsInput((allowance.maxDiscountAmount / 100).toFixed(2))
+    }
+    setNotesInput(allowance.notes || '')
+    setIsModalOpen(true)
+  }
+
+  const closeModal = () => {
+    setIsModalOpen(false)
+    setEditingAllowance(null)
+  }
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+
+    const pct = parseFloat(percentageInput)
+    if (isNaN(pct) || pct < 1 || pct > 100) {
+      showError('Percentage must be between 1 and 100')
+      return
+    }
+
+    let cents: number | null = null
+    if (!isUncapped) {
+      const dollars = parseFloat(dollarsInput)
+      if (isNaN(dollars) || dollars < 0) {
+        showError('Dollar limit must be a valid non-negative number')
+        return
+      }
+      cents = Math.round(dollars * 100)
+    }
+
+    let seasonId = ''
+    let categoryId = ''
+
+    if (editingAllowance) {
+      seasonId = editingAllowance.seasonId
+      categoryId = editingAllowance.categoryId
+    } else {
+      if (availableOptions.length === 0) {
+        showError('No available season/category combinations to add')
+        return
+      }
+      const option = availableOptions[selectedOptionIndex]
+      seasonId = option.seasonId
+      categoryId = option.categoryId
+    }
+
+    setIsSubmitting(true)
+
+    try {
+      const res = await fetch(`/api/admin/users/${userId}/discount-allowances`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          seasonId,
+          categoryId,
+          discountPercentage: pct,
+          maxDiscountAmount: cents,
+          notes: notesInput.trim() || null
+        })
+      })
+
+      const data = await res.json()
+
+      if (res.ok && data.success) {
+        showSuccess(
+          editingAllowance
+            ? `Updated allowance for ${userName}`
+            : `Added allowance for ${userName}`
+        )
+        closeModal()
+        fetchAllowances()
+        router.refresh()
+      } else {
+        showError(data.error || 'Failed to save discount allowance')
+      }
+    } catch (err) {
+      showError('An unexpected error occurred')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleRevoke = async (allowance: Allowance) => {
+    if (!confirm(`Are you sure you want to revoke the ${allowance.categoryName} allowance for ${allowance.seasonName}?`)) {
+      return
+    }
+
+    setIsSubmitting(true)
+    try {
+      const res = await fetch(`/api/admin/users/${userId}/discount-allowances`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          seasonId: allowance.seasonId,
+          categoryId: allowance.categoryId,
+          discountPercentage: allowance.discountPercentage,
+          maxDiscountAmount: 0, // Revocation sets max_discount_amount = 0
+          notes: allowance.notes
+        })
+      })
+
+      const data = await res.json()
+
+      if (res.ok && data.success) {
+        showSuccess(`Revoked ${allowance.categoryName} allowance for ${userName}`)
+        fetchAllowances()
+        router.refresh()
+      } else {
+        showError(data.error || 'Failed to revoke allowance')
+      }
+    } catch (err) {
+      showError('An unexpected error occurred')
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  return (
+    <div className="bg-white shadow rounded-lg mb-6">
+      <div className="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
+        <div>
+          <h2 className="text-lg font-medium text-gray-900">Per-User Discount Allowances</h2>
+          <p className="mt-1 text-sm text-gray-600">
+            Grant, edit, and revoke custom seasonal discount percentages and caps
+          </p>
+        </div>
+        {availableOptions.length > 0 && (
+          <button
+            onClick={openAddModal}
+            className="px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-xs font-medium transition-colors"
+          >
+            + Add Allowance
+          </button>
+        )}
+      </div>
+
+      <div className="px-6 py-4">
+        {/* Help text callout box */}
+        <div className="mb-4 bg-blue-50 border-l-4 border-blue-400 p-3 rounded text-xs text-blue-800 space-y-1">
+          <p className="font-medium">📌 Important Operational Guidance:</p>
+          <p>1. Allowance rows take effect immediately upon saving.</p>
+          <p>2. Members redeeming legacy fixed-percentage codes (e.g. PRIDE75) are capped by their allowance dollar limit.</p>
+        </div>
+
+        {loading ? (
+          <div className="text-sm text-gray-500 py-4">Loading discount allowances...</div>
+        ) : allowances.length === 0 ? (
+          <div className="text-sm text-gray-500 py-4 text-center border-2 border-dashed border-gray-200 rounded-lg">
+            No active or upcoming discount allowances for this user.
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {allowances.map((allowance) => (
+              <div
+                key={allowance.id}
+                className={`border rounded-lg p-4 transition-colors ${
+                  allowance.isRevoked ? 'bg-red-50/50 border-red-200' : 'bg-gray-50 border-gray-200'
+                }`}
+              >
+                <div className="flex justify-between items-start mb-2">
+                  <div>
+                    <div className="flex items-center space-x-2">
+                      <h4 className="text-sm font-semibold text-gray-900">{allowance.categoryName}</h4>
+                      <span className="text-xs text-gray-500">({allowance.seasonName})</span>
+                    </div>
+                  </div>
+
+                  <div className="flex items-center space-x-2">
+                    {allowance.isRevoked ? (
+                      <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
+                        Revoked
+                      </span>
+                    ) : allowance.maxDiscountAmount === null ? (
+                      <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
+                        No dollar cap
+                      </span>
+                    ) : (
+                      <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                        Active
+                      </span>
+                    )}
+
+                    <button
+                      onClick={() => openEditModal(allowance)}
+                      disabled={isSubmitting}
+                      className="px-2 py-1 bg-gray-200 hover:bg-gray-300 text-gray-700 rounded text-xs font-medium"
+                    >
+                      Edit
+                    </button>
+                    {!allowance.isRevoked && (
+                      <button
+                        onClick={() => handleRevoke(allowance)}
+                        disabled={isSubmitting}
+                        className="px-2 py-1 bg-red-100 hover:bg-red-200 text-red-700 rounded text-xs font-medium"
+                      >
+                        Revoke
+                      </button>
+                    )}
+                  </div>
+                </div>
+
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-xs mt-3 bg-white p-3 rounded border border-gray-100">
+                  <div>
+                    <span className="text-gray-500 block">Percentage</span>
+                    <span className="font-medium text-gray-900">{allowance.discountPercentage}%</span>
+                  </div>
+                  <div>
+                    <span className="text-gray-500 block">Dollar Limit</span>
+                    <span className="font-medium text-gray-900">
+                      {allowance.maxDiscountAmount === null
+                        ? 'No dollar cap'
+                        : allowance.isRevoked
+                        ? 'Revoked ($0.00)'
+                        : formatAmount(allowance.maxDiscountAmount)}
+                    </span>
+                  </div>
+                  <div>
+                    <span className="text-gray-500 block">Total Used</span>
+                    <span className="font-medium text-blue-600">{formatAmount(allowance.totalUsed)}</span>
+                  </div>
+                  <div>
+                    <span className="text-gray-500 block">Remaining</span>
+                    <span className="font-medium text-green-600">
+                      {allowance.isRevoked
+                        ? 'Not eligible'
+                        : allowance.remaining === null
+                        ? 'Unlimited'
+                        : formatAmount(allowance.remaining)}
+                    </span>
+                  </div>
+                </div>
+
+                {allowance.notes && (
+                  <div className="mt-2 text-xs text-gray-600 bg-gray-100 p-2 rounded">
+                    <span className="font-medium text-gray-700">Notes: </span>
+                    {allowance.notes}
+                  </div>
+                )}
+
+                <div className="mt-2 text-[11px] text-gray-400">
+                  Last updated {formatDate(new Date(allowance.updatedAt))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Add / Edit Modal */}
+      {isModalOpen && (
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
+          <div className="bg-white rounded-lg max-w-md w-full p-6 shadow-xl">
+            <h3 className="text-lg font-medium text-gray-900 mb-4">
+              {editingAllowance ? 'Edit Discount Allowance' : 'Add Discount Allowance'}
+            </h3>
+
+            <form onSubmit={handleSubmit} className="space-y-4 text-sm">
+              {editingAllowance ? (
+                <div className="bg-gray-50 p-3 rounded border text-xs">
+                  <p><span className="font-medium">Category:</span> {editingAllowance.categoryName}</p>
+                  <p><span className="font-medium">Season:</span> {editingAllowance.seasonName}</p>
+                </div>
+              ) : (
+                <div>
+                  <label className="block text-xs font-medium text-gray-700 mb-1">
+                    Season & Category
+                  </label>
+                  <select
+                    value={selectedOptionIndex}
+                    onChange={(e) => setSelectedOptionIndex(Number(e.target.value))}
+                    className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  >
+                    {availableOptions.map((opt, idx) => (
+                      <option key={`${opt.seasonId}:${opt.categoryId}`} value={idx}>
+                        {opt.seasonName} — {opt.categoryName}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              )}
+
+              <div>
+                <label className="block text-xs font-medium text-gray-700 mb-1">
+                  Discount Percentage (1–100%) <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="number"
+                  min="1"
+                  max="100"
+                  required
+                  value={percentageInput}
+                  onChange={(e) => setPercentageInput(e.target.value)}
+                  placeholder="e.g. 50"
+                  className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+
+              <div>
+                <div className="flex items-center justify-between mb-1">
+                  <label className="block text-xs font-medium text-gray-700">
+                    Max Seasonal Discount ($)
+                  </label>
+                  <label className="flex items-center space-x-1 text-xs text-purple-700 font-medium">
+                    <input
+                      type="checkbox"
+                      checked={isUncapped}
+                      onChange={(e) => setIsUncapped(e.target.checked)}
+                      className="rounded border-gray-300 text-purple-600 focus:ring-purple-500"
+                    />
+                    <span>No dollar cap</span>
+                  </label>
+                </div>
+
+                {!isUncapped && (
+                  <input
+                    type="number"
+                    step="0.01"
+                    min="0"
+                    required={!isUncapped}
+                    value={dollarsInput}
+                    onChange={(e) => setDollarsInput(e.target.value)}
+                    placeholder="e.g. 250.00"
+                    className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                )}
+              </div>
+
+              <div>
+                <label className="block text-xs font-medium text-gray-700 mb-1">
+                  Notes (survives revocation)
+                </label>
+                <textarea
+                  rows={3}
+                  value={notesInput}
+                  onChange={(e) => setNotesInput(e.target.value)}
+                  placeholder="Reason for aid / approval details..."
+                  className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+
+              <div className="flex justify-end space-x-2 pt-4 border-t border-gray-100">
+                <button
+                  type="button"
+                  onClick={closeModal}
+                  className="px-4 py-2 border border-gray-300 rounded text-sm text-gray-700 hover:bg-gray-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded text-sm font-medium disabled:opacity-50"
+                >
+                  {isSubmitting ? 'Saving...' : 'Save Allowance'}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/admin/reports/users/[id]/page.tsx
+++ b/src/app/admin/reports/users/[id]/page.tsx
@@ -9,6 +9,7 @@ import AdminToggleSection from './AdminToggleSection'
 import DiscountUsage from '@/components/DiscountUsage'
 import RoleBadge from '@/components/RoleBadge'
 import PaymentPlanSection from './PaymentPlanSection'
+import DiscountAllowanceSection from './DiscountAllowanceSection'
 import BreadcrumbNav from '@/components/BreadcrumbNav'
 import { parseBreadcrumbs, buildBreadcrumbUrl } from '@/lib/breadcrumb-utils'
 import { userHasValidPaymentMethod } from '@/lib/payment-method-utils'
@@ -711,6 +712,12 @@ export default async function UserDetailPage({ params, searchParams: searchParam
                 userId={user.id}
                 isAdmin={user.is_admin}
                 isViewingOwnProfile={isViewingOwnProfile}
+                userName={`${user.first_name} ${user.last_name}`}
+              />
+
+              {/* Discount Allowances */}
+              <DiscountAllowanceSection
+                userId={user.id}
                 userName={`${user.first_name} ${user.last_name}`}
               />
 

--- a/src/app/api/admin/discount-categories/[id]/route.ts
+++ b/src/app/api/admin/discount-categories/[id]/route.ts
@@ -76,7 +76,7 @@ export async function PUT(
     }
 
     const body = await request.json()
-    const { name, description, accounting_code, max_discount_per_user_per_season, is_active } = body
+    const { name, description, accounting_code, max_discount_per_user_per_season, is_active, requires_user_allowance } = body
 
     // Validation
     if (!name?.trim()) {
@@ -125,6 +125,7 @@ export async function PUT(
         accounting_code: accounting_code.trim().toUpperCase(),
         max_discount_per_user_per_season: max_discount_per_user_per_season || null,
         is_active: is_active ?? true,
+        ...(requires_user_allowance !== undefined && { requires_user_allowance: Boolean(requires_user_allowance) })
       })
       .eq('id', id)
       .select()

--- a/src/app/api/admin/discount-categories/route.ts
+++ b/src/app/api/admin/discount-categories/route.ts
@@ -68,7 +68,7 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json()
-    const { name, accounting_code, max_discount_per_user_per_season, description } = body
+    const { name, accounting_code, max_discount_per_user_per_season, description, requires_user_allowance } = body
     
     // Validate required fields
     if (!name || !accounting_code) {
@@ -93,7 +93,8 @@ export async function POST(request: NextRequest) {
         name: name.trim(),
         accounting_code: accounting_code.trim().toUpperCase(),
         max_discount_per_user_per_season,
-        description: description?.trim() || null
+        description: description?.trim() || null,
+        requires_user_allowance: Boolean(requires_user_allowance)
       })
       .select()
       .single()

--- a/src/app/api/admin/reports/discount-eligibility/route.ts
+++ b/src/app/api/admin/reports/discount-eligibility/route.ts
@@ -1,0 +1,134 @@
+import { createClient } from '@/lib/supabase/server'
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  resolveEffectiveDiscountLimitsBatch,
+  calculateSeasonalDiscountUsageBatch
+} from '@/lib/services/discount-limit-service'
+
+/**
+ * GET /api/admin/reports/discount-eligibility
+ * Returns per-user discount allowances and eligibility for a season
+ */
+export async function GET(request: NextRequest) {
+  try {
+    const supabase = await createClient()
+
+    // 1. Authenticate & Admin Check
+    const { data: { user: currentUser }, error: authError } = await supabase.auth.getUser()
+    if (authError || !currentUser) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { data: userProfile } = await supabase
+      .from('users')
+      .select('is_admin')
+      .eq('id', currentUser.id)
+      .single()
+
+    if (!userProfile?.is_admin) {
+      return NextResponse.json({ error: 'Forbidden - Admin access required' }, { status: 403 })
+    }
+
+    // 2. Determine target seasonId
+    const { searchParams } = new URL(request.url)
+    let seasonId = searchParams.get('seasonId')
+
+    const nowIso = new Date().toISOString()
+
+    // Fetch all active & upcoming seasons for dropdown
+    const { data: seasons } = await supabase
+      .from('seasons')
+      .select('id, name, start_date, end_date')
+      .order('start_date', { ascending: false })
+
+    if (!seasonId) {
+      // Default to current season (end_date >= now) or most recent
+      const currentSeason = seasons?.find(s => new Date(s.start_date) <= new Date() && new Date(s.end_date) >= new Date())
+        || seasons?.[0]
+      seasonId = currentSeason?.id || null
+    }
+
+    if (!seasonId) {
+      return NextResponse.json({
+        seasons: seasons || [],
+        selectedSeasonId: null,
+        eligibility: []
+      })
+    }
+
+    // 3. Query user_discount_allowances joined with users and categories for season
+    const { data: allowances, error: allowancesError } = await supabase
+      .from('user_discount_allowances')
+      .select(`
+        id,
+        user_id,
+        discount_category_id,
+        season_id,
+        discount_percentage,
+        max_discount_amount,
+        notes,
+        created_at,
+        updated_at,
+        user:users(id, first_name, last_name, email, member_id),
+        category:discount_categories(id, name, requires_user_allowance)
+      `)
+      .eq('season_id', seasonId)
+
+    if (allowancesError) {
+      return NextResponse.json({ error: 'Failed to fetch discount allowances' }, { status: 500 })
+    }
+
+    const allowanceRows = allowances || []
+    const userIds = Array.from(new Set(allowanceRows.map(a => a.user_id)))
+
+    // 4. Batch resolve effective limits & usage
+    const effectiveLimitsMap = await resolveEffectiveDiscountLimitsBatch(supabase, userIds, seasonId)
+    const usageMap = await calculateSeasonalDiscountUsageBatch(supabase, userIds, seasonId)
+
+    // 5. Format report rows (including users with 0 usage)
+    const eligibility = allowanceRows.map(allowance => {
+      const user = Array.isArray(allowance.user) ? allowance.user[0] : allowance.user
+      const category = Array.isArray(allowance.category) ? allowance.category[0] : allowance.category
+      const key = `${allowance.user_id}:${allowance.discount_category_id}`
+
+      const effectiveLimit = effectiveLimitsMap.get(key)
+      const totalUsed = usageMap.get(key) || 0 // Missing map key = 0 usage
+
+      const isRevoked = allowance.max_discount_amount === 0 || effectiveLimit?.isEligible === false
+      const source = isRevoked ? 'denied' : 'user_allowance'
+      const maxAllowed = effectiveLimit?.maxAllowed ?? allowance.max_discount_amount
+      const remaining = !isRevoked && maxAllowed !== null ? Math.max(0, maxAllowed - totalUsed) : (!isRevoked ? null : 0)
+
+      return {
+        allowanceId: allowance.id,
+        userId: allowance.user_id,
+        userName: `${user?.first_name || ''} ${user?.last_name || ''}`.trim() || 'Unknown User',
+        userEmail: user?.email || '',
+        memberId: user?.member_id || null,
+        categoryId: allowance.discount_category_id,
+        categoryName: category?.name || 'Category',
+        discountPercentage: allowance.discount_percentage,
+        maxDiscountAmount: allowance.max_discount_amount,
+        effectiveMaxAllowed: maxAllowed,
+        totalUsed,
+        remaining,
+        isRevoked,
+        source, // 'user_allowance' | 'denied'
+        notes: allowance.notes,
+        updatedAt: allowance.updated_at
+      }
+    })
+
+    // Sort by user name
+    eligibility.sort((a, b) => a.userName.localeCompare(b.userName))
+
+    return NextResponse.json({
+      seasons: seasons || [],
+      selectedSeasonId: seasonId,
+      eligibility
+    })
+  } catch (error) {
+    console.error('Error fetching discount eligibility report:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/reports/discount-usage/route.ts
+++ b/src/app/api/admin/reports/discount-usage/route.ts
@@ -1,5 +1,6 @@
 import { createClient, createAdminClient } from '@/lib/supabase/server'
 import { NextRequest, NextResponse } from 'next/server'
+import { resolveEffectiveDiscountLimitsBatch } from '@/lib/services/discount-limit-service'
 
 export async function GET(request: NextRequest) {
   try {
@@ -172,26 +173,46 @@ export async function GET(request: NextRequest) {
       season.totalAmount += amount
     })
 
-    // Calculate remaining amounts and fully utilized status
-    seasonMap.forEach(season => {
-      season.categories.forEach(category => {
-        category.users.forEach(user => {
-          if (category.maxPerUser !== null) {
-            user.remaining = Math.max(0, category.maxPerUser - user.totalAmount)
-            user.isFullyUtilized = user.totalAmount >= category.maxPerUser
+    // Calculate remaining amounts and fully utilized status using resolveEffectiveDiscountLimitsBatch per user
+    for (const season of Array.from(seasonMap.values())) {
+      const seasonUserIds = Array.from(new Set(
+        season.categories.flatMap(cat => cat.users.map(u => u.userId))
+      ))
+
+      const effectiveLimitsMap = await resolveEffectiveDiscountLimitsBatch(
+        adminSupabase,
+        seasonUserIds,
+        season.seasonId
+      )
+
+      for (const category of season.categories) {
+        for (const user of category.users) {
+          const key = `${user.userId}:${category.categoryId}`
+          const effectiveLimit = effectiveLimitsMap.get(key)
+          const maxAllowed = effectiveLimit?.maxAllowed ?? category.maxPerUser
+
+          if (effectiveLimit?.isEligible === false) {
+            user.remaining = 0
+            user.isFullyUtilized = true
+          } else if (maxAllowed !== null) {
+            user.remaining = Math.max(0, maxAllowed - user.totalAmount)
+            user.isFullyUtilized = user.totalAmount >= maxAllowed
+          } else {
+            user.remaining = null
+            user.isFullyUtilized = false
           }
 
           // Sort discount codes by date (most recent first)
           user.discountCodes.sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
-        })
+        }
 
         // Sort users by total amount (highest first)
         category.users.sort((a, b) => b.totalAmount - a.totalAmount)
-      })
+      }
 
       // Sort categories by total amount (highest first)
       season.categories.sort((a, b) => b.totalAmount - a.totalAmount)
-    })
+    }
 
     // Convert map to array and sort by season (most recent first)
     const seasons = Array.from(seasonMap.values())

--- a/src/app/api/admin/users/[id]/discount-allowances/route.ts
+++ b/src/app/api/admin/users/[id]/discount-allowances/route.ts
@@ -1,0 +1,317 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient, createAdminClient } from '@/lib/supabase/server'
+import { logger } from '@/lib/logging/logger'
+import {
+  resolveEffectiveDiscountLimitsBatch,
+  calculateSeasonalDiscountUsageBatch
+} from '@/lib/services/discount-limit-service'
+
+/**
+ * GET /api/admin/users/[id]/discount-allowances
+ * List user's discount allowances for current and upcoming seasons
+ */
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    const supabase = await createClient()
+
+    // Check if user is admin
+    const { data: { user: currentUser }, error: authError } = await supabase.auth.getUser()
+    if (authError || !currentUser) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { data: adminCheck } = await supabase
+      .from('users')
+      .select('is_admin')
+      .eq('id', currentUser.id)
+      .single()
+
+    if (!adminCheck?.is_admin) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const nowIso = new Date().toISOString()
+
+    // 1. Query active & upcoming seasons (end_date >= now)
+    const { data: activeSeasons, error: seasonsError } = await supabase
+      .from('seasons')
+      .select('id, name, start_date, end_date')
+      .gte('end_date', nowIso)
+      .order('start_date', { ascending: true })
+
+    if (seasonsError) {
+      return NextResponse.json({ error: 'Failed to fetch seasons' }, { status: 500 })
+    }
+
+    const activeSeasonIds = (activeSeasons || []).map(s => s.id)
+
+    // 2. Query user's discount allowances for active/upcoming seasons
+    let rawAllowances: any[] = []
+    if (activeSeasonIds.length > 0) {
+      const { data: allowancesData, error: allowancesError } = await supabase
+        .from('user_discount_allowances')
+        .select(`
+          id,
+          user_id,
+          discount_category_id,
+          season_id,
+          discount_percentage,
+          max_discount_amount,
+          notes,
+          created_by,
+          updated_by,
+          created_at,
+          updated_at,
+          category:discount_categories(id, name, requires_user_allowance),
+          season:seasons(id, name, start_date, end_date)
+        `)
+        .eq('user_id', id)
+        .in('season_id', activeSeasonIds)
+
+      if (allowancesError) {
+        return NextResponse.json({ error: 'Failed to fetch discount allowances' }, { status: 500 })
+      }
+      rawAllowances = allowancesData || []
+    }
+
+    // 3. Batch resolve usage & effective limits for each active season
+    const formattedAllowances = []
+    for (const season of activeSeasons || []) {
+      const seasonAllowances = rawAllowances.filter(a => a.season_id === season.id)
+      if (seasonAllowances.length === 0) continue
+
+      const effectiveLimitsMap = await resolveEffectiveDiscountLimitsBatch(supabase, [id], season.id)
+      const usageMap = await calculateSeasonalDiscountUsageBatch(supabase, [id], season.id)
+
+      for (const allowance of seasonAllowances) {
+        const category = Array.isArray(allowance.category) ? allowance.category[0] : allowance.category
+        const categoryId = allowance.discount_category_id
+        const key = `${id}:${categoryId}`
+
+        const effectiveLimit = effectiveLimitsMap.get(key)
+        const totalUsed = usageMap.get(key) || 0
+
+        const maxAllowed = effectiveLimit?.maxAllowed ?? allowance.max_discount_amount
+        const isEligible = effectiveLimit?.isEligible ?? (allowance.max_discount_amount !== 0)
+        const remaining = (isEligible && maxAllowed !== null) ? Math.max(0, maxAllowed - totalUsed) : (isEligible ? null : 0)
+
+        formattedAllowances.push({
+          id: allowance.id,
+          userId: allowance.user_id,
+          seasonId: allowance.season_id,
+          seasonName: allowance.season?.name || season.name,
+          categoryId: allowance.discount_category_id,
+          categoryName: category?.name || 'Category',
+          discountPercentage: allowance.discount_percentage,
+          maxDiscountAmount: allowance.max_discount_amount,
+          notes: allowance.notes,
+          createdBy: allowance.created_by,
+          updatedBy: allowance.updated_by,
+          createdAt: allowance.created_at,
+          updatedAt: allowance.updated_at,
+          totalUsed,
+          remaining,
+          effectiveMaxAllowed: maxAllowed,
+          isEligible,
+          isRevoked: allowance.max_discount_amount === 0 || !isEligible
+        })
+      }
+    }
+
+    // 4. Query all categories to compute available season/category combinations
+    const { data: allCategories } = await supabase
+      .from('discount_categories')
+      .select('id, name')
+      .order('name', { ascending: true })
+
+    const assignedSet = new Set(rawAllowances.map(a => `${a.season_id}:${a.discount_category_id}`))
+    const availableOptions = []
+
+    for (const season of activeSeasons || []) {
+      for (const category of allCategories || []) {
+        const comboKey = `${season.id}:${category.id}`
+        if (!assignedSet.has(comboKey)) {
+          availableOptions.push({
+            seasonId: season.id,
+            seasonName: season.name,
+            categoryId: category.id,
+            categoryName: category.name
+          })
+        }
+      }
+    }
+
+    return NextResponse.json({
+      allowances: formattedAllowances,
+      availableOptions
+    })
+  } catch (error) {
+    logger.logAdminAction(
+      'get-discount-allowances-error',
+      'Error getting discount allowances',
+      {
+        error: error instanceof Error ? error.message : String(error)
+      },
+      'error'
+    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+/**
+ * PUT /api/admin/users/[id]/discount-allowances
+ * Upsert a user's discount allowance for a season/category combination
+ */
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    const supabase = await createClient()
+    const adminSupabase = createAdminClient()
+
+    // Check if user is admin
+    const { data: { user: currentUser }, error: authError } = await supabase.auth.getUser()
+    if (authError || !currentUser) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { data: adminCheck } = await supabase
+      .from('users')
+      .select('is_admin')
+      .eq('id', currentUser.id)
+      .single()
+
+    if (!adminCheck?.is_admin) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const body = await request.json()
+    const { seasonId, categoryId, discountPercentage, maxDiscountAmount, notes } = body
+
+    if (!seasonId || !categoryId) {
+      return NextResponse.json({ error: 'seasonId and categoryId are required' }, { status: 400 })
+    }
+
+    // 1. Validate percentage: required, 1-100
+    if (
+      discountPercentage === undefined ||
+      discountPercentage === null ||
+      typeof discountPercentage !== 'number' ||
+      isNaN(discountPercentage) ||
+      discountPercentage < 1 ||
+      discountPercentage > 100
+    ) {
+      return NextResponse.json({ error: 'discountPercentage must be a number between 1 and 100' }, { status: 400 })
+    }
+
+    // 2. Validate maxDiscountAmount: null (uncapped) or >= 0 (cents)
+    if (
+      maxDiscountAmount !== null &&
+      maxDiscountAmount !== undefined &&
+      (typeof maxDiscountAmount !== 'number' || isNaN(maxDiscountAmount) || maxDiscountAmount < 0)
+    ) {
+      return NextResponse.json({ error: 'maxDiscountAmount must be null or a non-negative integer in cents' }, { status: 400 })
+    }
+
+    // 3. Validate season scope: end_date >= now
+    const { data: season, error: seasonError } = await supabase
+      .from('seasons')
+      .select('id, name, end_date')
+      .eq('id', seasonId)
+      .single()
+
+    if (seasonError || !season) {
+      return NextResponse.json({ error: 'Season not found' }, { status: 404 })
+    }
+
+    if (new Date(season.end_date) < new Date()) {
+      return NextResponse.json({ error: 'Writes to past seasons are not allowed' }, { status: 400 })
+    }
+
+    // 4. Fetch existing row for admin audit log before value
+    const { data: existingRow } = await supabase
+      .from('user_discount_allowances')
+      .select('*')
+      .eq('user_id', id)
+      .eq('season_id', seasonId)
+      .eq('discount_category_id', categoryId)
+      .maybeSingle()
+
+    const nowIso = new Date().toISOString()
+    const payload = {
+      user_id: id,
+      season_id: seasonId,
+      discount_category_id: categoryId,
+      discount_percentage: discountPercentage,
+      max_discount_amount: maxDiscountAmount ?? null,
+      notes: notes ?? null,
+      created_by: existingRow ? existingRow.created_by : currentUser.id,
+      updated_by: currentUser.id,
+      updated_at: nowIso
+    }
+
+    // 5. Upsert row
+    const { data: updatedAllowance, error: upsertError } = await adminSupabase
+      .from('user_discount_allowances')
+      .upsert(payload, {
+        onConflict: 'user_id,season_id,discount_category_id'
+      })
+      .select(`
+        *,
+        category:discount_categories(id, name),
+        season:seasons(id, name)
+      `)
+      .single()
+
+    if (upsertError) {
+      logger.logAdminAction(
+        'update-discount-allowance-error',
+        'Error upserting discount allowance',
+        {
+          userId: id,
+          seasonId,
+          categoryId,
+          error: upsertError.message
+        },
+        'error'
+      )
+      return NextResponse.json({ error: 'Failed to update discount allowance' }, { status: 500 })
+    }
+
+    // 6. Log admin action with before & after values
+    logger.logAdminAction(
+      'discount-allowance-updated',
+      `Discount allowance ${existingRow ? 'updated' : 'created'} for user`,
+      {
+        targetUserId: id,
+        adminUserId: currentUser.id,
+        seasonId,
+        categoryId,
+        before: existingRow || null,
+        after: updatedAllowance
+      },
+      'info'
+    )
+
+    return NextResponse.json({
+      success: true,
+      allowance: updatedAllowance
+    })
+  } catch (error) {
+    logger.logAdminAction(
+      'update-discount-allowance-exception',
+      'Exception updating discount allowance',
+      {
+        error: error instanceof Error ? error.message : String(error)
+      },
+      'error'
+    )
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/alternate-registrations/[gameId]/alternates/route.ts
+++ b/src/app/api/alternate-registrations/[gameId]/alternates/route.ts
@@ -152,6 +152,7 @@ export async function GET(
       
       // Calculate discount amount and check usage limits using discount-limit-service
       let discountAmount = 0
+      let isIneligible = false
       let isOverLimit = false
       let usageStatus = null
       let category = null
@@ -167,7 +168,8 @@ export async function GET(
 
         if (!isEligible || effectivePercentage === null || isNaN(effectivePercentage)) {
           discountAmount = 0
-          isOverLimit = true
+          isIneligible = true
+          isOverLimit = false
         } else {
           const basePrice = registration.alternate_price || 0
           const requestedDiscountAmount = Math.round((basePrice * effectivePercentage) / 100)
@@ -207,6 +209,7 @@ export async function GET(
           percentage: effectivePercentage,
           discountAmount,
           categoryName: category?.name,
+          isIneligible,
           isOverLimit,
           usageStatus
         } : null,

--- a/src/components/AdminNavigation.tsx
+++ b/src/components/AdminNavigation.tsx
@@ -79,6 +79,7 @@ export default function AdminNavigation({ user }: AdminNavigationProps) {
         { name: 'Membership Reports', href: '/admin/reports/memberships' },
         { name: 'Registration Reports', href: '/admin/reports/registrations' },
         { name: 'Discount Usage', href: '/admin/reports/discount-usage' },
+        { name: 'Discount Eligibility', href: '/admin/reports/discount-eligibility' },
         { name: 'Payment Plans', href: '/admin/reports/payment-plans' },
         { name: 'User Reports', href: '/admin/reports/users' }
       ]

--- a/src/components/AlternateSelectionInterface.tsx
+++ b/src/components/AlternateSelectionInterface.tsx
@@ -20,6 +20,7 @@ interface Alternate {
     discountValue: number
     discountAmount: number
     categoryName: string
+    isIneligible?: boolean
     isOverLimit: boolean
     usageStatus?: {
       currentUsage: number
@@ -322,12 +323,18 @@ export default function AlternateSelectionInterface({
                         
                         {alternate.discountCode && (
                           <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${
-                            alternate.discountCode.isOverLimit 
+                            alternate.discountCode.isIneligible
+                              ? 'bg-red-100 text-red-800'
+                              : alternate.discountCode.isOverLimit 
                               ? 'bg-orange-100 text-orange-800' 
                               : 'bg-purple-100 text-purple-800'
                           }`}>
                             {alternate.discountCode.code}
-                            {alternate.discountCode.isOverLimit && ' ⚠️'}
+                            {alternate.discountCode.isIneligible
+                              ? ' (Ineligible)'
+                              : alternate.discountCode.isOverLimit
+                              ? ' ⚠️'
+                              : ''}
                           </span>
                         )}
                       </div>
@@ -335,6 +342,12 @@ export default function AlternateSelectionInterface({
                       <div className="text-sm text-gray-500">
                         {alternate.email} • Registered {formatDate(alternate.registeredAt)}
                       </div>
+                      
+                      {alternate.discountCode?.isIneligible && (
+                        <div className="text-xs text-red-600 mt-1">
+                          User is ineligible for this discount category.
+                        </div>
+                      )}
                       
                       {alternate.discountCode?.isOverLimit && alternate.discountCode.usageStatus && (
                         <div className="text-xs text-orange-600 mt-1">

--- a/src/components/GameAlternatesCard.tsx
+++ b/src/components/GameAlternatesCard.tsx
@@ -39,6 +39,7 @@ interface Alternate {
     percentage: number
     discountAmount: number
     categoryName?: string
+    isIneligible?: boolean
     isOverLimit: boolean
   } | null
   pricing: {

--- a/src/components/admin/AdminDashboardActions.tsx
+++ b/src/components/admin/AdminDashboardActions.tsx
@@ -49,6 +49,7 @@ const QUICK_ACTIONS: QuickAction[] = [
   { id: 'membership-reports', label: 'Membership Reports', description: 'Analyze membership trends and data', href: '/admin/reports/memberships', group: 'Reports' },
   { id: 'registration-reports', label: 'Registration Reports', description: 'View registration statistics', href: '/admin/reports/registrations', group: 'Reports' },
   { id: 'discount-usage', label: 'Discount Usage', description: 'Track discount code usage', href: '/admin/reports/discount-usage', group: 'Reports' },
+  { id: 'discount-eligibility', label: 'Discount Eligibility', description: 'View per-user discount allowances and eligibility', href: '/admin/reports/discount-eligibility', group: 'Reports' },
   { id: 'payment-plans', label: 'Payment Plans', description: 'Review active payment plans', href: '/admin/reports/payment-plans', group: 'Reports' },
   { id: 'user-reports', label: 'User Reports', description: 'View and manage user accounts and permissions', href: '/admin/reports/users', group: 'Reports' },
 ]

--- a/src/lib/services/discount-limit-service.ts
+++ b/src/lib/services/discount-limit-service.ts
@@ -721,21 +721,12 @@ export async function getSeasonalDiscountUsageSummary(
   seasonId: string
 ): Promise<SeasonalDiscountUsage | null> {
   try {
-    // Get category with seasonal limit
-    const { data: category, error: categoryError } = await supabase
-      .from('discount_categories')
-      .select('max_discount_per_user_per_season')
-      .eq('id', categoryId)
-      .single()
-
-    if (categoryError || !category) {
-      return null
-    }
-
-    const maxAllowed = category.max_discount_per_user_per_season || 0
-    if (maxAllowed <= 0) {
-      return null // No seasonal limit set
-    }
+    const effectiveLimit = await resolveEffectiveDiscountLimits(
+      supabase,
+      userId,
+      categoryId,
+      seasonId
+    )
 
     const totalUsed = await calculateSeasonalDiscountUsage(
       supabase,
@@ -744,6 +735,21 @@ export async function getSeasonalDiscountUsageSummary(
       seasonId
     )
 
+    // 1. Check ineligibility FIRST (e.g. revoked allowance or gated category without allowance)
+    if (!effectiveLimit.isEligible) {
+      return {
+        totalUsed,
+        remaining: 0,
+        maxAllowed: 0
+      }
+    }
+
+    // 2. Check uncapped SECOND (e.g. maxAllowed is null)
+    if (effectiveLimit.maxAllowed === null) {
+      return null // No seasonal cap set / unlimited
+    }
+
+    const maxAllowed = effectiveLimit.maxAllowed
     const remaining = Math.max(0, maxAllowed - totalUsed)
 
     return {


### PR DESCRIPTION
## Summary

Consolidates discount percentage resolution behind a single shared helper. Five call sites each computed a percentage independently, and they disagreed — one correct, four wrong in two different ways.

Unreachable in production today: `PRIDE` is inactive, no category is gated, and `user_discount_allowances` is empty. **It becomes reachable the moment Phase 3 lets an admin save the first allowance row**, which is why this ships before Phase 3 rather than as part of it.

Closes the gap left by Phase 2. The Phase 2 plan listed both payment services under "resolve effective percentage for allowance-driven codes"; the walkthrough reported them done and they were not.

## The rule

The allowance's **dollar cap** applies to every code in the category. The allowance's **percentage** applies only to allowance-driven codes. A member with a 50% / $250 allowance redeeming `PRIDE75` gets 75%, capped at $250 (decision D5).

New shared helper in `discount-limit-service.ts`:

```ts
export function resolveDiscountPercentage(
  discountCode: { percentage?: number | string | null; uses_user_allowance?: boolean | null },
  effectiveLimit?: EffectiveLimit | null
): number | null
```

Returns the resolved allowance percentage when `uses_user_allowance` is true, the code's own percentage otherwise, `null` when unresolvable. Notably it does **not** fall back to the code's percentage for allowance-driven codes — `PRIDE` has none, and that fallback would have quietly reintroduced the bug.

## What was wrong

| Site | Before | After |
|---|---|---|
| `validate-discount-code` | Correct | Uses the shared helper |
| `alternates` GET route | Allowance percentage overrode fixed codes | Uses the shared helper; response carries the effective percentage |
| `AlternatePaymentService` | Never consulted the allowance | Resolves, checks eligibility, uses the helper |
| `WaitlistPaymentService.calculateChargeAmount` | Never consulted the allowance | Same |
| `chargeWaitlistUser` override path | Second inline copy — **found by audit, not in the original scope** | Folded into `calculateChargeAmount` via `basePriceOverride` |

Concretely, without this fix and with allowance rows present:

- **Fixed code** (`PRIDE75`, 50% allowance): the captain's list showed 50%, the charge applied 75%. Display and charge disagreed.
- **Allowance-driven code** (`PRIDE`): the payment services resolved 0% and charged **full price**, while the list showed a discount.

## Also in this PR

- **`chargeWaitlistUser`'s override path called `calculateChargeAmount` and discarded everything but `discountCode`**, redoing the work inline against the override price. That double-queried, emitted warning logs computed against the wrong base price, and left the per-code `usage_limit` check only in the discarded pass. Now one call with `basePriceOverride`.
- **Removed `typeof <importedFunction> === 'function'` guards** from both payment services. These accommodated Jest mocks in production code, and each fallback branch reimplemented the pre-fix percentage logic — including an operator-precedence bug where `??` binds tighter than `?:`, yielding `parseFloat(String(true))`. Test mocks now use `jest.requireActual`.
- **Collapsed duplicated `checkSeasonalDiscountLimit` ternaries** into one call passing `{ effectiveLimit: effectiveLimit ?? undefined }`.
- **`checkSeasonalDiscountLimit` accepts a pre-resolved `effectiveLimit`**, saving a duplicate lookup. It still evaluates `isEligible` and the cap — the option saves a query, it does not bypass a decision.
- **Stripe moved to a `getStripe()` factory** in `WaitlistPaymentService` (was module-level instantiation). Removes an import-time dependency on the env var; constructs a client per charge instead of per process. Outside the stated scope, noted for completeness.
- **Silent $0 outcomes now log.** Payment paths can't show an error, so `*-discount-user-ineligible` and `*-discount-percentage-unresolvable` fire when a discount is dropped. A resolved `0%` is quiet — it's a valid value, not a failure.

**Decision:** an ineligible user on a payment path is charged full price and logged, rather than the transaction failing. This matches what the alternates list already displays before selection, and a data problem in the discount system shouldn't block roster management mid-season.

## Verification

68 tests across 5 suites, all passing.

| Suite | Count |
|---|---|
| `discount-limit-service.test.ts` | 27 |
| `validate-discount-code.test.ts` | 10 |
| `alternate-payment-service.test.ts` | 7 |
| `waitlist-payment-service.test.ts` | 12 (was 8) |
| `cross-path-discount-consistency.test.ts` | 12 |

**New cross-path integration suite** — the assertion this feature had been missing. It imports the real `GET` handler and the real `AlternatePaymentService`, mocks only table responses, and lets each path run its own resolution and arithmetic before comparing final dollar amounts. Non-tautological by construction: it asserts `percentage: 75` for `PRIDE75` despite a 50% allowance, and `50` for `PRIDE` whose column is null. Both fail against the previous code.

**Waitlist override coverage** — asserts the discount is computed against the override price, not the category price: 50% of $80 = $40, not 50% of $100 = $50. Deliberately below the cap, so passing can only mean the override was used as the base. This is the one path in the feature that can't be exercised manually.

Existing assertions in `alternate-payment-service.test.ts` and `waitlist-payment-service.test.ts` are unchanged; waitlist gained four new cases.

## Deployment

No migration, no schema change, no behavior change in production — every path still resolves to `source: 'category_default'` while `user_discount_allowances` is empty.

## Unblocks

Phase 3 (admin API + UI + reporting) can now create allowance rows without the display and charge paths disagreeing.
