### PR TITLE
Add registration deletion for unpublished registrations

### DIFF
--- a/src/app/admin/registrations/[id]/page.tsx
+++ b/src/app/admin/registrations/[id]/page.tsx
@@ -15,6 +15,7 @@ import EditableRegistrationMembership from '@/components/EditableRegistrationMem
 import EditableSurveyConfiguration from '@/components/EditableSurveyConfiguration'
 import GamesPreview from '@/components/GamesPreview'
 import CaptainManager from '@/components/CaptainManager'
+import DeleteRegistrationButton from '@/components/DeleteRegistrationButton'
 
 export default async function RegistrationDetailPage({
   params,
@@ -121,6 +122,12 @@ export default async function RegistrationDetailPage({
                     <span className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">
                       Not Published
                     </span>
+                  )}
+                  {!registration.published_at && (
+                    <DeleteRegistrationButton
+                      registrationId={id}
+                      registrationName={registration.name}
+                    />
                   )}
                 </div>
                 <p className="mt-1 text-sm text-gray-600">

--- a/src/app/admin/registrations/[id]/timing/page.tsx
+++ b/src/app/admin/registrations/[id]/timing/page.tsx
@@ -238,6 +238,11 @@ export default function EditRegistrationTimingPage() {
                     : "Registration is in draft mode and hidden from all users."
                   }
                 </p>
+                {!formData.is_active && (
+                  <p className="mt-2 text-sm text-yellow-700">
+                    Once published, this registration can no longer be deleted — only closed by ending its registration window.
+                  </p>
+                )}
               </div>
 
               {/* Info Section */}

--- a/src/app/admin/registrations/page.tsx
+++ b/src/app/admin/registrations/page.tsx
@@ -32,6 +32,7 @@ export default async function RegistrationsPage() {
       name,
       type,
       is_active,
+      published_at,
       allow_discounts,
       presale_code,
       presale_start_at,

--- a/src/app/api/admin/registrations/[id]/route.ts
+++ b/src/app/api/admin/registrations/[id]/route.ts
@@ -1,0 +1,68 @@
+import { createClient } from '@/lib/supabase/server'
+import { NextRequest, NextResponse } from 'next/server'
+
+// DELETE /api/admin/registrations/[id] - Delete a never-published registration
+export async function DELETE(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    const supabase = await createClient()
+
+    const { data: { user } } = await supabase.auth.getUser()
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { data: userProfile } = await supabase
+      .from('users')
+      .select('is_admin')
+      .eq('id', user.id)
+      .single()
+
+    if (!userProfile?.is_admin) {
+      return NextResponse.json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    const { data: registration, error: fetchError } = await supabase
+      .from('registrations')
+      .select('id, published_at')
+      .eq('id', id)
+      .single()
+
+    if (fetchError || !registration) {
+      return NextResponse.json({ error: 'Registration not found' }, { status: 404 })
+    }
+
+    if (registration.published_at) {
+      return NextResponse.json({
+        error: 'Cannot delete a registration that has been published. Close it instead by ending its registration window.'
+      }, { status: 400 })
+    }
+
+    // Clean up access codes, which reference registrations without ON DELETE CASCADE.
+    // Safe to remove outright: published_at is null, so these codes could never have been used.
+    await supabase
+      .from('access_codes')
+      .delete()
+      .eq('registration_id', id)
+
+    const { error: deleteError } = await supabase
+      .from('registrations')
+      .delete()
+      .eq('id', id)
+
+    if (deleteError) {
+      throw deleteError
+    }
+
+    return NextResponse.json({ message: 'Registration deleted successfully' })
+  } catch (error) {
+    console.error('Error deleting registration:', error)
+    return NextResponse.json(
+      { error: 'Failed to delete registration' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/components/DeleteRegistrationButton.tsx
+++ b/src/components/DeleteRegistrationButton.tsx
@@ -1,0 +1,73 @@
+'use client'
+
+import { useState } from 'react'
+import { useRouter } from 'next/navigation'
+import ConfirmationDialog from '@/components/ConfirmationDialog'
+
+interface DeleteRegistrationButtonProps {
+  registrationId: string
+  registrationName: string
+}
+
+export default function DeleteRegistrationButton({
+  registrationId,
+  registrationName
+}: DeleteRegistrationButtonProps) {
+  const router = useRouter()
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleConfirmDelete = async () => {
+    try {
+      setDeleting(true)
+      setError(null)
+
+      const response = await fetch(`/api/admin/registrations/${registrationId}`, {
+        method: 'DELETE'
+      })
+
+      if (!response.ok) {
+        const data = await response.json()
+        throw new Error(data.error || 'Failed to delete registration')
+      }
+
+      router.push('/admin/registrations')
+    } catch (err) {
+      console.error('Error deleting registration:', err)
+      setError(err instanceof Error ? err.message : 'Failed to delete registration')
+      setDeleting(false)
+    }
+  }
+
+  return (
+    <>
+      <button
+        onClick={() => setDialogOpen(true)}
+        className="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium text-red-700 border border-red-300 hover:bg-red-50"
+      >
+        Delete Registration
+      </button>
+
+      <ConfirmationDialog
+        isOpen={dialogOpen}
+        title="Delete Registration"
+        message={
+          <div>
+            <p>Are you sure you want to delete <strong>{registrationName}</strong>?</p>
+            <p className="mt-2 text-sm text-gray-600">This will permanently delete the registration and all its categories. This cannot be undone.</p>
+            {error && (
+              <p className="mt-2 text-sm text-red-600">{error}</p>
+            )}
+          </div>
+        }
+        confirmText="Delete"
+        cancelText="Cancel"
+        onConfirm={handleConfirmDelete}
+        onCancel={() => setDialogOpen(false)}
+        isLoading={deleting}
+        variant="danger"
+      />
+    </>
+  )
+}

--- a/src/components/RegistrationsList.tsx
+++ b/src/components/RegistrationsList.tsx
@@ -5,12 +5,14 @@ import Link from 'next/link'
 import { getRegistrationStatus, getStatusDisplayText, getStatusBadgeStyle } from '@/lib/registration-status'
 import RegistrationTypeBadge from '@/components/RegistrationTypeBadge'
 import { formatEventDateTime } from '@/lib/date-utils'
+import ConfirmationDialog from '@/components/ConfirmationDialog'
 
 interface Registration {
   id: string
   name: string
   type: string
   is_active: boolean
+  published_at?: string | null
   allow_discounts: boolean
   presale_code: string | null
   presale_start_at?: string | null
@@ -82,9 +84,15 @@ function CollapsibleSection({ title, count, children, defaultExpanded = true, ba
   )
 }
 
-function RegistrationItem({ registration }: { registration: Registration }) {
+function RegistrationItem({
+  registration,
+  onDeleteClick
+}: {
+  registration: Registration
+  onDeleteClick: (id: string, name: string) => void
+}) {
   const status = getRegistrationStatus(registration as any)
-  
+
   return (
     <li>
       <div className="px-4 py-4 flex items-center justify-between">
@@ -129,6 +137,14 @@ function RegistrationItem({ registration }: { registration: Registration }) {
           >
             Edit
           </Link>
+          {!registration.published_at && (
+            <button
+              onClick={() => onDeleteClick(registration.id, registration.name)}
+              className="text-red-600 hover:text-red-500 text-sm font-medium"
+            >
+              Delete
+            </button>
+          )}
         </div>
       </div>
     </li>
@@ -136,23 +152,67 @@ function RegistrationItem({ registration }: { registration: Registration }) {
 }
 
 export default function RegistrationsList({ registrations }: RegistrationsListProps) {
+  const [regs, setRegs] = useState(registrations)
+  const [registrationToDelete, setRegistrationToDelete] = useState<{ id: string; name: string } | null>(null)
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+  const [deleteError, setDeleteError] = useState<string | null>(null)
+
   // Group registrations by status
-  const activeRegistrations = registrations.filter(reg => {
+  const activeRegistrations = regs.filter(reg => {
     const status = getRegistrationStatus(reg as any)
     return status === 'open' || status === 'presale'
   })
-  
-  const comingSoonRegistrations = registrations.filter(reg => {
+
+  const comingSoonRegistrations = regs.filter(reg => {
     const status = getRegistrationStatus(reg as any)
     return status === 'coming_soon'
   })
-  
-  const draftRegistrations = registrations.filter(reg => !reg.is_active)
-  
-  const closedRegistrations = registrations.filter(reg => {
+
+  const draftRegistrations = regs.filter(reg => !reg.is_active)
+
+  const closedRegistrations = regs.filter(reg => {
     const status = getRegistrationStatus(reg as any)
     return status === 'expired' || status === 'past'
   })
+
+  const handleDeleteClick = (id: string, name: string) => {
+    setDeleteError(null)
+    setRegistrationToDelete({ id, name })
+    setDeleteDialogOpen(true)
+  }
+
+  const handleCancelDelete = () => {
+    setDeleteDialogOpen(false)
+    setRegistrationToDelete(null)
+  }
+
+  const handleConfirmDelete = async () => {
+    if (!registrationToDelete) return
+
+    try {
+      setDeleting(true)
+      setDeleteError(null)
+
+      const response = await fetch(`/api/admin/registrations/${registrationToDelete.id}`, {
+        method: 'DELETE'
+      })
+
+      if (!response.ok) {
+        const data = await response.json()
+        throw new Error(data.error || 'Failed to delete registration')
+      }
+
+      setRegs(prev => prev.filter(r => r.id !== registrationToDelete.id))
+      setDeleteDialogOpen(false)
+      setRegistrationToDelete(null)
+    } catch (err) {
+      console.error('Error deleting registration:', err)
+      setDeleteError(err instanceof Error ? err.message : 'Failed to delete registration')
+    } finally {
+      setDeleting(false)
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -163,7 +223,7 @@ export default function RegistrationsList({ registrations }: RegistrationsListPr
         defaultExpanded={true}
       >
         {draftRegistrations.map(registration => (
-          <RegistrationItem key={registration.id} registration={registration} />
+          <RegistrationItem key={registration.id} registration={registration} onDeleteClick={handleDeleteClick} />
         ))}
       </CollapsibleSection>
 
@@ -174,7 +234,7 @@ export default function RegistrationsList({ registrations }: RegistrationsListPr
         defaultExpanded={true}
       >
         {activeRegistrations.map(registration => (
-          <RegistrationItem key={registration.id} registration={registration} />
+          <RegistrationItem key={registration.id} registration={registration} onDeleteClick={handleDeleteClick} />
         ))}
       </CollapsibleSection>
 
@@ -185,7 +245,7 @@ export default function RegistrationsList({ registrations }: RegistrationsListPr
         defaultExpanded={true}
       >
         {comingSoonRegistrations.map(registration => (
-          <RegistrationItem key={registration.id} registration={registration} />
+          <RegistrationItem key={registration.id} registration={registration} onDeleteClick={handleDeleteClick} />
         ))}
       </CollapsibleSection>
 
@@ -196,9 +256,29 @@ export default function RegistrationsList({ registrations }: RegistrationsListPr
         defaultExpanded={false}
       >
         {closedRegistrations.map(registration => (
-          <RegistrationItem key={registration.id} registration={registration} />
+          <RegistrationItem key={registration.id} registration={registration} onDeleteClick={handleDeleteClick} />
         ))}
       </CollapsibleSection>
+
+      <ConfirmationDialog
+        isOpen={deleteDialogOpen}
+        title="Delete Registration"
+        message={
+          <div>
+            <p>Are you sure you want to delete <strong>{registrationToDelete?.name}</strong>?</p>
+            <p className="mt-2 text-sm text-gray-600">This will permanently delete the registration and all its categories. This cannot be undone.</p>
+            {deleteError && (
+              <p className="mt-2 text-sm text-red-600">{deleteError}</p>
+            )}
+          </div>
+        }
+        confirmText="Delete"
+        cancelText="Cancel"
+        onConfirm={handleConfirmDelete}
+        onCancel={handleCancelDelete}
+        isLoading={deleting}
+        variant="danger"
+      />
     </div>
   )
 }

--- a/supabase/migrations/2026-08-13-add-published-at-to-registrations.sql
+++ b/supabase/migrations/2026-08-13-add-published-at-to-registrations.sql
@@ -1,0 +1,40 @@
+-- Add published_at to track the first time a registration ever went live.
+-- Unlike is_active (which can be toggled back to false), published_at is set once and
+-- never cleared, so it reliably answers "has this registration ever been published" -
+-- used to permanently gate deletion: once published, a registration can only be closed
+-- (via its registration end date), never deleted, even if later unpublished.
+
+ALTER TABLE registrations
+ADD COLUMN IF NOT EXISTS published_at TIMESTAMP WITH TIME ZONE;
+
+CREATE OR REPLACE FUNCTION set_registration_published_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.is_active = TRUE AND NEW.published_at IS NULL THEN
+        NEW.published_at = NOW();
+    END IF;
+    RETURN NEW;
+END;
+$$ language 'plpgsql';
+
+CREATE TRIGGER set_registrations_published_at
+    BEFORE INSERT OR UPDATE OF is_active ON registrations
+    FOR EACH ROW EXECUTE FUNCTION set_registration_published_at();
+
+-- Backfill: currently-active registrations were published at least by their last update.
+UPDATE registrations SET published_at = updated_at WHERE is_active = TRUE AND published_at IS NULL;
+
+-- Backfill safety net: a registration that is a draft today but already has real
+-- registrant/waitlist/discount activity must have been published at some point in the
+-- past (that activity is only possible while live), even though it looks like a fresh
+-- draft now. Protect it too, so pre-existing data isn't retroactively made deletable.
+UPDATE registrations SET published_at = COALESCE(updated_at, created_at)
+WHERE published_at IS NULL
+  AND is_active = FALSE
+  AND (
+    EXISTS (SELECT 1 FROM user_registrations WHERE registration_id = registrations.id)
+    OR EXISTS (SELECT 1 FROM waitlists WHERE registration_id = registrations.id)
+    OR EXISTS (SELECT 1 FROM discount_usage WHERE registration_id = registrations.id)
+  );
+
+COMMENT ON COLUMN registrations.published_at IS 'When this registration first went live (is_active set to true). Never cleared once set. NULL means it has never been published and is still safely deletable.';


### PR DESCRIPTION
## Summary
This PR adds the ability to delete registrations that have never been published, while preventing deletion of any registration that has ever gone live. A new `published_at` timestamp column tracks when a registration first becomes active, providing a permanent record of publication status.

## Key Changes

- **Database Migration**: Added `published_at` column to `registrations` table with automatic trigger to set the timestamp when `is_active` transitions to true. Includes backfill logic for existing active registrations and those with historical activity.

- **API Endpoint**: Created `DELETE /api/admin/registrations/[id]` endpoint that:
  - Validates user is admin
  - Prevents deletion of published registrations (returns 400 error)
  - Cleans up related `access_codes` before deletion
  - Properly handles cascade deletion constraints

- **UI Components**:
  - Added delete button to `RegistrationItem` in the registrations list (only visible for unpublished registrations)
  - Created new `DeleteRegistrationButton` component for the registration detail page
  - Integrated `ConfirmationDialog` for both delete flows with clear warning about permanent deletion

- **State Management**: Updated `RegistrationsList` to manage local state for registrations, allowing optimistic UI updates after deletion without page reload

- **User Guidance**: Added warning message on timing page explaining that once published, registrations can only be closed, not deleted

## Implementation Details

- The `published_at` field is set once and never cleared, providing a reliable indicator of whether a registration has ever been published
- Deletion is only allowed for registrations where `published_at IS NULL`
- The migration includes safety nets to backfill `published_at` for registrations with existing user activity, preventing accidental deletion of registrations with historical data
- Error handling includes user-friendly messages for both API and UI layers

https://claude.ai/code/session_01BA15YtoMuXdVYLCGXQzdEq