### PR TITLE
Add deterministic color assignment for dynamic category badges

### DIFF
--- a/src/app/(user)/user/captain/[id]/roster/page.tsx
+++ b/src/app/(user)/user/captain/[id]/roster/page.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect } from 'react'
 import { useParams } from 'next/navigation'
 import Link from 'next/link'
-import { getLgbtqStatusLabel, getLgbtqStatusStyles, getGoalieStatusLabel, getGoalieStatusStyles, getCategoryPillStyles } from '@/lib/user-attributes'
+import { getLgbtqStatusLabel, getLgbtqStatusStyles, getGoalieStatusLabel, getGoalieStatusStyles } from '@/lib/user-attributes'
+import { getCategoryColors } from '@/lib/badge-colors'
 import UserLink from '@/components/UserLink'
 import { formatDate as formatDateUtil, formatTime as formatTimeUtil } from '@/lib/date-utils'
 import FinancialSummary from '@/components/FinancialSummary'
@@ -369,8 +370,8 @@ export default function CaptainRosterPage() {
                     onClick={() => toggleCategoryFilter(name)}
                     className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
                       categoryFilter === name
-                        ? 'bg-indigo-600 text-white border-indigo-600'
-                        : 'bg-indigo-50 text-indigo-800 border-indigo-200 hover:bg-indigo-100'
+                        ? getCategoryColors(name).chipActive
+                        : getCategoryColors(name).chipInactive
                     }`}
                   >
                     {name}
@@ -590,7 +591,7 @@ export default function CaptainRosterPage() {
                         />
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm">
-                        <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getCategoryPillStyles()}`}>
+                        <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getCategoryColors(member.category_name).pill}`}>
                           {member.category_name}
                         </span>
                       </td>
@@ -706,7 +707,7 @@ export default function CaptainRosterPage() {
                           />
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm">
-                          <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getCategoryPillStyles()}`}>
+                          <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getCategoryColors(waitlist.category_name).pill}`}>
                             {waitlist.category_name}
                           </span>
                         </td>

--- a/src/app/admin/reports/registrations/[id]/page.tsx
+++ b/src/app/admin/reports/registrations/[id]/page.tsx
@@ -3,7 +3,8 @@
 import { useState, useEffect } from 'react'
 import { useParams } from 'next/navigation'
 import Link from 'next/link'
-import { getLgbtqStatusLabel, getLgbtqStatusStyles, getGoalieStatusLabel, getGoalieStatusStyles, getCategoryPillStyles } from '@/lib/user-attributes'
+import { getLgbtqStatusLabel, getLgbtqStatusStyles, getGoalieStatusLabel, getGoalieStatusStyles } from '@/lib/user-attributes'
+import { getCategoryColors } from '@/lib/badge-colors'
 import WaitlistSelectionModal from '@/components/WaitlistSelectionModal'
 import EmailComposerModal from '@/components/EmailComposerModal'
 import UserLink from '@/components/UserLink'
@@ -435,8 +436,8 @@ export default function RegistrationDetailPage() {
                     onClick={() => toggleCategoryFilter(name)}
                     className={`inline-flex items-center gap-1 px-3 py-1 rounded-full text-xs font-medium border transition-colors ${
                       categoryFilter === name
-                        ? 'bg-indigo-600 text-white border-indigo-600'
-                        : 'bg-indigo-50 text-indigo-800 border-indigo-200 hover:bg-indigo-100'
+                        ? getCategoryColors(name).chipActive
+                        : getCategoryColors(name).chipInactive
                     }`}
                   >
                     {name}
@@ -656,7 +657,7 @@ export default function RegistrationDetailPage() {
                         />
                       </td>
                       <td className="px-6 py-4 whitespace-nowrap text-sm">
-                        <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getCategoryPillStyles()}`}>
+                        <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getCategoryColors(registration.category_name).pill}`}>
                           {registration.category_name}
                         </span>
                       </td>
@@ -805,7 +806,7 @@ export default function RegistrationDetailPage() {
                           />
                         </td>
                         <td className="px-6 py-4 whitespace-nowrap text-sm">
-                          <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getCategoryPillStyles()}`}>
+                          <span className={`inline-flex items-center px-2 py-0.5 rounded text-xs font-medium ${getCategoryColors(waitlist.category_name).pill}`}>
                             {waitlist.category_name}
                           </span>
                         </td>

--- a/src/components/EmailComposerModal.tsx
+++ b/src/components/EmailComposerModal.tsx
@@ -30,6 +30,15 @@ export default function EmailComposerModal({
   const bodyTrimmed = body.trim()
   const isValid = subjectTrimmed.length > 0 && bodyTrimmed.length > 0
 
+  const handleCopyEmails = async () => {
+    try {
+      await navigator.clipboard.writeText(recipients.map(r => r.email).join(', '))
+      showSuccess(`Copied ${recipients.length} email address${recipients.length !== 1 ? 'es' : ''}`)
+    } catch {
+      showError('Failed to copy emails')
+    }
+  }
+
   const handleSend = async () => {
     if (!isValid || isSending) return
     setIsSending(true)
@@ -68,14 +77,26 @@ export default function EmailComposerModal({
         <div className="px-6 py-4 overflow-y-auto flex-1 space-y-4">
           {/* Recipients */}
           <div>
-            <button
-              type="button"
-              onClick={() => setShowRecipients(v => !v)}
-              className="text-sm text-indigo-600 hover:text-indigo-800 font-medium"
-            >
-              Sending to {recipients.length} player{recipients.length !== 1 ? 's' : ''}{' '}
-              {showRecipients ? '▲' : '▼'}
-            </button>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setShowRecipients(v => !v)}
+                className="text-sm text-indigo-600 hover:text-indigo-800 font-medium"
+              >
+                Sending to {recipients.length} player{recipients.length !== 1 ? 's' : ''}{' '}
+                {showRecipients ? '▲' : '▼'}
+              </button>
+              <button
+                type="button"
+                onClick={handleCopyEmails}
+                title="Copy email addresses"
+                className="text-gray-400 hover:text-gray-600"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" className="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}>
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+                </svg>
+              </button>
+            </div>
             {showRecipients && (
               <ul className="mt-2 text-sm text-gray-700 max-h-32 overflow-y-auto border border-gray-200 rounded p-2 space-y-0.5">
                 {recipients.map(r => (

--- a/src/lib/badge-colors.ts
+++ b/src/lib/badge-colors.ts
@@ -1,0 +1,89 @@
+/**
+ * Deterministic color assignment for arbitrary category names.
+ *
+ * Registrations can define any number of categories (e.g. "Skater", "Goalie",
+ * "Registration", tournament divisions, etc.), so instead of a fixed lookup we
+ * hash the category name into a stable index in a fixed palette. The same name
+ * always resolves to the same color, everywhere it's rendered.
+ */
+
+interface CategoryColorVariant {
+  /** Table-cell badge, e.g. "Skater" pill in a roster row */
+  pill: string
+  /** Selected filter chip */
+  chipActive: string
+  /** Unselected filter chip */
+  chipInactive: string
+}
+
+// Hues deliberately avoid purple (LGBTQ+), blue (Ally), green (Goalie status),
+// and gray (No / No Response), which already carry meaning on these pages.
+const CATEGORY_COLOR_PALETTE: CategoryColorVariant[] = [
+  {
+    pill: 'bg-indigo-100 text-indigo-800',
+    chipActive: 'bg-indigo-600 text-white border-indigo-600',
+    chipInactive: 'bg-indigo-50 text-indigo-800 border-indigo-200 hover:bg-indigo-100',
+  },
+  {
+    pill: 'bg-amber-100 text-amber-800',
+    chipActive: 'bg-amber-600 text-white border-amber-600',
+    chipInactive: 'bg-amber-50 text-amber-800 border-amber-200 hover:bg-amber-100',
+  },
+  {
+    pill: 'bg-rose-100 text-rose-800',
+    chipActive: 'bg-rose-600 text-white border-rose-600',
+    chipInactive: 'bg-rose-50 text-rose-800 border-rose-200 hover:bg-rose-100',
+  },
+  {
+    pill: 'bg-teal-100 text-teal-800',
+    chipActive: 'bg-teal-600 text-white border-teal-600',
+    chipInactive: 'bg-teal-50 text-teal-800 border-teal-200 hover:bg-teal-100',
+  },
+  {
+    pill: 'bg-orange-100 text-orange-800',
+    chipActive: 'bg-orange-600 text-white border-orange-600',
+    chipInactive: 'bg-orange-50 text-orange-800 border-orange-200 hover:bg-orange-100',
+  },
+  {
+    pill: 'bg-cyan-100 text-cyan-800',
+    chipActive: 'bg-cyan-600 text-white border-cyan-600',
+    chipInactive: 'bg-cyan-50 text-cyan-800 border-cyan-200 hover:bg-cyan-100',
+  },
+  {
+    pill: 'bg-fuchsia-100 text-fuchsia-800',
+    chipActive: 'bg-fuchsia-600 text-white border-fuchsia-600',
+    chipInactive: 'bg-fuchsia-50 text-fuchsia-800 border-fuchsia-200 hover:bg-fuchsia-100',
+  },
+  {
+    pill: 'bg-lime-100 text-lime-800',
+    chipActive: 'bg-lime-600 text-white border-lime-600',
+    chipInactive: 'bg-lime-50 text-lime-800 border-lime-200 hover:bg-lime-100',
+  },
+  {
+    pill: 'bg-sky-100 text-sky-800',
+    chipActive: 'bg-sky-600 text-white border-sky-600',
+    chipInactive: 'bg-sky-50 text-sky-800 border-sky-200 hover:bg-sky-100',
+  },
+  {
+    pill: 'bg-pink-100 text-pink-800',
+    chipActive: 'bg-pink-600 text-white border-pink-600',
+    chipInactive: 'bg-pink-50 text-pink-800 border-pink-200 hover:bg-pink-100',
+  },
+]
+
+function hashCategoryName(name: string): number {
+  let hash = 5381
+  for (let i = 0; i < name.length; i++) {
+    hash = (hash * 33) ^ name.charCodeAt(i)
+  }
+  return Math.abs(hash)
+}
+
+/**
+ * Get the color variant set for a category name. The same name always maps
+ * to the same colors, regardless of what other categories exist.
+ */
+export function getCategoryColors(name: string): CategoryColorVariant {
+  const index = hashCategoryName(name) % CATEGORY_COLOR_PALETTE.length
+  return CATEGORY_COLOR_PALETTE[index]
+}

--- a/src/lib/user-attributes.ts
+++ b/src/lib/user-attributes.ts
@@ -33,10 +33,3 @@ export function getGoalieStatusLabel(isGoalie: boolean): string {
 export function getGoalieStatusStyles(isGoalie: boolean): string {
   return isGoalie ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-500'
 }
-
-/**
- * Get CSS classes for category pill styling
- */
-export function getCategoryPillStyles(): string {
-  return 'bg-indigo-100 text-indigo-800'
-}


### PR DESCRIPTION
## Summary
Implement a deterministic color assignment system for dynamic category badges that ensures consistent colors across the application. This replaces the hardcoded indigo styling with a hash-based palette that maps category names to stable color variants.

## Key Changes
- **New module** `src/lib/badge-colors.ts`: Introduces `getCategoryColors()` function that uses a DJB2 hash algorithm to deterministically map category names to colors from a 10-color palette
  - Palette deliberately avoids purple (LGBTQ+), blue (Ally), green (Goalie), and gray (No/No Response) to prevent semantic conflicts
  - Provides three style variants per color: pill (table badges), chipActive (selected filter), and chipInactive (unselected filter)
  
- **Updated roster and registration pages**: Replace hardcoded indigo styling with dynamic color assignment
  - `src/app/(user)/user/captain/[id]/roster/page.tsx`
  - `src/app/admin/reports/registrations/[id]/page.tsx`
  - Both pages now use `getCategoryColors(name)` for category filter chips and member category badges

- **Removed obsolete function**: `getCategoryPillStyles()` from `src/lib/user-attributes.ts` as it's no longer needed

- **Enhanced email composer**: Added copy-to-clipboard button in `src/components/EmailComposerModal.tsx` for quickly copying recipient email addresses

## Implementation Details
- The hash function uses DJB2 algorithm for consistent hashing across JavaScript environments
- Same category name always resolves to the same color index, ensuring consistency across all pages and sessions
- Color palette is intentionally limited to 10 colors to maintain visual distinction while avoiding semantic color meanings already in use

https://claude.ai/code/session_016ykxPb78eAAQ41w6NVqxk4