### PR TITLE
Consolidate agent instructions into AGENTS.md

### DIFF
--- a/.agents/rules/admin-page-menu-requirement.md
+++ b/.agents/rules/admin-page-menu-requirement.md
@@ -1,5 +1,0 @@
----
-trigger: always_on
----
-
-When adding a new admin page, add it to navigation and verify it's reachable by clicking, not by URL

--- a/.agents/rules/build-verification.md
+++ b/.agents/rules/build-verification.md
@@ -1,9 +1,0 @@
----
-trigger: always_on
----
-
-Before reporting work complete, run npm run build and paste the raw, unfiltered output — including the final success or error lines. Do not summarize, scope, or filter the result (e.g. "0 errors in modified files"). If the build fails, fix it and re-run; do not report completion with a failing build.
-
-npx tsc --noEmit is a faster subset useful during iteration, but it is not a substitute: npm run build additionally parses pages and components that no test imports, runs lint, and validates server/client boundaries.
-
-The same applies to test runs: paste the actual Jest output, not a description of it.

--- a/.agents/rules/database-migration-limits.md
+++ b/.agents/rules/database-migration-limits.md
@@ -1,5 +1,0 @@
----
-trigger: always_on
----
-
-Migrations in this project are applied manually by the maintainer. Write the migration file only. Do not run supabase db push, db reset, migration up, or supabase link under any circumstances. Do not attempt to verify the migration by connecting to the database. The migration file existing in supabase/migrations/ is the complete deliverable.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,3 +21,7 @@ Run `npm run build` and paste the raw, unfiltered output — including the final
 `npx tsc --noEmit` is a faster subset useful during iteration, but it is not a substitute: `npm run build` additionally parses pages and components that no test imports, runs lint, and validates server/client boundaries.
 
 The same applies to test runs: paste the actual Jest output, not a description of it.
+
+## Linting
+
+CI's lint step is currently non-blocking (`continue-on-error: true`) while a pre-existing backlog gets paid down (issue #197) — don't take that as license to add to it. Run `npm run lint` before reporting work complete and don't introduce new errors or warnings in files you touch, even though CI won't fail on them yet. If your task is specifically a #197 sub-issue, verify with `npm run lint`, `npm test`, and `npm run build` as its plan describes.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Agent Instructions
+
+Instructions for AI coding agents working in this repository.
+
+## Testing the UI
+
+The login screen (magic link/OTP, Google OAuth, passkey) can't be driven by automated tools. On preview deployments, use the login bypass endpoint instead of trying to automate the real login flow — see [README.md § Preview auth bypass for automated testing](README.md#preview-auth-bypass-for-automated-testing) for the endpoint, required env vars, and one-time setup.
+
+## Database migrations
+
+Migrations are applied manually by the maintainer. Write the migration file only. Do not run `supabase db push`, `db reset`, `migration up`, or `supabase link` under any circumstances. Do not attempt to verify the migration by connecting to the database. The migration file existing in `supabase/migrations/` is the complete deliverable.
+
+## Admin pages
+
+When adding a new admin page, add it to navigation and verify it's reachable by clicking, not by URL.
+
+## Before reporting work complete
+
+Run `npm run build` and paste the raw, unfiltered output — including the final success or error lines. Do not summarize, scope, or filter the result (e.g. "0 errors in modified files"). If the build fails, fix it and re-run; do not report completion with a failing build.
+
+`npx tsc --noEmit` is a faster subset useful during iteration, but it is not a substitute: `npm run build` additionally parses pages and components that no test imports, runs lint, and validates server/client boundaries.
+
+The same applies to test runs: paste the actual Jest output, not a description of it.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
## Summary
- Adds `AGENTS.md` as the canonical instructions file for AI coding agents, with a pointer to the preview-auth-bypass docs in the README (used for driving the UI on preview deployments, since the real login flow can't be automated) plus the migration, admin-page, build-verification, and linting rules.
- Adds `CLAUDE.md` as a one-line `@AGENTS.md` import so Claude Code loads the same content without a second copy to keep in sync.
- Removes `.agents/rules/*` — nothing in the repo was actually loading that directory, so those three rules weren't being enforced; their content now lives in AGENTS.md where it will be.
- Notes that CI's lint step is temporarily non-blocking while issue #197's backlog gets paid down, and tells agents to keep running `npm run lint` anyway so they don't add to it.

## Test plan
- [x] Verified no tool config in the repo referenced `.agents/rules/`
- [x] Confirmed the README anchor (`#preview-auth-bypass-for-automated-testing`) used in AGENTS.md matches the existing section heading
- N/A — documentation-only change, no build/lint/test impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)