### PR TITLE
Merge PR 185 from Development - Gated Refund Fix

### DIFF
--- a/src/__tests__/api/validate-discount-code.test.ts
+++ b/src/__tests__/api/validate-discount-code.test.ts
@@ -639,6 +639,98 @@ describe('/api/validate-discount-code POST', () => {
     )
   })
 
+  it('should cap retroactive refund application at the customer\'s remaining season limit', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'admin-1' } }, error: null })
+
+    // 1. registrations query
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1', user_id: 'customer-1' }, error: null })
+        })
+      })
+    })
+
+    // 2. discount_codes query (100% allowance code, e.g. would normally discount the full $100 payment)
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: {
+                id: 'code-pride',
+                code: 'PRIDEAID',
+                percentage: null,
+                uses_user_allowance: true,
+                is_active: true,
+                discount_categories: {
+                  id: 'cat-financial-aid',
+                  name: 'Financial Aid',
+                  accounting_code: 'ACC400',
+                  max_discount_per_user_per_season: 2500,
+                  requires_user_allowance: true,
+                  default_percentage: null,
+                  is_active: true
+                }
+              },
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    // 3. xero_invoices returns no invoice (code was never applied at checkout)
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [],
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    // 4. user_discount_allowances query - customer has a 100% allowance, capped at $25 for the season
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({
+              data: [{ discount_percentage: 100, max_discount_amount: 2500 }],
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    // Customer has already used $0 of their $25 cap this season, but the requested $100 discount exceeds it
+    ;(checkSeasonalDiscountLimit as jest.Mock).mockResolvedValue({
+      originalAmount: 10000,
+      finalAmount: 2500,
+      isPartialDiscount: true,
+      isAtLimit: false
+    })
+
+    const request = new NextRequest('http://localhost/api/validate-discount-code', {
+      method: 'POST',
+      body: JSON.stringify({ code: 'PRIDEAID', registrationId: 'reg-1', paymentId: 'pay-missing', amount: 10000, isRefund: true })
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.isValid).toBe(true)
+    expect(data.discountAmount).toBe(2500) // capped at remaining $25, not the full $100 discount
+    expect(data.isPartialDiscount).toBe(true)
+    expect(data.partialDiscountMessage).toBeTruthy()
+  })
+
   it('should resolve percentage from allowance for allowance-driven code and calculate requested amount before cap check', async () => {
     mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-allowance' } }, error: null })
 

--- a/src/__tests__/api/validate-discount-code.test.ts
+++ b/src/__tests__/api/validate-discount-code.test.ts
@@ -475,13 +475,13 @@ describe('/api/validate-discount-code POST', () => {
     expect(data.discountAmount).toBe(3500)
   })
 
-  it('should fail refund for allowance-driven code when no invoice line item is found (no fallback)', async () => {
-    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null })
+  it('should deny retroactive refund application for allowance-driven code when customer has no allowance', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'admin-1' } }, error: null })
 
     mockSupabase.from.mockReturnValueOnce({
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
-          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1' }, error: null })
+          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1', user_id: 'customer-1' }, error: null })
         })
       })
     })
@@ -527,6 +527,8 @@ describe('/api/validate-discount-code POST', () => {
       })
     })
 
+    // user_discount_allowances lookup for the customer returns no row (falls back to beforeEach default: [])
+
     const request = new NextRequest('http://localhost/api/validate-discount-code', {
       method: 'POST',
       body: JSON.stringify({ code: 'PRIDE', registrationId: 'reg-1', paymentId: 'pay-missing', amount: 10000, isRefund: true })
@@ -537,7 +539,104 @@ describe('/api/validate-discount-code POST', () => {
 
     expect(response.status).toBe(200)
     expect(data.isValid).toBe(false)
-    expect(data.error).toBe('Original discount line item not found for refund')
+    expect(data.error).toBe("This code isn't available to this customer's account.")
+  })
+
+  it('should retroactively apply allowance-driven code during refund when customer has an eligible allowance', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'admin-1' } }, error: null })
+
+    // 1. registrations query
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1', user_id: 'customer-1' }, error: null })
+        })
+      })
+    })
+
+    // 2. discount_codes query
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            single: jest.fn().mockResolvedValue({
+              data: {
+                id: 'code-pride',
+                code: 'PRIDE',
+                percentage: null,
+                uses_user_allowance: true,
+                is_active: true,
+                discount_categories: {
+                  id: 'cat-financial-aid',
+                  name: 'Financial Aid',
+                  accounting_code: 'ACC400',
+                  max_discount_per_user_per_season: null,
+                  requires_user_allowance: true,
+                  default_percentage: null,
+                  is_active: true
+                }
+              },
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    // 3. xero_invoices returns no invoice (code was never applied at checkout)
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            in: jest.fn().mockResolvedValue({
+              data: [],
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    // 4. user_discount_allowances query - customer has a 60% allowance
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          eq: jest.fn().mockReturnValue({
+            eq: jest.fn().mockResolvedValue({
+              data: [{ discount_percentage: 60, max_discount_amount: null }],
+              error: null
+            })
+          })
+        })
+      })
+    })
+
+    ;(checkSeasonalDiscountLimit as jest.Mock).mockResolvedValue({
+      originalAmount: 6000,
+      finalAmount: 6000,
+      isPartialDiscount: false,
+      isAtLimit: false
+    })
+
+    const request = new NextRequest('http://localhost/api/validate-discount-code', {
+      method: 'POST',
+      body: JSON.stringify({ code: 'PRIDE', registrationId: 'reg-1', paymentId: 'pay-missing', amount: 10000, isRefund: true })
+    })
+
+    const response = await POST(request)
+    const data = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(data.isValid).toBe(true)
+    expect(data.discountAmount).toBe(6000) // 60% of $100.00 payment
+    expect(checkSeasonalDiscountLimit).toHaveBeenCalledWith(
+      expect.anything(),
+      'customer-1', // eligibility resolved for the registration owner, not the admin
+      'code-pride',
+      'season-1',
+      6000,
+      expect.objectContaining({ isRefund: false })
+    )
   })
 
   it('should resolve percentage from allowance for allowance-driven code and calculate requested amount before cap check', async () => {

--- a/src/app/api/validate-discount-code/route.ts
+++ b/src/app/api/validate-discount-code/route.ts
@@ -41,10 +41,10 @@ export async function POST(request: NextRequest) {
       }, { status: 400 })
     }
 
-    // Get the registration to determine the season
+    // Get the registration to determine the season and owning customer
     const { data: registration, error: regError } = await supabase
       .from('registrations')
-      .select('season_id')
+      .select('season_id, user_id')
       .eq('id', registrationId)
       .single()
 
@@ -184,8 +184,64 @@ export async function POST(request: NextRequest) {
       } else {
         // Split fallback strategy for 0 invoices / 0 line items found
         if (discountCode.uses_user_allowance) {
-          console.error('[validate-discount-code] Original discount line item not found for refund of allowance-driven code:', { code: discountCode.code, paymentId })
-          return NextResponse.json({ isValid: false, error: 'Original discount line item not found for refund' })
+          // The customer never actually applied this gated code at checkout (e.g. they forgot to
+          // enter it). An admin can retroactively apply it during a refund, but only if the
+          // registration's owner actually has an allowance for it - so resolve eligibility against
+          // the customer, not the admin performing the refund.
+          const effectiveLimit = await resolveEffectiveDiscountLimits(
+            supabase,
+            registration.user_id,
+            category.id,
+            registration.season_id,
+            codeWithCategory.category
+          )
+
+          if (!effectiveLimit.isEligible) {
+            console.warn('[validate-discount-code] Refund requested for allowance-driven code the customer is not eligible for:', { code: discountCode.code, paymentId, registrationId })
+            return NextResponse.json({ isValid: false, error: "This code isn't available to this customer's account." })
+          }
+
+          const pct = resolveDiscountPercentage(discountCode, effectiveLimit)
+
+          if (pct == null || isNaN(pct)) {
+            console.error('[validate-discount-code] Percentage unresolvable for retroactive refund application:', { code: discountCode.code, paymentId, registrationId })
+            return NextResponse.json({ isValid: false, error: "This code isn't available to this customer's account." })
+          }
+
+          effectivePct = pct
+          const requestedDiscountAmount = Math.round((amount * pct) / 100)
+
+          const limitResult = await checkSeasonalDiscountLimit(
+            supabase,
+            registration.user_id,
+            discountCode.id,
+            registration.season_id,
+            requestedDiscountAmount,
+            {
+              isRefund: false,
+              discountCode: codeWithCategory,
+              effectiveLimit
+            }
+          )
+
+          const maxAllowed = effectiveLimit.maxAllowed ?? category?.max_discount_per_user_per_season ?? 0
+
+          if (limitResult.isAtLimit) {
+            return NextResponse.json({
+              isValid: false,
+              error: `This customer has already reached their $${(maxAllowed / 100).toFixed(2)} season limit for ${category?.name || ''}. No additional discount can be applied.`
+            })
+          }
+
+          if (limitResult.isPartialDiscount) {
+            discountAmount = limitResult.finalAmount
+            isPartialDiscount = true
+            partialDiscountMessage = `Applied $${(discountAmount / 100).toFixed(2)} discount (${discountCode.code}). Customer has already used part of their $${(maxAllowed / 100).toFixed(2)} season limit for ${category?.name || ''}.`
+          } else {
+            discountAmount = requestedDiscountAmount
+          }
+
+          console.warn('[validate-discount-code] Retroactively applying allowance-driven code during refund (no original line item found):', { code: discountCode.code, paymentId, registrationId, discountAmount })
         } else {
           console.warn('[validate-discount-code] Original discount line item not found for refund of fixed-percentage code; using percentage fallback:', { code: discountCode.code, paymentId })
           const fallbackPct = parseFloat(String(discountCode.percentage)) || 0


### PR DESCRIPTION
* When a customer forgot to apply an allowance-driven (gated) discount code at checkout, refunding them via a discount code previously hard-errored with "Original discount line item not found for refund", since there was no original line item to derive the refund amount from.
* The refund validation now resolves the registration owner's discount allowance directly (not the admin performing the refund), denies the request if the customer isn't actually eligible for the gated code, and otherwise computes the discount amount as if it were being applied for the first time — including enforcing the customer's remaining seasonal cap (partial discount if they're close to their limit, hard block if already at it).