### PR TITLE
Fix missing donation offset on fully-assisted membership invoices

### DIFF
--- a/src/__tests__/lib/membership-validation.test.ts
+++ b/src/__tests__/lib/membership-validation.test.ts
@@ -5,6 +5,7 @@
 import {
   validateMembershipCoverage,
   formatMembershipWarning,
+  validateAssistanceAmount,
   UserMembership,
   Season,
 } from '@/lib/membership-validation'
@@ -250,6 +251,56 @@ describe('Membership Validation Functions', () => {
       expect(result).toContain('1 month')
       expect(result).not.toContain('days')
       expect(result).not.toContain('months')
+    })
+  })
+
+  describe('validateAssistanceAmount', () => {
+    const priceCents = 3000 // $30.00
+
+    it('rejects a blank amount', () => {
+      expect(validateAssistanceAmount('', priceCents)).not.toBeNull()
+    })
+
+    it('rejects a whitespace-only amount', () => {
+      expect(validateAssistanceAmount('   ', priceCents)).not.toBeNull()
+    })
+
+    it('rejects a bare "-"', () => {
+      expect(validateAssistanceAmount('-', priceCents)).not.toBeNull()
+    })
+
+    it('rejects a bare "+"', () => {
+      expect(validateAssistanceAmount('+', priceCents)).not.toBeNull()
+    })
+
+    it('rejects non-numeric text', () => {
+      expect(validateAssistanceAmount('abc', priceCents)).not.toBeNull()
+    })
+
+    it('rejects a negative amount', () => {
+      expect(validateAssistanceAmount('-5', priceCents)).not.toBeNull()
+    })
+
+    it('rejects an amount over the membership price', () => {
+      expect(validateAssistanceAmount('31', priceCents)).not.toBeNull()
+    })
+
+    it('accepts an explicit $0', () => {
+      expect(validateAssistanceAmount('0', priceCents)).toBeNull()
+    })
+
+    it('accepts a mid-range amount', () => {
+      expect(validateAssistanceAmount('15', priceCents)).toBeNull()
+    })
+
+    it('accepts an amount exactly equal to the membership price', () => {
+      expect(validateAssistanceAmount('30', priceCents)).toBeNull()
+    })
+
+    it('includes the dollar bounds in the error message', () => {
+      const error = validateAssistanceAmount('', priceCents)
+      expect(error).toContain('$0')
+      expect(error).toContain('$30.00')
     })
   })
 })

--- a/src/app/api/create-membership-payment-intent/route.ts
+++ b/src/app/api/create-membership-payment-intent/route.ts
@@ -20,6 +20,7 @@ async function handleFreeMembership({
   membership,
   membershipId,
   durationMonths,
+  paymentOption,
   assistanceAmount,
   paymentContext,
   startTime,
@@ -32,6 +33,7 @@ async function handleFreeMembership({
   membership: any
   membershipId: string
   durationMonths: number
+  paymentOption?: string
   assistanceAmount?: number
   paymentContext: any
   startTime: number
@@ -83,9 +85,20 @@ async function handleFreeMembership({
     )
 
     const membershipAmount = durationMonths === 12 ? membership.price_annual : membership.price_monthly * durationMonths
-    
 
-    
+    // Boundary validation: an "assistance" purchase must send a valid assistance
+    // amount that reconciles with the membership price (amountToCharge is 0 here)
+    if (paymentOption === 'assistance') {
+      if (typeof assistanceAmount !== 'number' || !Number.isFinite(assistanceAmount)) {
+        capturePaymentError(new Error('Invalid assistance amount for free membership'), paymentContext, 'warning')
+        return NextResponse.json({ error: 'Invalid assistance amount' }, { status: 400 })
+      }
+      if (Math.round(assistanceAmount) !== Math.round(membershipAmount)) {
+        capturePaymentError(new Error('Assistance amount does not reconcile with membership price'), paymentContext, 'warning')
+        return NextResponse.json({ error: 'Assistance amount does not match membership price' }, { status: 400 })
+      }
+    }
+
     // Get accounting codes from system_accounting_codes (only needed if applying discount)
     const { data: accountingCodes } = await supabase
       .from('system_accounting_codes')
@@ -437,6 +450,7 @@ export async function POST(request: NextRequest) {
         membership: null, // Will fetch in function
         membershipId,
         durationMonths,
+        paymentOption,
         assistanceAmount,
         paymentContext,
         startTime,
@@ -484,8 +498,20 @@ export async function POST(request: NextRequest) {
     }
 
     const membershipAmount = getMembershipAmount()
-    
-    
+
+    // Boundary validation: an "assistance" purchase must send a valid assistance
+    // amount that reconciles with the membership price and the charged amount
+    if (paymentOption === 'assistance') {
+      if (typeof assistanceAmount !== 'number' || !Number.isFinite(assistanceAmount)) {
+        capturePaymentError(new Error('Invalid assistance amount for paid membership'), paymentContext, 'warning')
+        return NextResponse.json({ error: 'Invalid assistance amount' }, { status: 400 })
+      }
+      if (Math.round(amountToCharge + assistanceAmount) !== Math.round(membershipAmount)) {
+        capturePaymentError(new Error('Assistance amount does not reconcile with membership price'), paymentContext, 'warning')
+        return NextResponse.json({ error: 'Assistance amount does not match membership price' }, { status: 400 })
+      }
+    }
+
     // Get accounting codes from system_accounting_codes
     const { data: accountingCodes, error: accountingError } = await supabase
       .from('system_accounting_codes')

--- a/src/components/MembershipPurchase.tsx
+++ b/src/components/MembershipPurchase.tsx
@@ -124,6 +124,19 @@ export default function MembershipPurchase({ membership, userEmail, userMembersh
   }
   
   const finalAmount = getFinalPaymentAmount()
+
+  // Validate the "how much can you pay" field for the assistance option.
+  // Returns an error message when the field is blank, non-numeric, negative,
+  // or exceeds the membership price; null when it's a valid amount.
+  const getAssistanceValidationError = (): string | null => {
+    if (paymentOption !== 'assistance') return null
+    const trimmed = requestedPurchaseAmount.trim()
+    const parsed = parseFloat(trimmed)
+    if (trimmed === '' || isNaN(parsed) || parsed < 0 || parsed * 100 > selectedPrice) {
+      return `Please enter a valid amount between $0 and $${(selectedPrice / 100).toFixed(2)}`
+    }
+    return null
+  }
   
   // Set default assistance amount when duration changes
   React.useEffect(() => {
@@ -163,13 +176,10 @@ export default function MembershipPurchase({ membership, userEmail, userMembersh
       return
     }
 
-    if (paymentOption === 'assistance') {
-      const trimmed = requestedPurchaseAmount.trim()
-      const parsed = parseFloat(trimmed)
-      if (trimmed === '' || isNaN(parsed) || parsed < 0 || parsed * 100 > selectedPrice) {
-        setError(`Please enter a valid amount between $0 and $${(selectedPrice / 100).toFixed(2)}`)
-        return
-      }
+    const assistanceError = getAssistanceValidationError()
+    if (assistanceError) {
+      setError(assistanceError)
+      return
     }
 
     setIsLoading(true)
@@ -302,13 +312,10 @@ export default function MembershipPurchase({ membership, userEmail, userMembersh
   const handleUseDifferentMethod = async () => {
     if (!selectedDuration || !paymentOption) return
 
-    if (paymentOption === 'assistance') {
-      const trimmed = requestedPurchaseAmount.trim()
-      const parsed = parseFloat(trimmed)
-      if (trimmed === '' || isNaN(parsed) || parsed < 0 || parsed * 100 > selectedPrice) {
-        setError(`Please enter a valid amount between $0 and $${(selectedPrice / 100).toFixed(2)}`)
-        return
-      }
+    const assistanceError = getAssistanceValidationError()
+    if (assistanceError) {
+      setError(assistanceError)
+      return
     }
 
     setShowConfirmationScreen(false)
@@ -646,24 +653,32 @@ export default function MembershipPurchase({ membership, userEmail, userMembersh
                     <span className="text-gray-900">${(selectedPrice / 100).toFixed(2)}</span>
                   </div>
                   
-                  {paymentOption === 'assistance' && (
+                  {paymentOption === 'assistance' && getAssistanceValidationError() && (
+                    <div className="text-orange-600 text-sm mt-1">
+                      Enter a valid amount above to see your total
+                    </div>
+                  )}
+
+                  {paymentOption === 'assistance' && !getAssistanceValidationError() && (
                     <div className="flex justify-between text-orange-600">
                       <span>Assistance Discount:</span>
                       <span>-${((selectedPrice - finalAmount) / 100).toFixed(2)}</span>
                     </div>
                   )}
-                  
+
                   {paymentOption === 'donation' && (
                     <div className="flex justify-between text-blue-600">
                       <span>Additional Donation:</span>
                       <span>+${((finalAmount - selectedPrice) / 100).toFixed(2)}</span>
                     </div>
                   )}
-                  
-                  <div className="flex justify-between font-medium text-lg mt-2 pt-2 border-t">
-                    <span className="text-gray-900">Total:</span>
-                    <span className="text-gray-900">${(finalAmount / 100).toFixed(2)}</span>
-                  </div>
+
+                  {!(paymentOption === 'assistance' && getAssistanceValidationError()) && (
+                    <div className="flex justify-between font-medium text-lg mt-2 pt-2 border-t">
+                      <span className="text-gray-900">Total:</span>
+                      <span className="text-gray-900">${(finalAmount / 100).toFixed(2)}</span>
+                    </div>
+                  )}
                 </div>
               </>
             )}
@@ -705,16 +720,18 @@ export default function MembershipPurchase({ membership, userEmail, userMembersh
       {/* Purchase Button */}
       <button
         onClick={handlePurchase}
-        disabled={isLoading || !selectedDuration || !paymentOption}
+        disabled={isLoading || !selectedDuration || !paymentOption || !!getAssistanceValidationError()}
         className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed text-white px-4 py-2 rounded-md text-sm font-medium transition-colors"
       >
-        {isLoading 
-          ? 'Processing...' 
-          : !selectedDuration 
+        {isLoading
+          ? 'Processing...'
+          : !selectedDuration
             ? 'Select Duration to Continue'
             : !paymentOption
               ? 'Select Payment Option to Continue'
-              : `Purchase Membership - $${(finalAmount / 100).toFixed(2)}`
+              : getAssistanceValidationError()
+                ? 'Enter a Valid Amount to Continue'
+                : `Purchase Membership - $${(finalAmount / 100).toFixed(2)}`
         }
       </button>
 

--- a/src/components/MembershipPurchase.tsx
+++ b/src/components/MembershipPurchase.tsx
@@ -516,7 +516,6 @@ export default function MembershipPurchase({ membership, userEmail, userMembersh
                               ? 'border-red-400 focus:ring-red-500 focus:border-red-500'
                               : 'border-gray-300 focus:ring-blue-500 focus:border-blue-500'
                           }`}
-                          placeholder="0.00"
                         />
                       </div>
                       {getAssistanceValidationError() ? (

--- a/src/components/MembershipPurchase.tsx
+++ b/src/components/MembershipPurchase.tsx
@@ -13,6 +13,7 @@ import { useToast } from '@/contexts/ToastContext'
 import Link from 'next/link'
 import { handlePaymentFlow, PaymentFlowData } from '@/lib/payment-flow-dispatcher'
 import { calculateMembershipDates, isMembershipExtension } from '@/lib/membership-utils'
+import { validateAssistanceAmount } from '@/lib/membership-validation'
 
 // Force import client config
 import '../../instrumentation-client'
@@ -125,17 +126,9 @@ export default function MembershipPurchase({ membership, userEmail, userMembersh
   
   const finalAmount = getFinalPaymentAmount()
 
-  // Validate the "how much can you pay" field for the assistance option.
-  // Returns an error message when the field is blank, non-numeric, negative,
-  // or exceeds the membership price; null when it's a valid amount.
   const getAssistanceValidationError = (): string | null => {
     if (paymentOption !== 'assistance') return null
-    const trimmed = requestedPurchaseAmount.trim()
-    const parsed = parseFloat(trimmed)
-    if (trimmed === '' || isNaN(parsed) || parsed < 0 || parsed * 100 > selectedPrice) {
-      return `Please enter a valid amount between $0 and $${(selectedPrice / 100).toFixed(2)}`
-    }
-    return null
+    return validateAssistanceAmount(requestedPurchaseAmount, selectedPrice)
   }
   
   // Set default assistance amount when duration changes
@@ -518,13 +511,23 @@ export default function MembershipPurchase({ membership, userEmail, userMembersh
                           step="0.01"
                           value={requestedPurchaseAmount}
                           onChange={(e) => setAssistanceAmount(e.target.value)}
-                          className="block w-full pl-7 pr-3 py-2 border-gray-300 rounded-md focus:ring-blue-500 focus:border-blue-500 text-sm text-gray-900"
+                          className={`block w-full pl-7 pr-3 py-2 rounded-md text-sm text-gray-900 ${
+                            getAssistanceValidationError()
+                              ? 'border-red-400 focus:ring-red-500 focus:border-red-500'
+                              : 'border-gray-300 focus:ring-blue-500 focus:border-blue-500'
+                          }`}
                           placeholder="0.00"
                         />
                       </div>
-                      <div className="text-xs text-gray-500 mt-1">
-                        Maximum: ${(selectedPrice / 100).toFixed(2)}
-                      </div>
+                      {getAssistanceValidationError() ? (
+                        <div className="text-xs text-red-600 mt-1">
+                          {getAssistanceValidationError()}
+                        </div>
+                      ) : (
+                        <div className="text-xs text-gray-500 mt-1">
+                          Maximum: ${(selectedPrice / 100).toFixed(2)}
+                        </div>
+                      )}
                     </div>
                   )}
                 </div>
@@ -655,7 +658,7 @@ export default function MembershipPurchase({ membership, userEmail, userMembersh
                   
                   {paymentOption === 'assistance' && getAssistanceValidationError() && (
                     <div className="text-orange-600 text-sm mt-1">
-                      Enter a valid amount above to see your total
+                      Fix the amount above to see your total
                     </div>
                   )}
 

--- a/src/components/MembershipPurchase.tsx
+++ b/src/components/MembershipPurchase.tsx
@@ -163,16 +163,25 @@ export default function MembershipPurchase({ membership, userEmail, userMembersh
       return
     }
 
+    if (paymentOption === 'assistance') {
+      const trimmed = requestedPurchaseAmount.trim()
+      const parsed = parseFloat(trimmed)
+      if (trimmed === '' || isNaN(parsed) || parsed < 0 || parsed * 100 > selectedPrice) {
+        setError(`Please enter a valid amount between $0 and $${(selectedPrice / 100).toFixed(2)}`)
+        return
+      }
+    }
+
     setIsLoading(true)
     setError(null)
-    
+
     try {
       const paymentData: PaymentFlowData = {
         amount: finalAmount,
         membershipId: membership.id,
         durationMonths: selectedDuration,
         paymentOption: paymentOption,
-        assistanceAmount: paymentOption === 'assistance' ? (selectedPrice - parseFloat(requestedPurchaseAmount) * 100) : undefined, // Positive assistance amount (amount being discounted)
+        assistanceAmount: paymentOption === 'assistance' ? (selectedPrice - (parseFloat(requestedPurchaseAmount) || 0) * 100) : undefined, // Positive assistance amount (amount being discounted)
         donationAmount: paymentOption === 'donation' ? parseFloat(donationAmount) * 100 : undefined,
         savePaymentMethod: shouldSavePaymentMethod,
         expectedValidFrom: startDate.toISOString().split('T')[0],
@@ -293,10 +302,19 @@ export default function MembershipPurchase({ membership, userEmail, userMembersh
   const handleUseDifferentMethod = async () => {
     if (!selectedDuration || !paymentOption) return
 
+    if (paymentOption === 'assistance') {
+      const trimmed = requestedPurchaseAmount.trim()
+      const parsed = parseFloat(trimmed)
+      if (trimmed === '' || isNaN(parsed) || parsed < 0 || parsed * 100 > selectedPrice) {
+        setError(`Please enter a valid amount between $0 and $${(selectedPrice / 100).toFixed(2)}`)
+        return
+      }
+    }
+
     setShowConfirmationScreen(false)
     setIsLoading(true)
     setError(null)
-    
+
     // Continue with regular payment flow (bypass saved method check)
     try {
       const paymentData: PaymentFlowData = {
@@ -304,7 +322,7 @@ export default function MembershipPurchase({ membership, userEmail, userMembersh
         membershipId: membership.id,
         durationMonths: selectedDuration,
         paymentOption: paymentOption,
-        assistanceAmount: paymentOption === 'assistance' ? (selectedPrice - parseFloat(requestedPurchaseAmount) * 100) : undefined,
+        assistanceAmount: paymentOption === 'assistance' ? (selectedPrice - (parseFloat(requestedPurchaseAmount) || 0) * 100) : undefined,
         donationAmount: paymentOption === 'donation' ? parseFloat(donationAmount) * 100 : undefined,
         savePaymentMethod: shouldSavePaymentMethod,
         expectedValidFrom: startDate.toISOString().split('T')[0],

--- a/src/lib/membership-validation.ts
+++ b/src/lib/membership-validation.ts
@@ -116,7 +116,27 @@ export function calculateExtensionCost(
   monthsNeeded: number
 ): number {
   if (!membership.membership) return 0
-  
+
   const monthlyPrice = membership.membership.price_monthly
   return monthsNeeded * monthlyPrice
+}
+
+/**
+ * Validate the "how much are you able to pay?" field on an assistance
+ * purchase. Returns an error message when the value is blank, non-numeric,
+ * negative, or exceeds the membership price; null when it's a valid amount.
+ *
+ * requestedAmount is the raw string from the input field (dollars).
+ * priceCents is the full membership price in cents.
+ */
+export function validateAssistanceAmount(
+  requestedAmount: string,
+  priceCents: number
+): string | null {
+  const trimmed = requestedAmount.trim()
+  const parsed = parseFloat(trimmed)
+  if (trimmed === '' || isNaN(parsed) || parsed < 0 || parsed * 100 > priceCents) {
+    return `Please enter a valid amount between $0 and $${(priceCents / 100).toFixed(2)}`
+  }
+  return null
 }


### PR DESCRIPTION
## Problem

A member requesting full financial assistance ($0 to pay) on a membership could end up with a Xero invoice for the *full* membership price marked "Awaiting Payment" — even though the system's own record correctly showed the invoice as $0.00/Completed. This happened for INV-9194.

## Root cause

The "How much are you able to pay?" input on the assistance flow (`src/components/MembershipPurchase.tsx`) starts pre-filled at 50% of the membership price; a member requesting $0 has to clear it. Clearing the field made `parseFloat('')` evaluate to `NaN`, which `JSON.stringify` silently serialized to `null` in the request body. The server's `if (assistanceAmount && assistanceAmount > 0)` check treated `null` as falsy, so it skipped staging the offsetting `donation` line item — while the charged amount still correctly resolved to $0. Net effect: the local payment record was right, but the Xero-bound invoice had only the full-price `membership` line with nothing to offset it.

## Fixes (4 commits)

1. **`837bcfc`** — Require an explicit, valid assistance amount before submission instead of silently defaulting a blank field to $0. Add matching server-side boundary validation (`src/app/api/create-membership-payment-intent/route.ts`) that rejects a non-reconciling `assistanceAmount` with a 400, as defense-in-depth against any client bug or direct API call.
2. **`0591016`** — Fix the live Purchase Summary preview and Purchase button label, which were still computing/displaying a fabricated total for invalid input (e.g. blank/`-`/`+` showed as a full discount; over-max showed as no discount) even though actual submission was already blocked.
3. **`ca9eb10`** — Extract the validation into a tested `validateAssistanceAmount()` helper (`src/lib/membership-validation.ts`) with unit tests covering blank, `-`, `+`, non-numeric, negative, over-max, and the valid boundary cases. Red-border the input and show the specific error message next to it instead of only in the summary section.
4. **`e09863c`** — Remove the `0.00` placeholder text on the input so a blank/invalid field doesn't visually look like an entered zero.

## Data remediation

INV-9194 was corrected directly in Xero and in the local `xero_invoice_line_items` table by the repo owner during this investigation; no further data migration is needed. The other invoices initially flagged by a broad DB sweep turned out to already carry a correct (legacy-format) offsetting line item and were not affected.

## Test plan

- [x] `npx tsc --noEmit` — clean on all changed files (pre-existing unrelated errors elsewhere in the repo, confirmed via `git stash` diff)
- [x] `npx eslint` on all changed files — no new warnings/errors vs. the pre-existing baseline
- [x] `npx jest src/__tests__/lib/membership-validation.test.ts` — 25/25 passing, including 11 new cases for `validateAssistanceAmount()`
- [x] Manually exercised the assistance flow in the live build for blank, `-`, `+`, over-max, and valid inputs, confirming the preview/button/submission all agree

---
_Generated by [Claude Code](https://claude.ai/code/session_018LszxThquSM9rnG3MEewCb)_