### PR TITLE
Fixing UI Gaps in UI for discount codes

### DIFF
--- a/docs/features/planning/discount-codes-admin-ui-gaps.md
+++ b/docs/features/planning/discount-codes-admin-ui-gaps.md
@@ -1,0 +1,97 @@
+# Discount Codes Admin UI Doesn't Support Allowance-Driven Codes
+
+**Status:** 🔴 Open
+**Created:** 2026-07-29
+**Severity:** Medium — `PRIDE` is currently uneditable through the UI, and saving it would corrupt it
+**Origin:** Phase 3 scope gap. The spec covered adding `requires_user_allowance` to the discount **categories** admin and never mentioned the discount **codes** admin, so allowance-driven codes have no UI support at all.
+**Related:** [Per-User Discount Allowances](./user-discount-allowances.md)
+
+## Problem 1 — Allowance-driven codes can't be viewed or edited safely
+
+`discount_codes.uses_user_allowance` was added in Phase 2. Codes with this flag carry
+`percentage = NULL` and resolve their percentage from `user_discount_allowances` at redemption
+time. The codes admin knows nothing about it.
+
+Opening `PRIDE` in `/admin/discount-codes/[id]/edit` today:
+
+- **Discount Percentage is empty and required.** The form cannot be submitted without a value, and
+  the submit button stays disabled reading "Complete Form to Update".
+- **Entering a value to satisfy the form writes a real percentage where the design intends `NULL`.**
+  It would be inert — `resolveDiscountPercentage` checks `uses_user_allowance` first and never reads
+  the code's own value — but it is misleading to the next admin, and if anyone later cleared
+  `uses_user_allowance` the code would silently begin applying it.
+- **The preview reads "% off"** with no number.
+- Nothing on the page indicates the code is allowance-driven.
+
+So the page is a trap: it looks broken, and the obvious way to "fix" it corrupts the record.
+
+**Workaround in use:** activate and manage `PRIDE` via direct SQL.
+
+### Required changes
+
+- **Read `uses_user_allowance`** on the edit and new forms.
+- **When true:** replace the percentage input with static explanatory text — e.g. "Percentage is
+  set per user via discount allowances" — disabled rather than hidden, so it is obvious why the
+  field is absent. Skip the required-percentage validation. Never write a percentage for these
+  codes; the column must stay `NULL`.
+- **When false:** unchanged from today.
+- **Preview** should say something like "Per-user allowance" instead of "% off".
+- **Codes list** should show the flag, so `PRIDE` is distinguishable from `PRIDE75` at a glance.
+- **Creating** an allowance-driven code from the UI is optional. The partial unique index allows at
+  most one per category, so if the form offers a `uses_user_allowance` checkbox it must surface that
+  constraint violation as a usable message rather than a raw database error. Deferring creation to
+  SQL is an acceptable v1.
+
+## Problem 2 — Empty context box on the codes admin
+
+The blue box at the top of the discount code edit page renders with blank values:
+
+```
+Category:
+Accounting Code:
+```
+
+Reported as empty for **all** discount codes, not only `PRIDE`, so this is independent of the null
+percentage. The "Back to Category Codes" button also does not navigate anywhere.
+
+The box is worth keeping — category and accounting code are useful context when editing a code —
+so populate it rather than remove it:
+
+- Fetch and display the parent category name and its accounting code
+- Fix the "Back to Category Codes" link target
+- The page header reads "Update discount code for" with a trailing blank; it should name the code
+  or the category
+
+## Not in Scope
+
+- Any change to resolution logic. This is UI only.
+- `discount_categories.default_percentage`. It remains deliberately absent from the UI (Phase 3,
+  decision D1) — nothing reads it, and exposing it would reintroduce the inheritance ambiguity that
+  decision removed.
+- The "This is a REVENUE account" accounting-code warning on the categories page — pre-existing and
+  unrelated.
+
+## Acceptance Criteria
+
+- `PRIDE` opens in the edit form without validation errors and can be saved without writing a
+  percentage
+- After saving `PRIDE` through the UI, `SELECT percentage FROM discount_codes WHERE code = 'PRIDE'`
+  still returns `NULL`
+- Fixed-percentage codes behave exactly as they do today, including required-percentage validation
+- The codes list distinguishes allowance-driven codes
+- The context box shows the real category name and accounting code for every code
+- "Back to Category Codes" navigates to that category's codes
+- `npx tsc --noEmit` reports no new errors in touched files; `npm run build` passes
+
+## Tests
+
+- Editing an allowance-driven code and saving leaves `percentage` `NULL`
+- Editing a fixed-percentage code still requires and persists a percentage
+- The form does not submit a percentage field for allowance-driven codes
+- Context box renders category name and accounting code for a code whose category has both
+
+## Priority
+
+Not blocking the `PRIDE` pilot — activation is a single SQL statement. But it should land before
+anyone else administers discount codes, because opening `PRIDE` in this form and clicking save is
+currently a way to quietly break it.

--- a/src/__tests__/api/admin/discount-codes-allowance-ui.test.ts
+++ b/src/__tests__/api/admin/discount-codes-allowance-ui.test.ts
@@ -1,0 +1,218 @@
+import { PUT } from '@/app/api/admin/discount-codes/[id]/route'
+import { NextRequest } from 'next/server'
+
+// Mock Supabase Server Client
+var mockSupabase: any = {
+  auth: {
+    getUser: jest.fn()
+  },
+  from: jest.fn()
+}
+
+jest.mock('@/lib/supabase/server', () => ({
+  createClient: jest.fn(() => Promise.resolve(mockSupabase))
+}))
+
+describe('/api/admin/discount-codes/[id] PUT Allowance & Context Support', () => {
+  const adminUser = { id: 'admin-1', email: 'admin@example.com' }
+  const normalUser = { id: 'user-1', email: 'user@example.com' }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('returns 401 if unauthenticated', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null }, error: null })
+
+    const req = new NextRequest('http://localhost/api/admin/discount-codes/code-1', {
+      method: 'PUT',
+      body: JSON.stringify({ code: 'PRIDE' })
+    })
+
+    const res = await PUT(req, { params: Promise.resolve({ id: 'code-1' }) })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 if user is not admin', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: normalUser }, error: null })
+    mockSupabase.from.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { is_admin: false }, error: null })
+        })
+      })
+    })
+
+    const req = new NextRequest('http://localhost/api/admin/discount-codes/code-1', {
+      method: 'PUT',
+      body: JSON.stringify({ code: 'PRIDE' })
+    })
+
+    const res = await PUT(req, { params: Promise.resolve({ id: 'code-1' }) })
+    expect(res.status).toBe(403)
+  })
+
+  it('allows updating an allowance-driven code without a percentage and persists percentage: null', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: adminUser }, error: null })
+
+    const updateMock = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: { id: 'code-pride', code: 'PRIDE', percentage: null, uses_user_allowance: true, is_active: false },
+            error: null
+          })
+        })
+      })
+    })
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'users') {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              single: jest.fn().mockResolvedValue({ data: { is_admin: true }, error: null })
+            })
+          })
+        }
+      }
+
+      if (table === 'discount_codes') {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              single: jest.fn().mockResolvedValue({
+                data: { id: 'code-pride', code: 'PRIDE', uses_user_allowance: true },
+                error: null
+              })
+            }),
+            neq: jest.fn().mockResolvedValue({ data: [], error: null })
+          }),
+          update: updateMock
+        }
+      }
+
+      return {}
+    })
+
+    const req = new NextRequest('http://localhost/api/admin/discount-codes/code-pride', {
+      method: 'PUT',
+      body: JSON.stringify({
+        code: 'PRIDE',
+        is_active: false
+      })
+    })
+
+    const res = await PUT(req, { params: Promise.resolve({ id: 'code-pride' }) })
+    expect(res.status).toBe(200)
+
+    const payloadSentToUpdate = updateMock.mock.calls[0][0]
+    expect(payloadSentToUpdate.percentage).toBeNull()
+    expect(payloadSentToUpdate.is_active).toBe(false)
+  })
+
+  it('server enforcement: ignores explicit percentage in body for allowance-driven codes and forces percentage: null', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: adminUser }, error: null })
+
+    const updateMock = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        select: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({
+            data: { id: 'code-pride', code: 'PRIDE', percentage: null, uses_user_allowance: true, is_active: true },
+            error: null
+          })
+        })
+      })
+    })
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'users') {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              single: jest.fn().mockResolvedValue({ data: { is_admin: true }, error: null })
+            })
+          })
+        }
+      }
+
+      if (table === 'discount_codes') {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              single: jest.fn().mockResolvedValue({
+                data: { id: 'code-pride', code: 'PRIDE', uses_user_allowance: true },
+                error: null
+              })
+            }),
+            neq: jest.fn().mockResolvedValue({ data: [], error: null })
+          }),
+          update: updateMock
+        }
+      }
+
+      return {}
+    })
+
+    // Client maliciously/stale-ly sends percentage: 50
+    const req = new NextRequest('http://localhost/api/admin/discount-codes/code-pride', {
+      method: 'PUT',
+      body: JSON.stringify({
+        code: 'PRIDE',
+        percentage: 50,
+        is_active: true
+      })
+    })
+
+    const res = await PUT(req, { params: Promise.resolve({ id: 'code-pride' }) })
+    expect(res.status).toBe(200)
+
+    // Verify API overrode the 50 in body with percentage: null
+    const payloadSentToUpdate = updateMock.mock.calls[0][0]
+    expect(payloadSentToUpdate.percentage).toBeNull()
+  })
+
+  it('enforces percentage validation for standard fixed-percentage codes', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: adminUser }, error: null })
+
+    mockSupabase.from.mockImplementation((table: string) => {
+      if (table === 'users') {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              single: jest.fn().mockResolvedValue({ data: { is_admin: true }, error: null })
+            })
+          })
+        }
+      }
+
+      if (table === 'discount_codes') {
+        return {
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              single: jest.fn().mockResolvedValue({
+                data: { id: 'code-fixed', code: 'PRIDE75', uses_user_allowance: false },
+                error: null
+              })
+            })
+          })
+        }
+      }
+
+      return {}
+    })
+
+    // Send PUT without percentage on fixed code
+    const req = new NextRequest('http://localhost/api/admin/discount-codes/code-fixed', {
+      method: 'PUT',
+      body: JSON.stringify({
+        code: 'PRIDE75'
+      })
+    })
+
+    const res = await PUT(req, { params: Promise.resolve({ id: 'code-fixed' }) })
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.error).toContain('Valid percentage')
+  })
+})

--- a/src/app/admin/discount-codes/[id]/edit/page.tsx
+++ b/src/app/admin/discount-codes/[id]/edit/page.tsx
@@ -109,8 +109,10 @@ export default function EditDiscountCodePage() {
         setError(errorData.error || 'Failed to update discount code')
       } else {
         // Navigate back to codes list, filtered by category if we came from there
-        const returnUrl = code?.discount_categories?.[0]?.id 
-          ? `/admin/discount-codes?category=${code.discount_categories[0].id}`
+        // Navigate back to codes list, filtered by category if we came from there
+        const category = Array.isArray(code?.discount_categories) ? code?.discount_categories[0] : code?.discount_categories
+        const returnUrl = category?.id 
+          ? `/admin/discount-codes?category=${category.id}`
           : '/admin/discount-codes'
         router.push(returnUrl)
       }
@@ -121,15 +123,16 @@ export default function EditDiscountCodePage() {
     }
   }
 
+  const category = Array.isArray(code?.discount_categories) ? code?.discount_categories[0] : code?.discount_categories
+  const isAllowanceDriven = Boolean(code?.uses_user_allowance)
+
   // Check for duplicate code
   const codeExists = existingCodes.some(existingCode => 
     existingCode.code.toLowerCase() === formData.code.trim().toLowerCase()
   )
   
   const canUpdateCode = formData.code.trim() &&
-                       formData.percentage &&
-                       parseFloat(formData.percentage) >= 1 &&
-                       parseFloat(formData.percentage) <= 100 &&
+                       (isAllowanceDriven || (formData.percentage && parseFloat(formData.percentage) >= 1 && parseFloat(formData.percentage) <= 100)) &&
                        !codeExists
 
   if (!code) {
@@ -149,7 +152,7 @@ export default function EditDiscountCodePage() {
           {/* Navigation - Top */}
           <div className="mb-4">
             <Link
-              href={`/admin/discount-codes?category=${code.discount_categories?.[0]?.id}`}
+              href={category?.id ? `/admin/discount-codes?category=${category.id}` : '/admin/discount-codes'}
               className="text-blue-600 hover:text-blue-500 text-sm font-medium"
             >
               ← Back to Category Codes
@@ -160,7 +163,7 @@ export default function EditDiscountCodePage() {
           <div className="mb-8">
             <h1 className="text-3xl font-bold text-gray-900">Edit Discount Code</h1>
             <p className="mt-1 text-sm text-gray-600">
-              Update discount code for {code.discount_categories?.[0]?.name}
+              Update discount code {code.code} for {category?.name || 'category'}
             </p>
           </div>
 
@@ -168,16 +171,16 @@ export default function EditDiscountCodePage() {
           <div className="bg-blue-50 border border-blue-200 rounded-md p-4 mb-6">
             <div className="flex items-center justify-between">
               <div>
-                <h3 className="text-sm font-medium text-blue-800">Category: {code.discount_categories?.[0]?.name}</h3>
+                <h3 className="text-sm font-medium text-blue-800">Category: {category?.name || 'Unassigned'}</h3>
                 <p className="mt-1 text-sm text-blue-700">
-                  Accounting Code: {code.discount_categories?.[0]?.accounting_code}
-                  {code.discount_categories?.[0]?.max_discount_per_user_per_season && (
-                    <span> • Limit: ${(code.discount_categories[0].max_discount_per_user_per_season / 100).toFixed(2)}/season</span>
+                  Accounting Code: {category?.accounting_code || 'None'}
+                  {category?.max_discount_per_user_per_season && (
+                    <span> • Limit: ${(category.max_discount_per_user_per_season / 100).toFixed(2)}/season</span>
                   )}
                 </p>
               </div>
               <Link
-                href={`/admin/discount-codes?category=${code.discount_categories?.[0]?.id}`}
+                href={category?.id ? `/admin/discount-codes?category=${category.id}` : '/admin/discount-codes'}
                 className="inline-flex items-center px-3 py-2 border border-blue-300 text-sm font-medium rounded-md text-blue-700 bg-white hover:bg-blue-50"
               >
                 Back to Category Codes
@@ -218,28 +221,35 @@ export default function EditDiscountCodePage() {
                 <label htmlFor="percentage" className="block text-sm font-medium text-gray-700">
                   Discount Percentage
                 </label>
-                <div className="mt-1 relative rounded-md shadow-sm">
-                  <input
-                    type="number"
-                    id="percentage"
-                    step="0.01"
-                    min="1"
-                    max="100"
-                    value={formData.percentage}
-                    onChange={(e) => setFormData(prev => ({ ...prev, percentage: e.target.value }))}
-                    className="block w-full pr-12 border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-                    placeholder="1.00"
-                    required
-                  />
-                  <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
-                    <span className="text-gray-500 sm:text-sm">%</span>
+                {isAllowanceDriven ? (
+                  <div className="mt-1 bg-indigo-50 border border-indigo-200 text-indigo-800 p-3 rounded-md text-sm font-medium">
+                    Percentage is set per user via discount allowances
                   </div>
-                </div>
-                <p className="mt-1 text-sm text-gray-500">
-                  Percentage discount to apply (1-100%)
-                </p>
+                ) : (
+                  <>
+                    <div className="mt-1 relative rounded-md shadow-sm">
+                      <input
+                        type="number"
+                        id="percentage"
+                        step="0.01"
+                        min="1"
+                        max="100"
+                        value={formData.percentage}
+                        onChange={(e) => setFormData(prev => ({ ...prev, percentage: e.target.value }))}
+                        className="block w-full pr-12 border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
+                        placeholder="1.00"
+                        required
+                      />
+                      <div className="absolute inset-y-0 right-0 pr-3 flex items-center pointer-events-none">
+                        <span className="text-gray-500 sm:text-sm">%</span>
+                      </div>
+                    </div>
+                    <p className="mt-1 text-sm text-gray-500">
+                      Percentage discount to apply (1-100%)
+                    </p>
+                  </>
+                )}
               </div>
-
 
               {/* Is Active */}
               <div className="flex items-center">
@@ -283,11 +293,13 @@ export default function EditDiscountCodePage() {
                     </div>
                     <div>
                       <dt className="text-sm font-medium text-gray-500">Discount</dt>
-                      <dd className="text-sm text-gray-900">{formData.percentage}% off</dd>
+                      <dd className="text-sm text-gray-900 font-medium">
+                        {isAllowanceDriven ? 'Per-user allowance' : `${formData.percentage}% off`}
+                      </dd>
                     </div>
                     <div>
                       <dt className="text-sm font-medium text-gray-500">Category</dt>
-                      <dd className="text-sm text-gray-900">{code.discount_categories?.[0]?.name}</dd>
+                      <dd className="text-sm text-gray-900">{category?.name || '-'}</dd>
                     </div>
                     <div>
                       <dt className="text-sm font-medium text-gray-500">Status</dt>
@@ -300,8 +312,8 @@ export default function EditDiscountCodePage() {
               {/* Submit Buttons */}
               <div className="flex justify-end space-x-3">
                 <Link
-                  href={code?.discount_categories?.[0]?.id 
-                    ? `/admin/discount-codes?category=${code.discount_categories[0].id}`
+                  href={category?.id 
+                    ? `/admin/discount-codes?category=${category.id}`
                     : '/admin/discount-codes'
                   }
                   className="bg-white py-2 px-4 border border-gray-300 rounded-md shadow-sm text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500"
@@ -332,7 +344,7 @@ export default function EditDiscountCodePage() {
           {/* Navigation - Bottom */}
           <div className="mt-6">
             <Link
-              href={`/admin/discount-codes?category=${code.discount_categories?.[0]?.id}`}
+              href={category?.id ? `/admin/discount-codes?category=${category.id}` : '/admin/discount-codes'}
               className="text-blue-600 hover:text-blue-500 text-sm font-medium"
             >
               ← Back to Category Codes

--- a/src/app/admin/discount-codes/[id]/edit/page.tsx
+++ b/src/app/admin/discount-codes/[id]/edit/page.tsx
@@ -80,12 +80,16 @@ export default function EditDiscountCodePage() {
     setError('')
 
     try {
-      const percentage = parseFloat(formData.percentage)
-      
-      if (isNaN(percentage) || percentage <= 0 || percentage > 100) {
-        setError('Please enter a valid percentage between 1 and 100')
-        setLoading(false)
-        return
+      let percentage: number | null = null
+
+      if (!isAllowanceDriven) {
+        percentage = parseFloat(formData.percentage)
+
+        if (isNaN(percentage) || percentage <= 0 || percentage > 100) {
+          setError('Please enter a valid percentage between 1 and 100')
+          setLoading(false)
+          return
+        }
       }
 
       const codeData = {

--- a/src/app/admin/discount-codes/page.tsx
+++ b/src/app/admin/discount-codes/page.tsx
@@ -145,6 +145,8 @@ export default async function DiscountCodesPage({ searchParams: searchParamsProm
                 {codes.map((code: any) => {
                   const isExpired = code.valid_until && new Date(code.valid_until) < new Date()
                   const isNotYetValid = code.valid_from && new Date(code.valid_from) > new Date()
+                  const category = Array.isArray(code.discount_categories) ? code.discount_categories[0] : code.discount_categories
+                  const isAllowanceDriven = Boolean(code.uses_user_allowance)
                   
                   return (
                     <li key={code.id}>
@@ -155,12 +157,20 @@ export default async function DiscountCodesPage({ searchParams: searchParamsProm
                               <p className="text-lg font-medium text-gray-900 font-mono">
                                 {code.code}
                               </p>
-                              <span className="ml-2 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
-                                {code.percentage}% off
-                              </span>
-                              <span className="ml-2 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
-                                {code.discount_categories?.[0]?.name}
-                              </span>
+                              {isAllowanceDriven ? (
+                                <span className="ml-2 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-indigo-100 text-indigo-800">
+                                  Allowance-Driven
+                                </span>
+                              ) : (
+                                <span className="ml-2 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
+                                  {code.percentage}% off
+                                </span>
+                              )}
+                              {category?.name && (
+                                <span className="ml-2 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
+                                  {category.name}
+                                </span>
+                              )}
                               {!code.is_active && (
                                 <span className="ml-2 inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
                                   Inactive
@@ -178,11 +188,11 @@ export default async function DiscountCodesPage({ searchParams: searchParamsProm
                               )}
                             </div>
                             <div className="mt-1 flex items-center text-sm text-gray-500">
-                              <span>Code: {code.discount_categories?.[0]?.accounting_code}</span>
-                              {code.discount_categories?.[0]?.max_discount_per_user_per_season && (
+                              <span>Code: {category?.accounting_code || 'None'}</span>
+                              {category?.max_discount_per_user_per_season && (
                                 <>
                                   <span className="mx-2">•</span>
-                                  <span>Limit: ${(code.discount_categories[0].max_discount_per_user_per_season / 100).toFixed(2)}/season</span>
+                                  <span>Limit: ${(category.max_discount_per_user_per_season / 100).toFixed(2)}/season</span>
                                 </>
                               )}
                               {code.valid_from && (

--- a/src/app/api/admin/discount-codes/[id]/route.ts
+++ b/src/app/api/admin/discount-codes/[id]/route.ts
@@ -88,8 +88,23 @@ export async function PUT(
       return NextResponse.json({ error: 'Code is required' }, { status: 400 })
     }
 
-    if (!percentage || isNaN(parseFloat(percentage)) || parseFloat(percentage) <= 0 || parseFloat(percentage) > 100) {
-      return NextResponse.json({ error: 'Valid percentage between 1-100 is required' }, { status: 400 })
+    // Query target code to check if allowance-driven
+    const { data: targetCode, error: targetError } = await supabase
+      .from('discount_codes')
+      .select('id, code, uses_user_allowance')
+      .eq('id', id)
+      .single()
+
+    if (targetError || !targetCode) {
+      return NextResponse.json({ error: 'Discount code not found' }, { status: 404 })
+    }
+
+    const isAllowanceDriven = Boolean(targetCode.uses_user_allowance)
+
+    if (!isAllowanceDriven) {
+      if (!percentage || isNaN(parseFloat(percentage)) || parseFloat(percentage) <= 0 || parseFloat(percentage) > 100) {
+        return NextResponse.json({ error: 'Valid percentage between 1-100 is required' }, { status: 400 })
+      }
     }
 
     // Validate dates if provided
@@ -121,7 +136,7 @@ export async function PUT(
       .from('discount_codes')
       .update({
         code: code.trim().toUpperCase(),
-        percentage: parseFloat(percentage),
+        percentage: isAllowanceDriven ? null : parseFloat(percentage),
         valid_from: valid_from || null,
         valid_until: valid_until || null,
         is_active: is_active ?? true,


### PR DESCRIPTION
## Summary

Makes allowance-driven discount codes viewable and editable through the admin UI, and fixes the category context box that rendered blank on every discount code page.

Closes a scope gap from Phase 3, which added `requires_user_allowance` controls to the discount **categories** admin but never touched the discount **codes** admin. As a result `PRIDE` — the allowance-driven code created in Phase 2 — could not be edited through the UI at all.

## The problem

`PRIDE` has `uses_user_allowance = true` and `percentage = NULL`; its percentage resolves per user from `user_discount_allowances` at redemption time. The codes admin had no concept of this.

Opening it in the edit form:

- Discount Percentage was empty and required, so the submit button stayed disabled reading "Complete Form to Update"
- Entering a value to satisfy the form would have written a real percentage where the design requires `NULL` — inert today, since `resolveDiscountPercentage` checks `uses_user_allowance` first and never reads the code's own value, but misleading, and live if anyone later cleared the flag
- The preview read "% off" with no number
- Nothing indicated the code was allowance-driven

So the page looked broken, and the obvious way to fix it would have quietly corrupted the record. `PRIDE` was being managed by direct SQL as a workaround.

Separately, the blue context box at the top of the codes admin rendered `Category:` and `Accounting Code:` with no values — on **every** code, not just `PRIDE` — and its "Back to Category Codes" button didn't navigate. Root cause: the joined `discount_categories` relation was read as if it were an array without normalizing the single-object response.

## Changes

**`PUT /api/admin/discount-codes/[id]`** — fetches the target row to read `uses_user_allowance` server-side, then:
- allowance-driven → skips percentage validation and writes `percentage: null`, **explicitly ignoring any percentage in the request body**
- fixed-percentage → unchanged; 1–100 still required

The server is the authority here. The guarantee doesn't depend on the UI hiding a field.

**Edit page** — normalizes the joined category, populates the context box (name, accounting code, working back-link, header naming the code), and for allowance-driven codes replaces the percentage input with disabled explanatory text, drops the percentage requirement from form validation, and shows "Per-user allowance" in the preview.

**List page** — same normalization so category name and accounting code display, plus an "Allowance-Driven" badge replacing the broken `null% off` text.

## Design notes

- **`uses_user_allowance` is the sole signal.** An earlier draft also treated `percentage === null` as equivalent. Rejected: the CHECK constraint already guarantees a null percentage only exists alongside the flag, so a row with `false` *and* `null` is a data problem that should surface, not be silently rendered as allowance-driven with validation skipped.
- **Creating allowance-driven codes from the UI is deliberately out of scope.** The problem was that `PRIDE` couldn't be edited, and `PRIDE` already exists. A creation checkbox would introduce an unguarded footgun — checking it on a category with no `default_percentage` and no allowances produces a code that resolves to nothing for anyone. The partial unique index permits at most one per category, so this is rare enough for SQL. Worth revisiting only if Board Member gets an allowance-driven code.
- **The context box was kept rather than removed.** Category and accounting code are useful when editing a code; it just needed real data.

## Verification

**Automated** — new suite `discount-codes-allowance-ui.test.ts`, 5 tests:
- 401 unauthenticated / 403 non-admin
- allowance-driven code updates without a percentage and persists `NULL`
- **server enforcement:** a request body containing `percentage: 50` on an allowance-driven code is ignored and `NULL` is written
- fixed-percentage codes still enforce 1–100

**Build** — `npm run build` clean, 152 pages.

**Manual**
- `PRIDE` shows the Allowance-Driven badge and correct category info in the list
- Context box populates with Financial Aid and its accounting code; back-link navigates
- Percentage field shows the disabled explanation rather than an empty required input
- Toggling `is_active` saves successfully, and `SELECT percentage FROM discount_codes WHERE code = 'PRIDE'` still returns `NULL`
- A fixed-percentage code (`PRIDE75`) still requires and persists a percentage

## Pre-existing issues noticed, not addressed

- The duplicate-code check in `PUT` fetches every row and filters in JS rather than querying with a filter. Harmless at nine codes.
- `next.config.ts` sets `typescript.ignoreBuildErrors: true`, so `npm run build` reports `Skipping validation of types`. `npx tsc --noEmit` remains the only type check; ~130 pre-existing errors are tracked separately.
