### PR TITLE
Fix Sentry severity forwarding and enable source map uploads

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,9 @@ LOOPS_EMAIL_CHANGE_CONFIRMED_TEMPLATE_ID=your_email_change_confirmed_template_id
 NEXT_PUBLIC_SENTRY_DSN=your_sentry_dsn_here
 SENTRY_ORG=your_sentry_org
 SENTRY_PROJECT=membership-system
+# Auth token for uploading source maps at build time (readable stack traces in Sentry).
+# Requires "Source Map Upload" + "Release Creation" scopes. Not needed for local dev.
+SENTRY_AUTH_TOKEN=your_sentry_auth_token_here
 
 # Xero Integration Configuration
 # Recommendation: Create separate Xero apps for development/preview/production environments
@@ -849,6 +852,14 @@ SENTRY_ORG=your_sentry_org
 SENTRY_PROJECT=membership-system
 ```
 
+**Production/CI only** (used at build time to upload source maps for readable stack traces; not needed for local dev):
+
+```bash
+SENTRY_AUTH_TOKEN=your_sentry_auth_token_here
+```
+
+Generate this token from Sentry's Settings → Auth Tokens with the **Source Map Upload** and **Release Creation** scopes. Without it, builds still succeed, but Sentry stack traces show minified code instead of your original source.
+
 The system automatically uses `NODE_ENV` to separate development and production events into different environments within the same project.
 
 ### 3. Critical Error Scenarios Monitored
@@ -1341,6 +1352,7 @@ LOOPS_PAYMENT_PLAN_COMPLETED_TEMPLATE_ID=your_payment_plan_completed_template_id
 NEXT_PUBLIC_SENTRY_DSN=your_sentry_dsn_here
 SENTRY_ORG=your_sentry_org
 SENTRY_PROJECT=membership-system
+SENTRY_AUTH_TOKEN=your_sentry_auth_token_here
 ```
 
 **Xero Integration:**

--- a/next.config.ts
+++ b/next.config.ts
@@ -39,9 +39,9 @@ export default withSentryConfig(nextConfig, {
   
   // Automatically tree-shake Sentry logger statements for a smaller bundle
   disableLogger: true,
-  
-  // Hides source maps from generated client bundles
-  sourcemaps: {
-    disable: true
-  },
+
+  // Uploads source maps to Sentry for readable stack traces (requires
+  // SENTRY_AUTH_TOKEN; falls back to no-op with a warning if it's unset).
+  // Uploaded maps are deleted from the build output afterward by default,
+  // so they are never served publicly.
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",
         "@hookform/resolvers": "^5.1.1",
-        "@sentry/nextjs": "^10.58.0",
+        "@sentry/nextjs": "^10.70.0",
         "@stripe/react-stripe-js": "^3.7.0",
         "@stripe/stripe-js": "^7.3.1",
         "@supabase/ssr": "^0.6.1",
@@ -61,6 +61,49 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer": {
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer/-/code-transformer-0.18.1.tgz",
+      "integrity": "sha512-u1Hb6bHjWtkSpiprwVP6YaHC1DTN4RAU3zYkUDUe7WMnJwdyU1pwTL9dFKiSJB9IiLue/EQovmyx6xhU7FFtAQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@types/estree": "^1.0.8",
+        "astring": "^1.9.0",
+        "esquery": "^1.7.0",
+        "meriyah": "^6.1.4",
+        "semifies": "^1.0.0",
+        "source-map": "^0.6.0"
+      },
+      "bin": {
+        "code-transformer": "cli.js"
+      }
+    },
+    "node_modules/@apm-js-collab/code-transformer-bundler-plugins": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/code-transformer-bundler-plugins/-/code-transformer-bundler-plugins-0.7.4.tgz",
+      "integrity": "sha512-nAfOeZPSUAQvJa1iFT/5oCrTm5YQhMMrfCNthNnaXHZiOQhu1KGuLoIx7HtbAi3wfwaBYLaICPIeenIaEwcXIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.1",
+        "es-module-lexer": "^2.1.0",
+        "magic-string": "^0.30.21",
+        "module-details-from-path": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@apm-js-collab/tracing-hooks": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@apm-js-collab/tracing-hooks/-/tracing-hooks-0.13.0.tgz",
+      "integrity": "sha512-mTvWz9rnQwx1U3h0XPTHaX7bgfkpipLLTQyjlC2cdhQpQEuoLT0AGzoydeoq2NxfEVv6fWOOETcSbb2nptleyw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@apm-js-collab/code-transformer": "^0.18.0",
+        "debug": "^4.4.1",
+        "module-details-from-path": "^1.0.4"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2106,9 +2149,9 @@
       }
     },
     "node_modules/@opentelemetry/api-logs": {
-      "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
-      "integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.220.0.tgz",
+      "integrity": "sha512-CmVa4ImJ+ynfrPMNaAXHET6Bhb44SwzmfyVJFq9ni2jgXJR/l7C6gfVFddNmHP+ZOkP9cf4f9DBe68qVLTHc9w==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/api": "^1.3.0"
@@ -2118,9 +2161,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
-      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.10.0.tgz",
+      "integrity": "sha512-/wNZ8twnEQQA4HoHu22+vcsdru6pWPWxW+7w+FlxT6Id7PE/WIbZmVKkte+PF72e0F2dnImFeHD2syyE1Mw6MQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2133,12 +2176,12 @@
       }
     },
     "node_modules/@opentelemetry/instrumentation": {
-      "version": "0.214.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.214.0.tgz",
-      "integrity": "sha512-MHqEX5Dk59cqVah5LiARMACku7jXSVk9iVDWOea4x3cr7VfdByeDCURK6o1lntT1JS/Tsovw01UJrBhN3/uC5w==",
+      "version": "0.220.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.220.0.tgz",
+      "integrity": "sha512-xQx3E2WxP1mDvKzxLxX+CTCtNLa560YJZ3087qYHerl2YmiKpv7AH+dAy7vmx+eVrZ5BwhfWUAVoKOoxCNHcpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/api-logs": "0.214.0",
+        "@opentelemetry/api-logs": "0.220.0",
         "import-in-the-middle": "^3.0.0",
         "require-in-the-middle": "^8.0.0"
       },
@@ -2150,12 +2193,29 @@
       }
     },
     "node_modules/@opentelemetry/resources": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.8.0.tgz",
-      "integrity": "sha512-qmXQ27ilDbUK/vGMqwL8D4/rhn76C+sherM4wTbjlfknR8Nvfc/hCxjRJPhkzZzUsPiNg16SA31NxMabwttRjg==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.10.0.tgz",
+      "integrity": "sha512-q6MMm2zhggzsHVNbabYwut+a6nbuQQe3URUoxaojM/8K1IBfwwPzvxIjNi2/lI1TFe+fMHMW9MWhrtDLEXEnkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.8.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/semantic-conventions": "^1.29.0"
+      },
+      "engines": {
+        "node": "^18.19.0 || >=20.6.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": ">=1.3.0 <1.10.0"
+      }
+    },
+    "node_modules/@opentelemetry/sdk-trace": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace/-/sdk-trace-2.10.0.tgz",
+      "integrity": "sha512-MfQGq3GRmTh5fM/y+OjaO0vj6+luCB1XO2gfXCalKCfgKw0eHL++sm75DNweC6ohlp+aFvACqeE0fYayqdRaoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -2166,13 +2226,14 @@
       }
     },
     "node_modules/@opentelemetry/sdk-trace-base": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.8.0.tgz",
-      "integrity": "sha512-mhU4jp+vW0mGbFRd+GeXHvmfA4aDqWjBjLC3pE5XMpLs0IE2ryYb019Ts2AQrOq67gaTF25D91+fgvEHDZEnuQ==",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.10.0.tgz",
+      "integrity": "sha512-GuYQQT7QD2EeO8lcZLRQzcbOyhqAzL+6WWTKTU9mSUBYBazkEDl+VrQcXQhbB08OWM9anD1aHleVadzulpOaUQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@opentelemetry/core": "2.8.0",
-        "@opentelemetry/resources": "2.8.0",
+        "@opentelemetry/core": "2.10.0",
+        "@opentelemetry/resources": "2.10.0",
+        "@opentelemetry/sdk-trace": "2.10.0",
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
       "engines": {
@@ -2183,9 +2244,9 @@
       }
     },
     "node_modules/@opentelemetry/semantic-conventions": {
-      "version": "1.41.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
-      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -2575,28 +2636,30 @@
       }
     },
     "node_modules/@sentry/browser": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.58.0.tgz",
-      "integrity": "sha512-Syf6h6HDwC15fk86+/0ql8ebwwJFw2wp+lvOX9GfLTJVOqrSILCrtLKNI+f4v/3w8mzImsv9ttJGGbUugLNvcA==",
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-10.70.0.tgz",
+      "integrity": "sha512-IK6+J+8H06tZe+A8L37TT5ZxxwNtyQatW8zl5RYYJ/e9CsjrM8fPi8I1OT7uquTw8UtjqFHt7bEef/Vy63ksPg==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.58.0",
-        "@sentry/core": "10.58.0",
-        "@sentry/feedback": "10.58.0",
-        "@sentry/replay": "10.58.0",
-        "@sentry/replay-canvas": "10.58.0"
+        "@sentry/browser-utils": "10.70.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/feedback": "10.70.0",
+        "@sentry/replay": "10.70.0",
+        "@sentry/replay-canvas": "10.70.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/browser-utils": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.58.0.tgz",
-      "integrity": "sha512-TzXrhZq3Llj6qPSv0ZVG5N5c7C6qNN/aRKJXhq2LombJrLwiQrWdgizp7zdHA0FGlZ7F5YpyRA2JIpkhvrFqYA==",
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/browser-utils/-/browser-utils-10.70.0.tgz",
+      "integrity": "sha512-IvjhafF5NFXrPCg5EHbAPGDwIhHxgUcLlHTklZ3DAdA6ky88BJYMfevbcnOEmgavf4nylhCaquRUFNB5+szj+A==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.58.0"
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0"
       },
       "engines": {
         "node": ">=18"
@@ -2785,43 +2848,56 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sentry/core": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.58.0.tgz",
-      "integrity": "sha512-bkIbh2c6dzwhrWn/FGWu7j8hf6TAat2XxpkGM91LiN09fLYUXIMwcohVsXqze5l2cq35TnvqmSROAbRNr27GVw==",
+    "node_modules/@sentry/conventions": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@sentry/conventions/-/conventions-0.16.0.tgz",
+      "integrity": "sha512-fO9PLmHdVURcSPUpWCItWAtgKiMwGdJHbovoSEyLplX5sxs2ugvI4CBPTrkkgqhObnZOD0CnWBKDzSVQYBKEyQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.70.0.tgz",
+      "integrity": "sha512-ozhCTDqg89oB4XmWfAwuHshABpvT7AkRpaPnogopPfMAaI61G1t8EKCJ4W7aum8JSBonlfyjPCyW5oYZFm0KvA==",
+      "license": "MIT",
+      "dependencies": {
+        "@sentry/conventions": "^0.16.0"
+      },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/feedback": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.58.0.tgz",
-      "integrity": "sha512-VmIlR/0O0GXITbvgjPkQqd6yM0JDEk52WXv6Rs1kTdaIDU5h3Y64VDVN4MAbYVRHqSz7F1arjRRk2FkaKC7ZOQ==",
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/feedback/-/feedback-10.70.0.tgz",
+      "integrity": "sha512-6VQn2ETJjHkk4QQDdx/587/JDfXsk3yBTLZ3UZOMtBVrkmwgk+1FJZ8ULJ3ud1xZcuh2icunIkc7tGVv2axdnw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.58.0"
+        "@sentry/core": "10.70.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/nextjs": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-10.58.0.tgz",
-      "integrity": "sha512-aiuCh9x5VcEvCrZtMyQqkx0uwd3fwp/m4Ca+3ciyY7xDD9jvYSXhh3saYWSg9neYcdAPa4Gjz2UCS/8a4H/+GQ==",
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/nextjs/-/nextjs-10.70.0.tgz",
+      "integrity": "sha512-HL6hoEARpdL/NH3uIQ/O9BczP5P3QLSWerQgv8C4/vZl3JPQOWmFsJEN0F8/dU4+OFqlPz3P52InZjaYO3MA+w==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
-        "@opentelemetry/semantic-conventions": "^1.40.0",
         "@rollup/plugin-commonjs": "28.0.1",
-        "@sentry/browser-utils": "10.58.0",
+        "@sentry/browser-utils": "10.70.0",
         "@sentry/bundler-plugin-core": "^5.3.0",
-        "@sentry/core": "10.58.0",
-        "@sentry/node": "10.58.0",
-        "@sentry/opentelemetry": "10.58.0",
-        "@sentry/react": "10.58.0",
-        "@sentry/vercel-edge": "10.58.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/node": "10.70.0",
+        "@sentry/opentelemetry": "10.70.0",
+        "@sentry/react": "10.70.0",
+        "@sentry/server-utils": "10.70.0",
+        "@sentry/vercel-edge": "10.70.0",
         "@sentry/webpack-plugin": "^5.3.0",
         "rollup": "^4.60.3",
         "stacktrace-parser": "^0.1.11"
@@ -2834,20 +2910,19 @@
       }
     },
     "node_modules/@sentry/node": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.58.0.tgz",
-      "integrity": "sha512-KICgacBS+I/eWzFlAembutSwFwy0WVSrGp8UMV9n1XZqqu4EBTlALRsbLNlDSv61UgH85L9L3vk91tgq6nJXAA==",
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.70.0.tgz",
+      "integrity": "sha512-SPOOVxmKTVIEtqvOKkQT163e/pOwucjS7OPsCHyRs8sFR4nfBNu0EThplyqnvqd5BWBMTPH6WTBQfo+QWHV+HA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
-        "@opentelemetry/core": "^2.6.1",
-        "@opentelemetry/instrumentation": "^0.214.0",
-        "@opentelemetry/sdk-trace-base": "^2.6.1",
-        "@opentelemetry/semantic-conventions": "^1.40.0",
-        "@sentry/core": "10.58.0",
-        "@sentry/node-core": "10.58.0",
-        "@sentry/opentelemetry": "10.58.0",
-        "@sentry/server-utils": "10.58.0",
+        "@opentelemetry/instrumentation": "^0.220.0",
+        "@opentelemetry/sdk-trace-base": "^2.9.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/node-core": "10.70.0",
+        "@sentry/opentelemetry": "10.70.0",
+        "@sentry/server-utils": "10.70.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -2855,13 +2930,14 @@
       }
     },
     "node_modules/@sentry/node-core": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.58.0.tgz",
-      "integrity": "sha512-7dTbYuoaSwSmF2GWDl7KK+sXQL8iqaZeZ2I/aFm+SvPZLckZF3OGFb2VsluWsSXQLnxtxPX9QP93viyK+VZsuA==",
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.70.0.tgz",
+      "integrity": "sha512-oPOEVVNxv5WHtckx2i06Wi9FLWyvOg/1DUeX732jZ4iqT2nupINaMH4nF4f4kSvUThFnxkFSRQxwqOxgzMKhKA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.58.0",
-        "@sentry/opentelemetry": "10.58.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "@sentry/opentelemetry": "10.70.0",
         "import-in-the-middle": "^3.0.0"
       },
       "engines": {
@@ -2872,8 +2948,7 @@
         "@opentelemetry/core": "^1.30.1 || ^2.1.0",
         "@opentelemetry/exporter-trace-otlp-http": ">=0.57.0 <1",
         "@opentelemetry/instrumentation": ">=0.57.1 <1",
-        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
-        "@opentelemetry/semantic-conventions": "^1.39.0"
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
       },
       "peerDependenciesMeta": {
         "@opentelemetry/api": {
@@ -2890,19 +2965,17 @@
         },
         "@opentelemetry/sdk-trace-base": {
           "optional": true
-        },
-        "@opentelemetry/semantic-conventions": {
-          "optional": true
         }
       }
     },
     "node_modules/@sentry/opentelemetry": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.58.0.tgz",
-      "integrity": "sha512-qKOGVmt02wDaq7E70VekG8Z9XM641trJPoTHSeVUfGaXVcmGc46ZldTNtfWbxJq/8f/fge2pap60gn066ido2Q==",
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.70.0.tgz",
+      "integrity": "sha512-UNV/2tqypcUK6FDzerAsFJn1Km/c4VZCYkUZDNbnV5S0cwAq2BYKMo4M5vovaLDBQlxA+Wk9ovbxi5wYjjl9fw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.58.0"
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0"
       },
       "engines": {
         "node": ">=18"
@@ -2910,18 +2983,18 @@
       "peerDependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/core": "^1.30.1 || ^2.1.0",
-        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0",
-        "@opentelemetry/semantic-conventions": "^1.39.0"
+        "@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.1.0"
       }
     },
     "node_modules/@sentry/react": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.58.0.tgz",
-      "integrity": "sha512-3FLRtnXrue30UZALrQ9wQZeuvVmZl/pTCA+RyPlaZ5GxcYTapN9CVbm1IvbQpK4w1bt80+JxaKM4HikvII6KpA==",
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/react/-/react-10.70.0.tgz",
+      "integrity": "sha512-j1d/4hvoaUVKs5GRrfmwUCkiEmkfaeHsk+xgausZlzg5YvmwpF+gyevBLNP26GFEH7nyHXW4l8dbbo0eNieJmw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser": "10.58.0",
-        "@sentry/core": "10.58.0"
+        "@sentry/browser": "10.70.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0"
       },
       "engines": {
         "node": ">=18"
@@ -2931,52 +3004,55 @@
       }
     },
     "node_modules/@sentry/replay": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.58.0.tgz",
-      "integrity": "sha512-EVasQNUenpwJksK9DI1TQ78YytpjLAhxn0UTiHqA3sU/s1fHK5XZdZJPr/9uEGedRoInIP0UIWmbOtOEX8HHDg==",
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay/-/replay-10.70.0.tgz",
+      "integrity": "sha512-xMnSGzJn9Xd29rYd32lkx/gFW+5mtgqADJ2FiZvis0MBGZuDlNRwPn0/Cs1xA3JNXKV3NGfhdmmvs90w4dHSmw==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/browser-utils": "10.58.0",
-        "@sentry/core": "10.58.0"
+        "@sentry/browser-utils": "10.70.0",
+        "@sentry/core": "10.70.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/replay-canvas": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.58.0.tgz",
-      "integrity": "sha512-ufFmaJ968DXGe6u9W/UqNVjCCTtAqT2bNtSu1jHAjIFFpWIuM80lcR33grK6SuGnFxceu5iJFaIW6JRyfbM0Sw==",
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/replay-canvas/-/replay-canvas-10.70.0.tgz",
+      "integrity": "sha512-irzpw22bK5CF3jbecDa0gBUcfjv7tgeUoLAvtIfeHOP5ajmf3o4Cp99a9RQqkfgvkcMeRZBUwE91SQhp6Ank+w==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.58.0",
-        "@sentry/replay": "10.58.0"
+        "@sentry/core": "10.70.0",
+        "@sentry/replay": "10.70.0"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/server-utils": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.58.0.tgz",
-      "integrity": "sha512-PywIl2jvl+tO5R4j+n72Lcf3ItanHcaMN/oL1U9ZHE8icaT2zpo2W4uOaslpQeQvqPC24HGZ3BW2etzsCFQbag==",
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/server-utils/-/server-utils-10.70.0.tgz",
+      "integrity": "sha512-rzegZjMFFgCp3o+N8+XU13rfSvz4B+f8rU0ijBGrQcHdMNyfsFDTu1UTm262JofmrV2u+s+D0u0vFTnqtOGkbA==",
       "license": "MIT",
       "dependencies": {
-        "@sentry/core": "10.58.0"
+        "@apm-js-collab/code-transformer-bundler-plugins": "^0.7.3",
+        "@apm-js-collab/tracing-hooks": "^0.13.0",
+        "@sentry/conventions": "^0.16.0",
+        "@sentry/core": "10.70.0",
+        "meriyah": "^6.1.4"
       },
       "engines": {
         "node": ">=18"
       }
     },
     "node_modules/@sentry/vercel-edge": {
-      "version": "10.58.0",
-      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-10.58.0.tgz",
-      "integrity": "sha512-6hG/IPXdqo/MdNx/y5a3QQQTBQ/Jcux/NXLyEW+a8DvGqyKgcydB4VK7Ci7S5gcvpPkWrhGD5EWRXkYRfUNxbA==",
+      "version": "10.70.0",
+      "resolved": "https://registry.npmjs.org/@sentry/vercel-edge/-/vercel-edge-10.70.0.tgz",
+      "integrity": "sha512-RJgatvWPLq7fm8tTiwH8oQ0TyHPzn4kr9kXFjqTsUsbnVyfZm4/jZ88V0vP05y/GHh/WjLQAGNqOajR9scduZA==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "^1.9.1",
-        "@opentelemetry/resources": "^2.6.1",
-        "@sentry/core": "10.58.0"
+        "@sentry/core": "10.70.0"
       },
       "engines": {
         "node": ">=18"
@@ -4418,15 +4494,6 @@
         "node": ">=0.4.0"
       }
     },
-    "node_modules/acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "license": "MIT",
-      "peerDependencies": {
-        "acorn": "^8"
-      }
-    },
     "node_modules/acorn-import-phases": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
@@ -4752,6 +4819,15 @@
       "version": "0.0.8",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/astring": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/astring/-/astring-1.9.0.tgz",
+      "integrity": "sha512-LElXdjswlqjWrPpJFg1Fx4wpkOCxj1TDHlSV4PlaRxHGWko024xICaa97ZkMfs6DRKlCguiAI+rbXv5GWwXIkg==",
+      "license": "MIT",
+      "bin": {
+        "astring": "bin/astring"
+      }
     },
     "node_modules/async-function": {
       "version": "1.0.0",
@@ -5707,11 +5783,10 @@
       }
     },
     "node_modules/es-module-lexer": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
-      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
-      "license": "MIT",
-      "peer": true
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -6158,8 +6233,9 @@
       }
     },
     "node_modules/esquery": {
-      "version": "1.6.0",
-      "dev": true,
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+      "integrity": "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -6890,14 +6966,13 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.1.0.tgz",
-      "integrity": "sha512-c0AeAV8VcwZzfYE7euTZY3H+VXUPMVugiovdosq80lqEXJmOekg3zGUAYg6KImHMaMuBoTUfTv7xNpUFdy0hJA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "acorn": "^8.15.0",
-        "acorn-import-attributes": "^1.9.5",
         "cjs-module-lexer": "^2.2.0",
+        "es-module-lexer": "^2.2.0",
         "module-details-from-path": "^1.0.4"
       },
       "engines": {
@@ -6905,9 +6980,9 @@
       }
     },
     "node_modules/import-in-the-middle/node_modules/cjs-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+      "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
       "license": "MIT"
     },
     "node_modules/import-local": {
@@ -8739,10 +8814,12 @@
       }
     },
     "node_modules/magic-string": {
-      "version": "0.30.17",
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
       "license": "MIT",
       "dependencies": {
-        "@jridgewell/sourcemap-codec": "^1.5.0"
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/make-dir": {
@@ -8789,6 +8866,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/meriyah": {
+      "version": "6.1.4",
+      "resolved": "https://registry.npmjs.org/meriyah/-/meriyah-6.1.4.tgz",
+      "integrity": "sha512-Sz8FzjzI0kN13GK/6MVEsVzMZEPvOhnmmI1lU5+/1cGOiK3QUahntrNNtdVeihrO7t9JpoH75iMNXg6R6uWflQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/micromatch": {
@@ -9990,6 +10076,12 @@
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/semifies": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semifies/-/semifies-1.0.0.tgz",
+      "integrity": "sha512-xXR3KGeoxTNWPD4aBvL5NUpMTT7WMANr3EWnaS190QVkY52lqqcVRD7Q05UVbBhiWDGWMlJEUam9m7uFFGVScw==",
+      "license": "Apache-2.0"
     },
     "node_modules/semver": {
       "version": "7.8.5",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@dnd-kit/modifiers": "^9.0.0",
     "@dnd-kit/sortable": "^10.0.0",
     "@hookform/resolvers": "^5.1.1",
-    "@sentry/nextjs": "^10.58.0",
+    "@sentry/nextjs": "^10.70.0",
     "@stripe/react-stripe-js": "^3.7.0",
     "@stripe/stripe-js": "^7.3.1",
     "@supabase/ssr": "^0.6.1",

--- a/src/lib/sentry-helpers.ts
+++ b/src/lib/sentry-helpers.ts
@@ -12,10 +12,15 @@ export async function captureSentryError(
     request?: any
     tags?: Record<string, string>
     extra?: Record<string, any>
+    level?: Sentry.SeverityLevel
   }
 ) {
   const scope = new Sentry.Scope()
-  
+
+  if (context?.level) {
+    scope.setLevel(context.level)
+  }
+
   // Add user context if available
   if (context?.user) {
     scope.setUser({
@@ -89,7 +94,6 @@ export async function captureSentryError(
  */
 export async function captureSentryMessage(
   message: string,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- accepted for API compatibility; not currently forwarded to Sentry.captureMessage (see capturePaymentError's `severity` for the same gap)
   level: Sentry.SeverityLevel = 'info',
   context?: {
     user?: any
@@ -99,7 +103,8 @@ export async function captureSentryMessage(
   }
 ) {
   const scope = new Sentry.Scope()
-  
+  scope.setLevel(level)
+
   // Add user context if available
   if (context?.user) {
     scope.setUser({
@@ -261,10 +266,10 @@ export async function captureCriticalPaymentError(
 export async function capturePaymentError(
   error: Error | any,
   context: PaymentContext,
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars -- accepted by ~30 call sites to signal severity, but not currently forwarded to captureSentryError/Sentry; flagged for follow-up, not fixed here
   severity: 'error' | 'warning' | 'info' = 'error'
 ) {
   await captureSentryError(error instanceof Error ? error : new Error(String(error)), {
+    level: severity,
     tags: {
       operation: context.operation || 'unknown',
       endpoint: context.endpoint || 'unknown',


### PR DESCRIPTION
## Summary

- Fixes #212 — `capturePaymentError()` and `captureSentryMessage()` in `src/lib/sentry-helpers.ts` accepted a `severity`/`level` parameter but never applied it to the Sentry scope, so every payment error and message reported at Sentry's default level regardless of caller intent (49 call sites affected).
- Bumps `@sentry/nextjs` from `10.58.0` to `10.70.0` (latest).
- Removes the `sourcemaps.disable: true` override in `next.config.ts` now that `SENTRY_AUTH_TOKEN` is configured in Vercel, so production builds upload source maps for readable stack traces (uploaded maps are deleted from the public build output afterward, per the plugin's default behavior — never served to end users).
- Documents `SENTRY_AUTH_TOKEN` in all three env-var reference blocks in `README.md`, including required scopes.

## Why

Filed as #212: severity/level was silently dropped, so Sentry alert triage/routing that depends on severity (paging on `error` but not `warning`) wasn't distinguishing real payment failures from expected/lower-priority warnings. Separately, source maps were disabled with no auth token configured, meaning even correctly-captured errors showed minified/unreadable stack traces in production — likely contributing to real issues being hard to triage and going unaddressed.

## Test plan

- [x] `npx jest` — full suite passes (280 tests, 24 suites)
- [x] `npx eslint src/lib/sentry-helpers.ts` — no new lint errors (pre-existing `no-explicit-any` warnings unrelated to this change)
- [x] `npx tsc --noEmit -p .` — no new type errors introduced
- [x] `npx next build` locally — compiles successfully past the Sentry/webpack step (build fails later only on missing local Supabase env vars, unrelated to this change)
- [x] Confirmed `SENTRY_AUTH_TOKEN` added to Vercel (Production + Preview) with Source Map Upload, Release Creation, and Code Mappings scopes

🤖 Generated with [Claude Code](https://claude.com/claude-code)