### PR TITLE
Discount Eligibility UI

### DIFF
--- a/.agents/rules/build-verification.md
+++ b/.agents/rules/build-verification.md
@@ -1,0 +1,9 @@
+---
+trigger: always_on
+---
+
+Before reporting work complete, run npm run build and paste the raw, unfiltered output — including the final success or error lines. Do not summarize, scope, or filter the result (e.g. "0 errors in modified files"). If the build fails, fix it and re-run; do not report completion with a failing build.
+
+npx tsc --noEmit is a faster subset useful during iteration, but it is not a substitute: npm run build additionally parses pages and components that no test imports, runs lint, and validates server/client boundaries.
+
+The same applies to test runs: paste the actual Jest output, not a description of it.

--- a/src/__tests__/api/admin/discount-eligibility-report.test.ts
+++ b/src/__tests__/api/admin/discount-eligibility-report.test.ts
@@ -3,7 +3,8 @@
  */
 
 jest.mock('@/lib/supabase/server', () => ({
-  createClient: jest.fn()
+  createClient: jest.fn(),
+  createAdminClient: jest.fn()
 }))
 
 jest.mock('@/lib/services/discount-limit-service', () => ({
@@ -12,7 +13,7 @@ jest.mock('@/lib/services/discount-limit-service', () => ({
 }))
 
 import { GET } from '@/app/api/admin/reports/discount-eligibility/route'
-import { createClient } from '@/lib/supabase/server'
+import { createClient, createAdminClient } from '@/lib/supabase/server'
 import {
   resolveEffectiveDiscountLimitsBatch,
   calculateSeasonalDiscountUsageBatch
@@ -36,6 +37,7 @@ describe('/api/admin/reports/discount-eligibility', () => {
     }
 
     ;(createClient as jest.Mock).mockResolvedValue(mockSupabase)
+    ;(createAdminClient as jest.Mock).mockReturnValue(mockSupabase)
   })
 
   it('returns 401 when unauthenticated', async () => {

--- a/src/app/admin/reports/discount-eligibility/page.tsx
+++ b/src/app/admin/reports/discount-eligibility/page.tsx
@@ -83,7 +83,10 @@ export default function DiscountEligibilityReportPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <AdminHeader />
+      <AdminHeader
+        title="Discount Eligibility"
+        description="Per-user discount allowances, limits, and remaining balances by season"
+      />
 
       <div className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
         <div className="px-4 py-6 sm:px-0">

--- a/src/app/admin/reports/discount-eligibility/page.tsx
+++ b/src/app/admin/reports/discount-eligibility/page.tsx
@@ -77,9 +77,8 @@ export default function DiscountEligibilityReportPage() {
   const totalUsedCents = eligibility.reduce((sum, r) => sum + r.totalUsed, 0)
 
   const breadcrumbs = [
-    { label: 'Admin Dashboard', href: '/admin' },
-    { label: 'Reports', href: '/admin/reports' },
-    { label: 'Discount Eligibility', href: '/admin/reports/discount-eligibility' }
+    { label: 'Admin Dashboard', path: '/admin' },
+    { label: 'Discount Eligibility', path: '/admin/reports/discount-eligibility' }
   ]
 
   return (

--- a/src/app/admin/reports/discount-eligibility/page.tsx
+++ b/src/app/admin/reports/discount-eligibility/page.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect } from 'react'
 import Link from 'next/link'
-import AdminHeader from '@/components/AdminHeader'
 import BreadcrumbNav from '@/components/BreadcrumbNav'
 import { formatAmount } from '@/lib/format-utils'
 import { formatDate } from '@/lib/date-utils'
@@ -83,11 +82,6 @@ export default function DiscountEligibilityReportPage() {
 
   return (
     <div className="min-h-screen bg-gray-50">
-      <AdminHeader
-        title="Discount Eligibility"
-        description="Per-user discount allowances, limits, and remaining balances by season"
-      />
-
       <div className="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
         <div className="px-4 py-6 sm:px-0">
           <BreadcrumbNav breadcrumbs={breadcrumbs} position="top" />

--- a/src/app/admin/reports/users/[id]/DiscountAllowanceSection.tsx
+++ b/src/app/admin/reports/users/[id]/DiscountAllowanceSection.tsx
@@ -227,17 +227,15 @@ export default function DiscountAllowanceSection({
 
   return (
     <div className="bg-white shadow rounded-lg mb-6">
-      <div className="px-6 py-4 border-b border-gray-200 flex justify-between items-center">
-        <div>
-          <h2 className="text-lg font-medium text-gray-900">Per-User Discount Allowances</h2>
-          <p className="mt-1 text-sm text-gray-600">
-            Grant, edit, and revoke custom seasonal discount percentages and caps
-          </p>
-        </div>
+      <div className="px-6 py-4 border-b border-gray-200">
+        <h2 className="text-lg font-medium text-gray-900">Per-User Discount Allowances</h2>
+        <p className="mt-1 text-sm text-gray-600">
+          Grant, edit, and revoke custom seasonal discount percentages and caps
+        </p>
         {availableOptions.length > 0 && (
           <button
             onClick={openAddModal}
-            className="px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-xs font-medium transition-colors"
+            className="mt-3 w-full px-3 py-1.5 bg-blue-600 hover:bg-blue-700 text-white rounded-md text-xs font-medium transition-colors whitespace-nowrap"
           >
             + Add Allowance
           </button>
@@ -280,15 +278,11 @@ export default function DiscountAllowanceSection({
                   allowance.isRevoked ? 'bg-red-50/50 border-red-200' : 'bg-gray-50 border-gray-200'
                 }`}
               >
-                <div className="flex justify-between items-start mb-2">
-                  <div>
-                    <div className="flex items-center space-x-2">
-                      <h4 className="text-sm font-semibold text-gray-900">{allowance.categoryName}</h4>
-                      <span className="text-xs text-gray-500">({allowance.seasonName})</span>
-                    </div>
-                  </div>
+                <div className="mb-2">
+                  <h4 className="text-sm font-semibold text-gray-900">{allowance.categoryName}</h4>
+                  <span className="text-xs text-gray-500">{allowance.seasonName}</span>
 
-                  <div className="flex items-center space-x-2">
+                  <div className="flex flex-wrap items-center gap-2 mt-2">
                     {allowance.isRevoked ? (
                       <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
                         Revoked
@@ -322,7 +316,7 @@ export default function DiscountAllowanceSection({
                   </div>
                 </div>
 
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-3 text-xs mt-3 bg-white p-3 rounded border border-gray-100">
+                <div className="grid grid-cols-2 gap-3 text-xs mt-3 bg-white p-3 rounded border border-gray-100">
                   <div>
                     <span className="text-gray-500 block">Percentage</span>
                     <span className="font-medium text-gray-900">{allowance.discountPercentage}%</span>

--- a/src/app/admin/reports/users/[id]/DiscountAllowanceSection.tsx
+++ b/src/app/admin/reports/users/[id]/DiscountAllowanceSection.tsx
@@ -337,7 +337,15 @@ export default function DiscountAllowanceSection({
                   </div>
                   <div>
                     <span className="text-gray-500 block">Remaining</span>
-                    <span className="font-medium text-green-600">
+                    <span
+                      className={`font-medium ${
+                        allowance.isRevoked
+                          ? 'text-red-600'
+                          : allowance.remaining === null
+                          ? 'text-purple-600'
+                          : 'text-green-600'
+                      }`}
+                    >
                       {allowance.isRevoked
                         ? 'Not eligible'
                         : allowance.remaining === null

--- a/src/app/api/admin/reports/discount-eligibility/route.ts
+++ b/src/app/api/admin/reports/discount-eligibility/route.ts
@@ -1,4 +1,4 @@
-import { createClient } from '@/lib/supabase/server'
+import { createClient, createAdminClient } from '@/lib/supabase/server'
 import { NextRequest, NextResponse } from 'next/server'
 import {
   resolveEffectiveDiscountLimitsBatch,
@@ -12,6 +12,7 @@ import {
 export async function GET(request: NextRequest) {
   try {
     const supabase = await createClient()
+    const adminSupabase = createAdminClient()
 
     // 1. Authenticate & Admin Check
     const { data: { user: currentUser }, error: authError } = await supabase.auth.getUser()
@@ -36,7 +37,7 @@ export async function GET(request: NextRequest) {
     const nowIso = new Date().toISOString()
 
     // Fetch all active & upcoming seasons for dropdown
-    const { data: seasons } = await supabase
+    const { data: seasons } = await adminSupabase
       .from('seasons')
       .select('id, name, start_date, end_date')
       .order('start_date', { ascending: false })
@@ -57,7 +58,7 @@ export async function GET(request: NextRequest) {
     }
 
     // 3. Query user_discount_allowances joined with users and categories for season
-    const { data: allowances, error: allowancesError } = await supabase
+    const { data: allowances, error: allowancesError } = await adminSupabase
       .from('user_discount_allowances')
       .select(`
         id,
@@ -69,12 +70,13 @@ export async function GET(request: NextRequest) {
         notes,
         created_at,
         updated_at,
-        user:users(id, first_name, last_name, email, member_id),
+        user:users!user_discount_allowances_user_id_fkey(id, first_name, last_name, email, member_id),
         category:discount_categories(id, name, requires_user_allowance)
       `)
       .eq('season_id', seasonId)
 
     if (allowancesError) {
+      console.error('Error fetching discount allowances:', allowancesError)
       return NextResponse.json({ error: 'Failed to fetch discount allowances' }, { status: 500 })
     }
 
@@ -82,8 +84,8 @@ export async function GET(request: NextRequest) {
     const userIds = Array.from(new Set(allowanceRows.map(a => a.user_id)))
 
     // 4. Batch resolve effective limits & usage
-    const effectiveLimitsMap = await resolveEffectiveDiscountLimitsBatch(supabase, userIds, seasonId)
-    const usageMap = await calculateSeasonalDiscountUsageBatch(supabase, userIds, seasonId)
+    const effectiveLimitsMap = await resolveEffectiveDiscountLimitsBatch(adminSupabase, userIds, seasonId)
+    const usageMap = await calculateSeasonalDiscountUsageBatch(adminSupabase, userIds, seasonId)
 
     // 5. Format report rows (including users with 0 usage)
     const eligibility = allowanceRows.map(allowance => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,9 +23,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
## Summary

Admins can now grant, edit, and revoke per-user discount allowances. This is the phase that makes allowances real — Phases 1 and 2 shipped inert infrastructure; the moment this merges, allowance rows can exist and they take effect immediately.

Completes [Per-User Discount Allowances](docs/features/planning/user-discount-allowances.md). Depends on Phase 2 and the [percentage resolution gap fix](docs/features/planning/discount-allowances-percentage-resolution-gap.md), both merged.

## What's included

**Admin API** — `/api/admin/users/[id]/discount-allowances` (GET/PUT). Admin check with the user client, `createAdminClient()` for data and writes, `logger.logAdminAction` on every mutation, `created_by`/`updated_by` from the acting admin, past-season writes rejected.

**User detail page** — `DiscountAllowanceSection` in the right-hand sidebar of `/admin/reports/users/[id]`. Lists allowances for current and upcoming seasons with percentage, cap, used, remaining, notes, and audit metadata. Add / Edit / Revoke, plus operational help text.

**Category admin** — `requires_user_allowance` checkbox on the create and edit forms, with a warning that enabling it denies every user without an allowance immediately. No UI for `default_percentage`, per D1.

**New Discount Eligibility report** — `/admin/reports/discount-eligibility`, grouped by season, showing member, category, status, percentage, cap, used, remaining, and notes. Registered in `AdminNavigation` and the dashboard action cards.

**Reporting fixes** — `/api/admin/reports/discount-usage` and `getSeasonalDiscountUsageSummary` now resolve limits per user instead of reading the category default. Both would have shown wrong remaining balances as soon as allowance rows existed.

**Alternates list** — `isIneligible` separated from `isOverLimit`, so a captain no longer sees an "over limit" badge on someone who was never eligible.

## Design decisions

- **No state expressed by an empty field.** Percentage is required (1–100). An uncapped allowance is set by an explicit "No dollar cap" toggle writing `NULL`. Revocation writes `0` and keeps the row, so notes and audit history survive. An "inherit the category default" mode was considered and rejected — `default_percentage` is `NULL` on every production category, so inheritance would have inherited nothing.
- **The category's `max_discount_per_user_per_season` is not inherited** as a per-user cap. It isn't per-season, which is the reason the cap moved onto the allowance in the first place.
- **The UI never reimplements resolution.** Displayed effective values come from `resolveEffectiveDiscountLimits`. Every bug in this feature has been two code paths disagreeing about the same question.
- **Eligibility and usage are separate reports.** Usage answers "who spent what" from invoices; eligibility answers "who was granted what" from allowances. A member granted $750 who hasn't registered appears only in the latter — and is exactly who the Phase 4 pre-flight needs to find.
- **Existing allowances plus an "Add allowance" picker**, rather than listing every season × category with empty states. Ten permanently-empty rows would dominate a sidebar where most users have no allowances at all.

## Verification

**Automated** — 80 tests across 9 suites. Both payment-service suites unmodified. New: a report-consistency integration test asserting the usage and eligibility reports agree on limit and remaining, running real resolution against mocked tables with the category default ($750) deliberately differing from the allowance ($250), so a route reading the raw category value fails the test.

**Manual, on dev**
- Revoked member refused at checkout with the neutral "This code isn't available to your account." — the only end-to-end proof that admin state reaches the member-facing path
- Un-revoking restores access
- `$250.00` round-trips correctly through cents
- Uncapped and revoked render as visibly distinct states
- Sidebar layout correct in the narrow right-hand column
- Report reachable by clicking through from the dashboard

**Not verified:** the ineligible vs. over-limit badges on the captain's alternate list — awkward to stage. Display-only; the underlying amounts are covered by the cross-path integration test.

## Fixes found during review

- **Build was failing.** An unbalanced `</div>` in `discount-categories/new/page.tsx` aborted the Turbopack build at the parse stage — which also meant nothing after it was ever typechecked.
- **Eligibility page crashed on load.** `BreadcrumbNav` expects `path`; the page passed `href`, so `next/link` received `undefined` and threw. A type error that the build could not catch (see below).
- **Eligibility API returned 500.** `user_discount_allowances` has three foreign keys to `users` (`user_id`, `created_by`, `updated_by`), so the PostgREST embed was ambiguous. Now disambiguated with the constraint name. The route also used the user client for cross-user data; it now follows the house pattern — user client for the admin check, `createAdminClient()` for the data.
- **Duplicate Admin/Member toggle** — the page used `AdminHeader`, which report pages don't; removed to match `discount-usage`.
- **"Not eligible" rendered green** in the Remaining column. Now red, with purple for "Unlimited" to match the "No dollar cap" badge.

## ⚠️ Note on type checking

`next.config.ts` sets `typescript.ignoreBuildErrors: true`, so `npm run build` reports `Skipping validation of types` and will not catch type errors. The breadcrumb crash above was a plain type error that shipped for exactly this reason.

`npx tsc --noEmit` currently reports **130 pre-existing errors across 32 files** — mostly debug routes (37), test files (30), and generated types. None are in files this PR touches; the one that was (`AdminHeader` missing `title`) is resolved.

Cleaning that backlog and setting `ignoreBuildErrors: false` deserves its own issue. Until then, `tsc --noEmit` is the only type check and the pass criterion is "no new errors in touched files," not a clean run.

## Deployment

No migration — the Phase 2 schema is already live in production. Nothing is gated and `PRIDE` remains inactive, so no member-facing behavior changes on merge.

## What's left

**Phase 4** — three SQL statements: activate `PRIDE`, gate Financial Aid, deactivate `PRIDE25/50/75/100`.

Pre-flight before that runs:
1. Use the new eligibility report to confirm every intended Financial Aid recipient has an allowance row for the season with a resolvable percentage. A gated category with a missing row means a member who had aid last season silently gets none.
2. `join-waitlist/route.ts` and `user-alternate-registrations/route.ts` select `percentage` without `uses_user_allowance`. Harmless today; once `PRIDE` is active they could reject a code whose percentage is `NULL` at signup.
