### PR TITLE
Fix production regression: discount code validation broken by invalid registrations query

### DIFF
--- a/src/__tests__/api/validate-discount-code.test.ts
+++ b/src/__tests__/api/validate-discount-code.test.ts
@@ -478,14 +478,16 @@ describe('/api/validate-discount-code POST', () => {
   it('should deny retroactive refund application for allowance-driven code when customer has no allowance', async () => {
     mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'admin-1' } }, error: null })
 
+    // 1. registrations query (no user_id column - registrations is the season/event template)
     mockSupabase.from.mockReturnValueOnce({
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
-          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1', user_id: 'customer-1' }, error: null })
+          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1' }, error: null })
         })
       })
     })
 
+    // 2. discount_codes query
     mockSupabase.from.mockReturnValueOnce({
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
@@ -513,7 +515,7 @@ describe('/api/validate-discount-code POST', () => {
       })
     })
 
-    // xero_invoices returns no invoice
+    // 3. xero_invoices returns no invoice
     mockSupabase.from.mockReturnValueOnce({
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
@@ -527,7 +529,16 @@ describe('/api/validate-discount-code POST', () => {
       })
     })
 
-    // user_discount_allowances lookup for the customer returns no row (falls back to beforeEach default: [])
+    // 4. payments query resolves the paying customer
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { user_id: 'customer-1' }, error: null })
+        })
+      })
+    })
+
+    // 5. user_discount_allowances lookup for the customer returns no row (falls back to beforeEach default: [])
 
     const request = new NextRequest('http://localhost/api/validate-discount-code', {
       method: 'POST',
@@ -545,11 +556,11 @@ describe('/api/validate-discount-code POST', () => {
   it('should retroactively apply allowance-driven code during refund when customer has an eligible allowance', async () => {
     mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'admin-1' } }, error: null })
 
-    // 1. registrations query
+    // 1. registrations query (no user_id column - registrations is the season/event template)
     mockSupabase.from.mockReturnValueOnce({
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
-          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1', user_id: 'customer-1' }, error: null })
+          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1' }, error: null })
         })
       })
     })
@@ -597,7 +608,16 @@ describe('/api/validate-discount-code POST', () => {
       })
     })
 
-    // 4. user_discount_allowances query - customer has a 60% allowance
+    // 4. payments query resolves the paying customer
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { user_id: 'customer-1' }, error: null })
+        })
+      })
+    })
+
+    // 5. user_discount_allowances query - customer has a 60% allowance
     mockSupabase.from.mockReturnValueOnce({
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
@@ -631,7 +651,7 @@ describe('/api/validate-discount-code POST', () => {
     expect(data.discountAmount).toBe(6000) // 60% of $100.00 payment
     expect(checkSeasonalDiscountLimit).toHaveBeenCalledWith(
       expect.anything(),
-      'customer-1', // eligibility resolved for the registration owner, not the admin
+      'customer-1', // eligibility resolved for the paying customer, not the admin
       'code-pride',
       'season-1',
       6000,
@@ -642,11 +662,11 @@ describe('/api/validate-discount-code POST', () => {
   it('should cap retroactive refund application at the customer\'s remaining season limit', async () => {
     mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'admin-1' } }, error: null })
 
-    // 1. registrations query
+    // 1. registrations query (no user_id column - registrations is the season/event template)
     mockSupabase.from.mockReturnValueOnce({
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({
-          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1', user_id: 'customer-1' }, error: null })
+          single: jest.fn().mockResolvedValue({ data: { season_id: 'season-1' }, error: null })
         })
       })
     })
@@ -694,7 +714,16 @@ describe('/api/validate-discount-code POST', () => {
       })
     })
 
-    // 4. user_discount_allowances query - customer has a 100% allowance, capped at $25 for the season
+    // 4. payments query resolves the paying customer
+    mockSupabase.from.mockReturnValueOnce({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { user_id: 'customer-1' }, error: null })
+        })
+      })
+    })
+
+    // 5. user_discount_allowances query - customer has a 100% allowance, capped at $25 for the season
     mockSupabase.from.mockReturnValueOnce({
       select: jest.fn().mockReturnValue({
         eq: jest.fn().mockReturnValue({

--- a/src/app/api/validate-discount-code/route.ts
+++ b/src/app/api/validate-discount-code/route.ts
@@ -41,10 +41,10 @@ export async function POST(request: NextRequest) {
       }, { status: 400 })
     }
 
-    // Get the registration to determine the season and owning customer
+    // Get the registration to determine the season
     const { data: registration, error: regError } = await supabase
       .from('registrations')
-      .select('season_id, user_id')
+      .select('season_id')
       .eq('id', registrationId)
       .single()
 
@@ -186,11 +186,29 @@ export async function POST(request: NextRequest) {
         if (discountCode.uses_user_allowance) {
           // The customer never actually applied this gated code at checkout (e.g. they forgot to
           // enter it). An admin can retroactively apply it during a refund, but only if the
-          // registration's owner actually has an allowance for it - so resolve eligibility against
-          // the customer, not the admin performing the refund.
+          // paying customer actually has an allowance for it - so resolve eligibility against the
+          // customer who made the payment, not the admin performing the refund. The registrations
+          // table has no user_id (it's the season/event template), so look up the customer via the
+          // payment being refunded.
+          if (!paymentId) {
+            console.error('[validate-discount-code] Missing paymentId for allowance-driven refund resolution:', { code: discountCode.code })
+            return NextResponse.json({ isValid: false, error: 'Original discount line item not found for refund' })
+          }
+
+          const { data: payment, error: paymentError } = await supabase
+            .from('payments')
+            .select('user_id')
+            .eq('id', paymentId)
+            .single()
+
+          if (paymentError || !payment) {
+            console.error('[validate-discount-code] Payment not found for allowance-driven refund resolution:', { code: discountCode.code, paymentId, error: paymentError })
+            return NextResponse.json({ isValid: false, error: 'Original discount line item not found for refund' })
+          }
+
           const effectiveLimit = await resolveEffectiveDiscountLimits(
             supabase,
-            registration.user_id,
+            payment.user_id,
             category.id,
             registration.season_id,
             codeWithCategory.category
@@ -213,7 +231,7 @@ export async function POST(request: NextRequest) {
 
           const limitResult = await checkSeasonalDiscountLimit(
             supabase,
-            registration.user_id,
+            payment.user_id,
             discountCode.id,
             registration.season_id,
             requestedDiscountAmount,


### PR DESCRIPTION
## Summary
- PR #185 introduced a regression: it added `user_id` to the `.select('season_id, user_id')` query against the `registrations` table, but `registrations` is the season/event template table and has no `user_id` column (the per-user link lives in `payments`/`user_registrations`). Supabase/PostgREST correctly rejected the malformed select with a 400, which broke **every** call to `/api/validate-discount-code` in production — checkout discount validation included, not just refunds.
- Fixes this by reverting the `registrations` query to its original `season_id`-only select, and instead resolving the paying customer for the gated-refund eligibility check via `payments.user_id`, keyed on the `paymentId` already passed into the refund flow (confirmed admins have RLS read access to all `payments` rows).

## Test plan
- [x] `npx jest src/__tests__/api/validate-discount-code.test.ts` — 12/12 passing
- [x] `npx jest --testPathPattern="discount"` — 66/66 passing across all discount-related suites
- [x] `npx tsc --noEmit` — no new type errors

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01YZVYvVcc19LXnyJZDKsRTw


---
_Generated by [Claude Code](https://claude.ai/code/session_01YZVYvVcc19LXnyJZDKsRTw)_