### PR TITLE
Fix Xero OAuth callback CSRF state validation

### DIFF
--- a/src/__tests__/api/xero/auth.test.ts
+++ b/src/__tests__/api/xero/auth.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Unit tests for /api/xero/auth route
+ * Verifies a fresh CSRF state token is generated, passed to the Xero client,
+ * and set as an httpOnly cookie on the response.
+ */
+
+jest.mock('next/server', () => require('../../../test-helpers/mock-next-server'))
+
+import { GET } from '@/app/api/xero/auth/route'
+import { createXeroOAuthClient } from '@/lib/xero/client'
+import { XERO_OAUTH_STATE_COOKIE } from '@/lib/xero/oauth-state'
+
+jest.mock('@/lib/supabase/server')
+jest.mock('@/lib/xero/client', () => ({
+  createXeroOAuthClient: jest.fn()
+}))
+
+const mockSupabase: any = {
+  auth: {
+    getUser: jest.fn()
+  },
+  from: jest.fn()
+}
+
+jest.requireMock('@/lib/supabase/server').createClient = jest.fn(() => Promise.resolve(mockSupabase))
+
+describe('/api/xero/auth GET', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('requires authentication', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null }, error: { message: 'Unauthorized' } })
+
+    const response = await GET()
+    expect(response.status).toBe(401)
+    expect(createXeroOAuthClient).not.toHaveBeenCalled()
+  })
+
+  it('requires admin access', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'user-1' } }, error: null })
+    mockSupabase.from.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { is_admin: false }, error: null })
+        })
+      })
+    })
+
+    const response = await GET()
+    expect(response.status).toBe(403)
+    expect(createXeroOAuthClient).not.toHaveBeenCalled()
+  })
+
+  it('generates a state token, seeds the Xero client with it, and sets it as an httpOnly cookie', async () => {
+    mockSupabase.auth.getUser.mockResolvedValue({ data: { user: { id: 'admin-1' } }, error: null })
+    mockSupabase.from.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: { is_admin: true }, error: null })
+        })
+      })
+    })
+
+    const buildConsentUrl = jest.fn().mockResolvedValue('https://login.xero.com/identity/connect/authorize?...')
+    ;(createXeroOAuthClient as jest.Mock).mockImplementation(() => ({ buildConsentUrl }))
+
+    const response = await GET()
+    const body = await response.json()
+
+    expect(body.consentUrl).toBe('https://login.xero.com/identity/connect/authorize?...')
+
+    const stateArg = (createXeroOAuthClient as jest.Mock).mock.calls[0][0]
+    expect(typeof stateArg).toBe('string')
+    expect(stateArg.length).toBeGreaterThanOrEqual(32)
+
+    const cookie = response.cookies.get(XERO_OAUTH_STATE_COOKIE)
+    expect(cookie?.value).toBe(stateArg)
+    expect(cookie?.httpOnly).toBe(true)
+    expect(cookie?.path).toBe('/api/xero/callback')
+  })
+})

--- a/src/__tests__/api/xero/callback.test.ts
+++ b/src/__tests__/api/xero/callback.test.ts
@@ -1,0 +1,116 @@
+/**
+ * Unit tests for /api/xero/callback route
+ * Verifies the CSRF state cookie is validated before any token exchange happens
+ */
+
+jest.mock('next/server', () => require('../../../test-helpers/mock-next-server'))
+
+import { NextRequest } from 'next/server'
+import { GET } from '@/app/api/xero/callback/route'
+import { createXeroOAuthClient } from '@/lib/xero/client'
+import { XERO_OAUTH_STATE_COOKIE } from '@/lib/xero/oauth-state'
+
+jest.mock('@/lib/supabase/server')
+jest.mock('@/lib/xero/client', () => ({
+  createXeroOAuthClient: jest.fn(),
+  logXeroSync: jest.fn().mockResolvedValue(undefined),
+  revokeXeroTokens: jest.fn().mockResolvedValue(true)
+}))
+
+function makeQueryBuilder(result: any = { data: null, error: null }) {
+  const builder: any = {}
+  builder.select = jest.fn(() => builder)
+  builder.update = jest.fn(() => builder)
+  builder.eq = jest.fn(() => builder)
+  builder.single = jest.fn(() => Promise.resolve(result))
+  builder.insert = jest.fn(() => Promise.resolve(result))
+  builder.then = (onFulfilled: any, onRejected: any) => Promise.resolve(result).then(onFulfilled, onRejected)
+  return builder
+}
+
+const mockSupabase: any = {
+  from: jest.fn(() => makeQueryBuilder())
+}
+
+jest.requireMock('@/lib/supabase/server').createClient = jest.fn(() => Promise.resolve(mockSupabase))
+
+function makeRequest(query: string, cookieState?: string) {
+  const headers: Record<string, string> = {}
+  if (cookieState !== undefined) {
+    headers.cookie = `${XERO_OAUTH_STATE_COOKIE}=${cookieState}`
+  }
+  return new NextRequest(`http://localhost/api/xero/callback${query}`, { headers })
+}
+
+describe('/api/xero/callback GET', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+    mockSupabase.from.mockImplementation(() => makeQueryBuilder())
+  })
+
+  it('redirects with the upstream error when Xero reports one, without checking state', async () => {
+    const request = makeRequest('?error=access_denied')
+    const response = await GET(request)
+
+    expect(response.headers.get('location')).toContain('xero_error=access_denied')
+    expect(createXeroOAuthClient).not.toHaveBeenCalled()
+  })
+
+  it('rejects the callback when no state cookie is present', async () => {
+    const request = makeRequest('?code=abc&state=whatever')
+    const response = await GET(request)
+
+    expect(response.headers.get('location')).toContain('xero_error=missing_state')
+    expect(createXeroOAuthClient).not.toHaveBeenCalled()
+  })
+
+  it('rejects the callback when the returned state does not match the cookie', async () => {
+    const request = makeRequest('?code=abc&state=wrong-value', 'expected-state')
+    const response = await GET(request)
+
+    expect(response.headers.get('location')).toContain('xero_error=state_mismatch')
+    expect(createXeroOAuthClient).not.toHaveBeenCalled()
+  })
+
+  it('rejects the callback when state is returned but missing from the query string', async () => {
+    const request = makeRequest('?code=abc', 'expected-state')
+    const response = await GET(request)
+
+    expect(response.headers.get('location')).toContain('xero_error=state_mismatch')
+  })
+
+  it('clears the state cookie on a mismatch redirect', async () => {
+    const request = makeRequest('?code=abc&state=wrong-value', 'expected-state')
+    const response = await GET(request)
+
+    const cookie = response.cookies.get(XERO_OAUTH_STATE_COOKIE)
+    expect(cookie?.value).toBe('')
+    expect(cookie?.maxAge).toBe(0)
+  })
+
+  it('proceeds to exchange the code and stores tokens when state matches', async () => {
+    const apiCallback = jest.fn().mockResolvedValue({
+      access_token: 'access-token',
+      refresh_token: 'refresh-token',
+      id_token: 'id-token',
+      expires_in: 1800,
+      scope: 'openid',
+      token_type: 'Bearer'
+    })
+    const updateTenants = jest.fn().mockResolvedValue([
+      { tenantId: 'tenant-1', tenantName: 'Test Org' }
+    ])
+    ;(createXeroOAuthClient as jest.Mock).mockReturnValue({ apiCallback, updateTenants })
+
+    const request = makeRequest('?code=valid-code&state=matching-state', 'matching-state')
+    const response = await GET(request)
+
+    expect(createXeroOAuthClient).toHaveBeenCalledWith('matching-state')
+    expect(apiCallback).toHaveBeenCalledWith(request.url)
+    expect(updateTenants).toHaveBeenCalledWith(true)
+    expect(response.headers.get('location')).toContain('xero_success=connected')
+
+    const cookie = response.cookies.get(XERO_OAUTH_STATE_COOKIE)
+    expect(cookie?.maxAge).toBe(0)
+  })
+})

--- a/src/__tests__/lib/xero/oauth-state.test.ts
+++ b/src/__tests__/lib/xero/oauth-state.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Unit tests for src/lib/xero/oauth-state.ts CSRF state cookie helpers
+ */
+
+jest.mock('next/server', () => require('../../../test-helpers/mock-next-server'))
+
+import { NextRequest, NextResponse } from 'next/server'
+import {
+  XERO_OAUTH_STATE_COOKIE,
+  generateXeroOAuthState,
+  setXeroOAuthStateCookie,
+  clearXeroOAuthStateCookie,
+  readXeroOAuthStateCookie
+} from '@/lib/xero/oauth-state'
+
+describe('generateXeroOAuthState', () => {
+  it('generates a sufficiently long, url-safe token', () => {
+    const state = generateXeroOAuthState()
+    expect(state.length).toBeGreaterThanOrEqual(32)
+    expect(state).toMatch(/^[A-Za-z0-9_-]+$/)
+  })
+
+  it('generates unique tokens on each call', () => {
+    const a = generateXeroOAuthState()
+    const b = generateXeroOAuthState()
+    expect(a).not.toBe(b)
+  })
+})
+
+describe('setXeroOAuthStateCookie / readXeroOAuthStateCookie', () => {
+  it('round-trips the state value through a response and request cookie', () => {
+    const state = generateXeroOAuthState()
+    const response = NextResponse.json({ ok: true })
+    setXeroOAuthStateCookie(response, state)
+
+    const setCookieHeader = response.cookies.get(XERO_OAUTH_STATE_COOKIE)
+    expect(setCookieHeader?.value).toBe(state)
+    expect(setCookieHeader?.httpOnly).toBe(true)
+    expect(setCookieHeader?.sameSite).toBe('lax')
+    expect(setCookieHeader?.path).toBe('/api/xero/callback')
+
+    const request = new NextRequest('http://localhost/api/xero/callback', {
+      headers: { cookie: `${XERO_OAUTH_STATE_COOKIE}=${state}` }
+    })
+    expect(readXeroOAuthStateCookie(request)).toBe(state)
+  })
+
+  it('returns undefined when no cookie is present', () => {
+    const request = new NextRequest('http://localhost/api/xero/callback')
+    expect(readXeroOAuthStateCookie(request)).toBeUndefined()
+  })
+})
+
+describe('clearXeroOAuthStateCookie', () => {
+  it('sets an expired cookie', () => {
+    const response = NextResponse.redirect('http://localhost/admin/accounting/xero')
+    clearXeroOAuthStateCookie(response)
+
+    const cookie = response.cookies.get(XERO_OAUTH_STATE_COOKIE)
+    expect(cookie?.value).toBe('')
+    expect(cookie?.maxAge).toBe(0)
+  })
+})

--- a/src/app/admin/accounting/xero/connect/page.tsx
+++ b/src/app/admin/accounting/xero/connect/page.tsx
@@ -100,6 +100,10 @@ export default function XeroConnectPage() {
         return 'Failed to store Xero tokens. Please check your database connection.'
       case 'callback_failed':
         return 'OAuth callback failed. Please try again.'
+      case 'missing_state':
+        return 'Your session expired before Xero redirected back. Please try connecting again.'
+      case 'state_mismatch':
+        return 'Security check failed for this connection attempt. Please try connecting again.'
       default:
         return `Connection failed: ${errorCode}. Please try again.`
     }

--- a/src/app/admin/accounting/xero/page.tsx
+++ b/src/app/admin/accounting/xero/page.tsx
@@ -133,6 +133,10 @@ function XeroIntegrationContent() {
         return 'Failed to store Xero tokens. Please check your database connection.'
       case 'callback_failed':
         return 'OAuth callback failed. Please try again.'
+      case 'missing_state':
+        return 'Your session expired before Xero redirected back. Please try connecting again.'
+      case 'state_mismatch':
+        return 'Security check failed for this connection attempt. Please try connecting again.'
       default:
         return `Connection failed: ${errorCode}. Please try again.`
     }

--- a/src/app/api/xero/auth/route.ts
+++ b/src/app/api/xero/auth/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from 'next/server'
-import { xero } from '@/lib/xero/client'
+import { createXeroOAuthClient } from '@/lib/xero/client'
 import { createClient } from '@/lib/supabase/server'
+import { generateXeroOAuthState, setXeroOAuthStateCookie } from '@/lib/xero/oauth-state'
 
 export async function GET() {
   try {
@@ -23,18 +24,22 @@ export async function GET() {
       return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
     }
 
-    // Generate OAuth URL
-    const consentUrl = await xero.buildConsentUrl()
-    
+    // Generate OAuth URL with a CSRF state token bound to this request
+    const state = generateXeroOAuthState()
+    const oauthClient = createXeroOAuthClient(state)
+    const consentUrl = await oauthClient.buildConsentUrl()
+
     if (!consentUrl) {
       return NextResponse.json({ error: 'Failed to generate consent URL' }, { status: 500 })
     }
 
     // Return the consent URL for the frontend to redirect to
-    return NextResponse.json({ 
+    const response = NextResponse.json({
       consentUrl,
-      message: 'Redirect to this URL to authorize Xero integration' 
+      message: 'Redirect to this URL to authorize Xero integration'
     })
+    setXeroOAuthStateCookie(response, state)
+    return response
 
   } catch (error) {
     console.error('Error initiating Xero OAuth:', error)

--- a/src/app/api/xero/callback/route.ts
+++ b/src/app/api/xero/callback/route.ts
@@ -1,6 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
-import { xero, logXeroSync, revokeXeroTokens } from '@/lib/xero/client'
+import { createXeroOAuthClient, logXeroSync, revokeXeroTokens } from '@/lib/xero/client'
 import { createClient } from '@/lib/supabase/server'
+import { readXeroOAuthStateCookie, clearXeroOAuthStateCookie } from '@/lib/xero/oauth-state'
+
+function redirectAndClearState(request: NextRequest, pathAndQuery: string) {
+  const response = NextResponse.redirect(new URL(pathAndQuery, request.url))
+  clearXeroOAuthStateCookie(response)
+  return response
+}
 
 export async function GET(request: NextRequest) {
   try {
@@ -8,40 +15,46 @@ export async function GET(request: NextRequest) {
     const { searchParams } = new URL(request.url)
     const code = searchParams.get('code')
     const error = searchParams.get('error')
+    const returnedState = searchParams.get('state')
 
     // Handle OAuth errors
     if (error) {
       console.error('Xero OAuth error:', error)
-      return NextResponse.redirect(
-        new URL('/admin/accounting/xero?xero_error=' + encodeURIComponent(error), request.url)
-      )
+      return redirectAndClearState(request, '/admin/accounting/xero?xero_error=' + encodeURIComponent(error))
+    }
+
+    // Validate the CSRF state token before touching the code or calling Xero
+    const expectedState = readXeroOAuthStateCookie(request)
+    if (!expectedState) {
+      console.error('Xero OAuth callback missing state cookie (expired or direct navigation)')
+      return redirectAndClearState(request, '/admin/accounting/xero?xero_error=missing_state')
+    }
+    if (!returnedState || returnedState !== expectedState) {
+      console.error('Xero OAuth callback state mismatch — possible CSRF attempt')
+      return redirectAndClearState(request, '/admin/accounting/xero?xero_error=state_mismatch')
     }
 
     if (!code) {
       console.error('No authorization code received from Xero')
-      return NextResponse.redirect(
-        new URL('/admin/accounting/xero?xero_error=no_code', request.url)
-      )
+      return redirectAndClearState(request, '/admin/accounting/xero?xero_error=no_code')
     }
 
-    // Exchange code for tokens
-    const tokenSet = await xero.apiCallback(request.url)
-    
+    // Exchange code for tokens using a request-scoped client seeded with the
+    // already-validated state, so the library's own internal check also passes
+    const oauthClient = createXeroOAuthClient(expectedState)
+    const tokenSet = await oauthClient.apiCallback(request.url)
+
     if (!tokenSet || !tokenSet.access_token) {
       console.error('Failed to exchange code for tokens')
-      return NextResponse.redirect(
-        new URL('/admin/accounting/xero?xero_error=token_exchange_failed', request.url)
-      )
+      return redirectAndClearState(request, '/admin/accounting/xero?xero_error=token_exchange_failed')
     }
 
     // Get tenant connections
-    const tenantConnections = await xero.updateTenants(true)
-    
+    const tenantConnections = await oauthClient.updateTenants(true)
+
     if (!tenantConnections || tenantConnections.length === 0) {
       console.error('No tenant connections found')
-      return NextResponse.redirect(
-        new URL('/admin/accounting/xero?xero_error=no_tenants', request.url)
-      )
+      return redirectAndClearState(request, '/admin/accounting/xero?xero_error=no_tenants')
     }
 
     // First, revoke existing OAuth connections on Xero's side (single tenant model)
@@ -149,20 +162,17 @@ export async function GET(request: NextRequest) {
     }
 
     if (storedTenants.length === 0) {
-      return NextResponse.redirect(
-        new URL('/admin/accounting/xero?xero_error=token_storage_failed', request.url)
-      )
+      return redirectAndClearState(request, '/admin/accounting/xero?xero_error=token_storage_failed')
     }
 
     // Success redirect
-    return NextResponse.redirect(
-      new URL('/admin/accounting/xero?xero_success=connected&tenants=' + encodeURIComponent(storedTenants.join(',')), request.url)
+    return redirectAndClearState(
+      request,
+      '/admin/accounting/xero?xero_success=connected&tenants=' + encodeURIComponent(storedTenants.join(','))
     )
 
   } catch (error) {
     console.error('Error in Xero OAuth callback:', error)
-    return NextResponse.redirect(
-      new URL('/admin/accounting/xero?xero_error=callback_failed', request.url)
-    )
+    return redirectAndClearState(request, '/admin/accounting/xero?xero_error=callback_failed')
   }
 }

--- a/src/contexts/ToastContext.tsx
+++ b/src/contexts/ToastContext.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { createContext, useContext, useState, ReactNode } from 'react'
+import { createContext, useContext, useState, useCallback, ReactNode } from 'react'
 import Toast from '@/components/Toast'
 
 export interface ToastData {
@@ -37,30 +37,30 @@ export function ToastProvider({ children }: ToastProviderProps) {
 
   const generateId = () => Math.random().toString(36).substr(2, 9)
 
-  const showToast = (toast: ToastData) => {
+  const showToast = useCallback((toast: ToastData) => {
     const id = generateId()
     setToasts(prev => [...prev, { ...toast, id }])
-  }
+  }, [])
 
-  const showSuccess = (title: string, message?: string) => {
+  const showSuccess = useCallback((title: string, message?: string) => {
     showToast({ title, message, type: 'success' })
-  }
+  }, [showToast])
 
-  const showError = (title: string, message?: string) => {
+  const showError = useCallback((title: string, message?: string) => {
     showToast({ title, message, type: 'error' })
-  }
+  }, [showToast])
 
-  const showWarning = (title: string, message?: string) => {
+  const showWarning = useCallback((title: string, message?: string) => {
     showToast({ title, message, type: 'warning' })
-  }
+  }, [showToast])
 
-  const showInfo = (title: string, message?: string) => {
+  const showInfo = useCallback((title: string, message?: string) => {
     showToast({ title, message, type: 'info' })
-  }
+  }, [showToast])
 
-  const removeToast = (id: string) => {
+  const removeToast = useCallback((id: string) => {
     setToasts(prev => prev.filter(toast => toast.id !== id))
-  }
+  }, [])
 
   return (
     <ToastContext.Provider value={{ showToast, showSuccess, showError, showWarning, showInfo }}>

--- a/src/lib/xero/client.ts
+++ b/src/lib/xero/client.ts
@@ -39,6 +39,25 @@ const xero = new XeroClient({
 
 export { xero }
 
+// Request-scoped XeroClient used only for the OAuth handshake (buildConsentUrl /
+// apiCallback). A fresh instance per request avoids racing/mutating the shared
+// `xero` singleton's config.state across concurrent invocations on the same
+// warm serverless instance.
+export function createXeroOAuthClient(state?: string): XeroClient {
+  return new XeroClient({
+    clientId: process.env.XERO_CLIENT_ID!,
+    clientSecret: process.env.XERO_CLIENT_SECRET!,
+    redirectUris: [process.env.XERO_REDIRECT_URI || 'http://localhost:3000/api/xero/callback'],
+    scopes: process.env.XERO_SCOPES?.split(' ') || [
+      'accounting.transactions',
+      'accounting.contacts',
+      'accounting.settings',
+      'offline_access'
+    ],
+    state
+  })
+}
+
 // Wrapper function for single-tenant operations
 export async function withActiveTenant<T>(
   operation: (tenantId: string) => Promise<T>

--- a/src/lib/xero/oauth-state.ts
+++ b/src/lib/xero/oauth-state.ts
@@ -1,0 +1,31 @@
+import { randomBytes } from 'crypto'
+import type { NextRequest, NextResponse } from 'next/server'
+
+export const XERO_OAUTH_STATE_COOKIE = 'xero_oauth_state'
+const STATE_COOKIE_MAX_AGE_SECONDS = 10 * 60 // enough time to complete Xero's consent screen
+
+export function generateXeroOAuthState(): string {
+  return randomBytes(32).toString('base64url')
+}
+
+function cookieOptions() {
+  return {
+    httpOnly: true,
+    secure: process.env.NODE_ENV !== 'development',
+    sameSite: 'lax' as const,
+    path: '/api/xero/callback',
+    maxAge: STATE_COOKIE_MAX_AGE_SECONDS,
+  }
+}
+
+export function setXeroOAuthStateCookie(response: NextResponse, state: string): void {
+  response.cookies.set(XERO_OAUTH_STATE_COOKIE, state, cookieOptions())
+}
+
+export function clearXeroOAuthStateCookie(response: NextResponse): void {
+  response.cookies.set(XERO_OAUTH_STATE_COOKIE, '', { ...cookieOptions(), maxAge: 0 })
+}
+
+export function readXeroOAuthStateCookie(request: NextRequest): string | undefined {
+  return request.cookies.get(XERO_OAUTH_STATE_COOKIE)?.value
+}

--- a/src/test-helpers/mock-next-server.js
+++ b/src/test-helpers/mock-next-server.js
@@ -1,0 +1,81 @@
+// Shared next/server mock for tests that need real cookie/redirect/header
+// behavior beyond what the global jest.setup.js stub provides (json() + status
+// only). Used via jest.mock('next/server', () => require('...mock-next-server'))
+// in individual test files — this does not replace the global mock everywhere,
+// only in files that opt in.
+
+function parseCookies(headerValue) {
+  const cookies = new Map()
+  if (!headerValue) return cookies
+  for (const part of headerValue.split(';')) {
+    const [name, ...rest] = part.trim().split('=')
+    if (!name) continue
+    cookies.set(name, rest.join('='))
+  }
+  return cookies
+}
+
+class MockHeaders {
+  constructor(init = {}) {
+    this._map = new Map()
+    for (const [key, value] of Object.entries(init)) {
+      this._map.set(key.toLowerCase(), value)
+    }
+  }
+  get(name) {
+    return this._map.get(name.toLowerCase()) ?? null
+  }
+  set(name, value) {
+    this._map.set(name.toLowerCase(), value)
+  }
+}
+
+class MockCookieJar {
+  constructor(initial = new Map()) {
+    this._map = initial
+  }
+  get(name) {
+    const value = this._map.get(name)
+    if (value === undefined) return undefined
+    return typeof value === 'string' ? { name, value } : value
+  }
+  set(name, value, options = {}) {
+    this._map.set(name, { name, value, ...options })
+  }
+}
+
+class MockNextRequest {
+  constructor(url, options = {}) {
+    this.url = url
+    this.method = options.method || 'GET'
+    this.headers = new MockHeaders(options.headers || {})
+    this._body = options.body
+    this.cookies = new MockCookieJar(parseCookies(this.headers.get('cookie')))
+  }
+
+  async json() {
+    return JSON.parse(this._body || '{}')
+  }
+}
+
+function makeResponse(status, headerInit = {}) {
+  return {
+    status,
+    headers: new MockHeaders(headerInit),
+    cookies: new MockCookieJar(),
+  }
+}
+
+const NextResponse = {
+  json: (data, options = {}) => {
+    const response = makeResponse(options.status || 200)
+    response.json = () => Promise.resolve(data)
+    return response
+  },
+  redirect: (url, options = {}) => {
+    const status = (options && options.status) || 307
+    return makeResponse(status, { location: String(url) })
+  },
+}
+
+module.exports = { NextRequest: MockNextRequest, NextResponse }


### PR DESCRIPTION
## Summary

- Fixes #214: the `/api/xero/auth` → `/api/xero/callback` flow never set a `state` on the shared `XeroClient` config, so `xero-node`'s/`openid-client`'s internal CSRF check was always a no-op (`{state: undefined}` on both sides, confirmed by tracing the installed dependency source). An attacker could complete their own Xero authorization and get an authenticated admin's browser to hit the callback with just a `code`, silently linking the attacker's Xero org as the connected tenant.
- Adds an app-owned CSRF `state` token carried via a short-lived `httpOnly`/`Secure`/`SameSite=Lax` cookie (`src/lib/xero/oauth-state.ts`), validated in the callback **before** any token exchange. The OAuth handshake runs on a fresh, request-scoped `XeroClient` (`createXeroOAuthClient`) instead of mutating the shared singleton, avoiding a race between concurrent invocations on a warm serverless instance.
- Drive-by fix: `ToastContext`'s `showSuccess`/`showError`/etc. were plain functions redefined on every render, which meant the `admin/accounting/xero` OAuth-redirect effect (which lists them as deps) could loop — re-firing before `router.replace()` cleared the triggering query params, flooding the network tab with duplicate RSC requests. Found while manually testing this fix, since it lands right on that redirect path. Memoized with `useCallback`.

## Test plan

- [x] `npm test` — 294 tests pass, including 14 new tests covering the cookie helpers and both routes
- [x] `npx tsc --noEmit` — zero new errors vs. baseline
- [x] Manually verified live against a Vercel preview, signed in via the preview-auth admin bypass:
  - [x] Happy path: real Xero OAuth round trip, tokens stored, `Connected to Xero — Demo Company (US)`
  - [x] State mismatch (`state=wrong-value` with valid cookie) → rejected, no connection created
  - [x] Missing state cookie → rejected, no connection created
  - [x] Xero-cancel (`error=access_denied`) → handled correctly
  - [x] Disconnect / reconnect
  - [x] No request-storm regression from the `ToastContext` fix
  - [x] End-to-end regression: purchased and paid for a membership, synced to Xero, verified the invoice appeared correctly in the Demo Company org

🤖 Generated with [Claude Code](https://claude.com/claude-code)