### PR TITLE
Fix PaymentMethodSetup buttonClassName prop not being applied

### DIFF
--- a/src/components/PaymentMethodSetup.tsx
+++ b/src/components/PaymentMethodSetup.tsx
@@ -28,6 +28,7 @@ export default function PaymentMethodSetup({
   alternatePrice,
   showModal = true,
   buttonText = "Save Payment Method",
+  buttonClassName,
   isUpdate = false
 }: PaymentMethodSetupProps) {
   const [setupIntentClientSecret, setSetupIntentClientSecret] = useState<string | null>(null)
@@ -114,6 +115,7 @@ export default function PaymentMethodSetup({
               onSuccess={handleSuccess}
               onError={handleError}
               buttonText={buttonText}
+              buttonClassName={buttonClassName}
               isUpdate={isUpdate}
             />
           </Elements>
@@ -176,6 +178,7 @@ export default function PaymentMethodSetup({
               onSuccess={handleSuccess}
               onError={handleError}
               buttonText={buttonText}
+              buttonClassName={buttonClassName}
               isUpdate={isUpdate}
             />
           </Elements>

--- a/src/components/SetupIntentForm.tsx
+++ b/src/components/SetupIntentForm.tsx
@@ -10,6 +10,7 @@ interface SetupIntentFormProps {
   registrationName: string
   alternatePrice: number | null
   buttonText?: string
+  buttonClassName?: string
   isUpdate?: boolean
 }
 
@@ -19,6 +20,7 @@ export default function SetupIntentForm({
   registrationName,
   alternatePrice,
   buttonText = "Save Payment Method",
+  buttonClassName = "w-full bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white font-medium py-3 px-4 rounded-md transition-colors",
   isUpdate = false
 }: SetupIntentFormProps) {
   const stripe = useStripe()
@@ -213,7 +215,7 @@ export default function SetupIntentForm({
       <button
         type="submit"
         disabled={!stripe || isProcessing || !cardNumberComplete || !cardExpiryComplete || !cardCvcComplete || postalCode.trim().length === 0}
-        className="w-full bg-blue-600 hover:bg-blue-700 disabled:bg-gray-400 text-white font-medium py-3 px-4 rounded-md transition-colors"
+        className={buttonClassName}
       >
         {isProcessing ? 'Saving Payment Method...' : buttonText}
       </button>


### PR DESCRIPTION
## Summary
- `SetupIntentForm` didn't accept a `buttonClassName` prop, so its submit `<button>` always rendered with hardcoded classes (`w-full bg-blue-600 ...`), regardless of what callers passed.
- `PaymentMethodSetup` accepted `buttonClassName` in its props interface but never destructured it or passed it down to `SetupIntentForm`.
- As a result, `PaymentMethodManager`'s "Add Payment Method" button (which passes a compact pill-style `buttonClassName`) silently rendered full-width blue instead of the intended compact outlined style.

## Fix
- Added `buttonClassName?: string` to `SetupIntentForm`'s props, applied to the submit button with the previous hardcoded classes as the default fallback.
- Threaded `buttonClassName` from `PaymentMethodSetup` through to both `SetupIntentForm` call sites (inline and modal variants).

## Notes for reviewers
- Purely cosmetic fix, no behavior change for callers that don't pass `buttonClassName` — they keep the same default button styling via the fallback.
- `PaymentMethodManager` (the component whose button was actually affected) isn't currently imported/mounted anywhere in the app, so I verified this fix via TypeScript rather than a live browser check.

Fixes #213

🤖 Generated with [Claude Code](https://claude.com/claude-code)