### PR TITLE
Fix #206: remove no-explicit-any from src/components (44 errors, 17 files)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ next-env.d.ts
 /logs/
 .claude/settings.local.json
 .claude/settings.local.json
+.env*.local

--- a/src/app/admin/registrations/[id]/games/page.tsx
+++ b/src/app/admin/registrations/[id]/games/page.tsx
@@ -5,7 +5,9 @@ import { useParams } from 'next/navigation'
 import Link from 'next/link'
 import { createClient } from '@/lib/supabase/client'
 import { useToast } from '@/contexts/ToastContext'
-import AlternateSelectionInterface from '@/components/AlternateSelectionInterface'
+import AlternateSelectionInterface, {
+  type AlternateSelectionResponse
+} from '@/components/AlternateSelectionInterface'
 import { formatDate } from '@/lib/date-utils'
 
 interface Game {
@@ -27,35 +29,6 @@ interface Registration {
   allow_alternates: boolean
   alternate_price: number
   alternate_accounting_code: string
-}
-
-/** Result of processing a single alternate selection, from POST /api/alternate-registrations/[gameId]/select. */
-interface AlternateSelectionResult {
-  userId: string
-  userName: string
-  success: boolean
-  error?: string
-  paymentId?: string
-  amountCharged?: number
-}
-
-interface AlternateSelectionResponse {
-  success: boolean
-  message: string
-  summary: {
-    totalProcessed: number
-    totalSelected: number
-    successfulSelections: number
-    failedSelections: number
-    totalAmountCharged: number
-    alreadySelected: number
-  }
-  results: AlternateSelectionResult[]
-  game: {
-    id: string
-    description: string
-    registrationName: string | undefined
-  }
 }
 
 export default function RegistrationGamesPage() {

--- a/src/app/api/validate-discount-code/route.ts
+++ b/src/app/api/validate-discount-code/route.ts
@@ -14,7 +14,7 @@ interface DiscountCodeQueryResult {
   discount_categories: (DiscountCategoryInfo & { is_active: boolean }) | null
 }
 
-interface DiscountValidationResult {
+export interface DiscountValidationResult {
   isValid: boolean
   discountCodeId?: string // Discount code ID for easy access
   discountCode?: {

--- a/src/components/AlternateSelectionInterface.tsx
+++ b/src/components/AlternateSelectionInterface.tsx
@@ -46,9 +46,47 @@ interface Game {
   alternateAccountingCode: string
 }
 
+interface AlternatesSummary {
+  totalAlternates: number
+  availableAlternates: number
+  alreadySelected: number
+  withValidPayment: number
+  withDiscounts: number
+  overLimitDiscounts: number
+}
+
+/** Result of a single alternate selection, from POST /api/alternate-registrations/[gameId]/select. */
+export interface AlternateSelectionResult {
+  userId: string
+  userName: string
+  success: boolean
+  error?: string
+  paymentId?: string
+  amountCharged?: number
+}
+
+export interface AlternateSelectionResponse {
+  success: boolean
+  message: string
+  summary: {
+    totalProcessed: number
+    totalSelected: number
+    successfulSelections: number
+    failedSelections: number
+    totalAmountCharged: number
+    alreadySelected: number
+  }
+  results: AlternateSelectionResult[]
+  game: {
+    id: string
+    description: string
+    registrationName: string | undefined
+  }
+}
+
 interface AlternateSelectionInterfaceProps {
   gameId: string
-  onSelectionComplete: (results: any) => void
+  onSelectionComplete: (results: AlternateSelectionResponse) => void
   onCancel: () => void
 }
 
@@ -63,7 +101,7 @@ export default function AlternateSelectionInterface({
   const [loading, setLoading] = useState(true)
   const [processing, setProcessing] = useState(false)
   const [error, setError] = useState('')
-  const [summary, setSummary] = useState<any>(null)
+  const [summary, setSummary] = useState<AlternatesSummary | null>(null)
 
   useEffect(() => {
     fetchAlternates().catch(err => {

--- a/src/components/DeleteAccountSection.tsx
+++ b/src/components/DeleteAccountSection.tsx
@@ -54,9 +54,9 @@ export default function DeleteAccountSection({}: DeleteAccountSectionProps) {
         router.push('/auth/login')
       }, 2000)
 
-    } catch (error: any) {
+    } catch (error) {
       console.error('Account deletion error:', error)
-      showError('Account deletion failed', error.message || 'An error occurred while deleting your account')
+      showError('Account deletion failed', error instanceof Error ? error.message : 'An error occurred while deleting your account')
       setIsDeleting(false)
     }
   }

--- a/src/components/EditableRegistrationMembership.tsx
+++ b/src/components/EditableRegistrationMembership.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { createClient } from '@/lib/supabase/client'
+import type { Database } from '@/types/database'
 
 interface EditableRegistrationMembershipProps {
   registrationId: string
@@ -15,7 +16,7 @@ export default function EditableRegistrationMembership({
   const supabase = createClient()
   const [isEditing, setIsEditing] = useState(false)
   const [membershipId, setMembershipId] = useState(initialMembershipId || '')
-  const [availableMemberships, setAvailableMemberships] = useState<any[]>([])
+  const [availableMemberships, setAvailableMemberships] = useState<Pick<Database['public']['Tables']['memberships']['Row'], 'id' | 'name'>[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 

--- a/src/components/GameAlternatesCard.tsx
+++ b/src/components/GameAlternatesCard.tsx
@@ -5,6 +5,7 @@ import { formatDate, formatTime } from '@/lib/date-utils'
 
 import { AlternatesAccessResult } from '@/lib/utils/alternates-access'
 import { useToast } from '@/contexts/ToastContext'
+import type { AlternateSelectionResponse } from '@/components/AlternateSelectionInterface'
 
 interface Game {
   id: string
@@ -184,22 +185,22 @@ export default function GameAlternatesCard({
         throw new Error('Failed to select alternates')
       }
 
-      const data = await response.json()
-      
+      const data: AlternateSelectionResponse = await response.json()
+
       // Refresh alternates list to show updated selection status
       await fetchAlternates()
       setSelectedAlternates(new Set())
       setError('') // Clear any previous errors
-      
+
       // Handle results and show appropriate toasts
       if (data.results) {
-        const successful = data.results.filter((r: any) => r.success).length
-        const failed = data.results.filter((r: any) => !r.success).length
-        
+        const successful = data.results.filter((r) => r.success).length
+        const failed = data.results.filter((r) => !r.success).length
+
         if (failed > 0) {
           const failureDetails = data.results
-            .filter((r: any) => !r.success && r.error)
-            .map((r: any) => (r.userName ? `${r.userName}: ${r.error}` : r.error))
+            .filter((r) => !r.success && r.error)
+            .map((r) => (r.userName ? `${r.userName}: ${r.error}` : r.error))
             .join('\n')
           showError(
             `${successful} charged successfully, ${failed} failed`,

--- a/src/components/GameCreationForm.tsx
+++ b/src/components/GameCreationForm.tsx
@@ -5,9 +5,19 @@ import { convertToNYTimezone } from '@/lib/date-utils'
 import { useToast } from '@/contexts/ToastContext'
 import EventDateTimeInput from '@/components/EventDateTimeInput'
 
+export interface Game {
+  id: string
+  registrationId: string
+  gameDescription: string
+  gameDate: string | null
+  createdAt: string
+  selectedCount?: number
+  availableCount?: number
+}
+
 interface GameCreationFormProps {
   registrationId: string
-  onGameCreated: (game: any) => void
+  onGameCreated: (game: Game) => void
   onCancel: () => void
 }
 

--- a/src/components/GamesPreview.tsx
+++ b/src/components/GamesPreview.tsx
@@ -4,17 +4,7 @@ import { useState, useEffect } from 'react'
 import { formatDate as formatDateUtil } from '@/lib/date-utils'
 
 import Link from 'next/link'
-import GameCreationForm from '@/components/GameCreationForm'
-
-interface Game {
-  id: string
-  registrationId: string
-  gameDescription: string
-  gameDate: string | null
-  createdAt: string
-  selectedCount?: number
-  availableCount?: number
-}
+import GameCreationForm, { type Game } from '@/components/GameCreationForm'
 
 interface GamesPreviewProps {
   registrationId: string
@@ -48,7 +38,7 @@ export default function GamesPreview({ registrationId }: GamesPreviewProps) {
     }
   }
 
-  const handleGameCreated = (newGame: any) => {
+  const handleGameCreated = (newGame: Game) => {
     setGames(prev => [newGame, ...prev])
     setShowCreateForm(false)
   }

--- a/src/components/PasskeySetupBanner.tsx
+++ b/src/components/PasskeySetupBanner.tsx
@@ -86,7 +86,7 @@ export default function PasskeySetupBanner({ promptPrefs }: PasskeySetupBannerPr
 
       showSuccess('Passkey created!', 'You can now sign in with your passkey. Manage it from your account page.')
       setVisible(false)
-    } catch (error: any) {
+    } catch (error) {
       if (!isUserCancelledError(error)) {
         console.error('Passkey registration error:', error)
         showError('Passkey setup failed', 'Something went wrong. You can try again from your account page.')

--- a/src/components/PasskeysSection.tsx
+++ b/src/components/PasskeysSection.tsx
@@ -79,7 +79,7 @@ export default function PasskeysSection() {
 
       showSuccess('Passkey created!', 'You can now sign in with your passkey.')
       await loadPasskeys()
-    } catch (error: any) {
+    } catch (error) {
       if (!isUserCancelledError(error)) {
         console.error('Passkey registration error:', error)
         showError('Passkey setup failed', 'Something went wrong. Please try again.')

--- a/src/components/PaymentForm.tsx
+++ b/src/components/PaymentForm.tsx
@@ -119,12 +119,15 @@ export default function PaymentForm({
       const { error, paymentIntent } = await stripe.confirmPayment({
         elements,
         confirmParams: {
-          return_url: registrationId 
+          return_url: registrationId
             ? `${window.location.origin}/user/registrations`
             : `${window.location.origin}/user/memberships`,
         },
         redirect: 'if_required',
       })
+      // Stripe's types narrow paymentIntent to `never` in the error branch, but a decline
+      // can still return a payment intent alongside the error - capture the id before narrowing.
+      const confirmedPaymentIntentId = paymentIntent?.id
 
       // Update registration status to 'processing' with payment intent ID (for registrations only)
       if (!error && paymentIntent && registrationId && categoryId) {
@@ -192,7 +195,7 @@ export default function PaymentForm({
 
         // Update payment record status to 'failed' 
         // Use payment intent ID from either the error response or the prop passed from parent
-        const intentId = (paymentIntent as any)?.id || paymentIntentId
+        const intentId = confirmedPaymentIntentId || paymentIntentId
         
         if (intentId) {
           try {

--- a/src/components/PaymentMethodsSection.tsx
+++ b/src/components/PaymentMethodsSection.tsx
@@ -16,6 +16,15 @@ interface PaymentMethod {
   }
 }
 
+/** Shape returned by GET /api/user-alternate-registrations (only the fields this component reads). */
+interface AlternateRegistration {
+  registration?: {
+    season?: {
+      end_date: string | null
+    } | null
+  } | null
+}
+
 export default function PaymentMethodsSection() {
   const [paymentMethod, setPaymentMethod] = useState<PaymentMethod | null>(null)
   const [loading, setLoading] = useState(true)
@@ -24,7 +33,7 @@ export default function PaymentMethodsSection() {
   const [showUpdateModal, setShowUpdateModal] = useState(false)
   const [showManageModal, setShowManageModal] = useState(false)
   const [showConfirmDialog, setShowConfirmDialog] = useState(false)
-  const [alternateRegs, setAlternateRegs] = useState<any[]>([])
+  const [alternateRegs, setAlternateRegs] = useState<AlternateRegistration[]>([])
   const { showSuccess, showError } = useToast()
 
   const loadPaymentMethod = async (): Promise<PaymentMethod | null> => {

--- a/src/components/RegistrationCategoriesDndList.tsx
+++ b/src/components/RegistrationCategoriesDndList.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { useState } from "react"
-import { DndContext, closestCenter, PointerSensor, useSensor, useSensors } from "@dnd-kit/core"
+import { DndContext, closestCenter, PointerSensor, useSensor, useSensors, type DragEndEvent } from "@dnd-kit/core"
 import { arrayMove, SortableContext, verticalListSortingStrategy } from "@dnd-kit/sortable"
 import {SortableItem} from "./SortableItem"
 
@@ -35,7 +35,7 @@ export default function RegistrationCategoriesDndList({ categories, registration
     useSensor(PointerSensor)
   )
 
-  const handleDragEnd = async (event: any) => {
+  const handleDragEnd = async (event: DragEndEvent) => {
     const { active, over } = event
     if (!over || active.id === over.id) return
     const oldIndex = items.findIndex((item) => item.id === active.id)

--- a/src/components/RegistrationPurchase.tsx
+++ b/src/components/RegistrationPurchase.tsx
@@ -10,12 +10,13 @@ import PaymentForm from './PaymentForm'
 import PaymentMethodSetup from './PaymentMethodSetup'
 import PaymentMethodNotice from './PaymentMethodNotice'
 import SavedPaymentConfirmation from './SavedPaymentConfirmation'
-import TallySurveyEmbed from './TallySurveyEmbed'
+import TallySurveyEmbed, { type TallySubmissionPayload } from './TallySurveyEmbed'
 import { useToast } from '@/contexts/ToastContext'
 import { getCategoryDisplayName } from '@/lib/registration-utils'
 import { validateMembershipCoverage, formatMembershipWarning } from '@/lib/membership-validation'
 import { RegistrationValidationService, type UserMembership } from '@/lib/services/registration-validation-service'
-import { getRegistrationStatus, isRegistrationAvailable } from '@/lib/registration-status'
+import { getRegistrationStatus, isRegistrationAvailable, type RegistrationWithTiming } from '@/lib/registration-status'
+import type { DiscountValidationResult } from '@/app/api/validate-discount-code/route'
 import WaitlistBadge from './WaitlistBadge'
 
 // Force import client config
@@ -34,7 +35,7 @@ function formatDateString(dateString: string): string {
 
 interface RegistrationCategory {
   id: string
-  custom_name?: string | null
+  custom_name: string | null
   max_capacity?: number | null
   current_count?: number
   required_membership_id?: string | null
@@ -47,15 +48,12 @@ interface RegistrationCategory {
   } | null
 }
 
-interface Registration {
-  id: string
+interface Registration extends RegistrationWithTiming {
   name: string
-  type: string
   alternate_price?: number | null
   alternate_accounting_code?: string | null
   allow_alternates?: boolean
   allow_lgbtq_presale?: boolean
-  presale_code?: string | null
   allow_discounts?: boolean
   survey_id?: string | null
   require_survey?: boolean
@@ -113,7 +111,7 @@ export default function RegistrationPurchase({
   const [error, setError] = useState<string | null>(null)
   const [presaleCode, setPresaleCode] = useState<string>('')
   const [discountCode, setDiscountCode] = useState<string>('')
-  const [discountValidation, setDiscountValidation] = useState<any>(null)
+  const [discountValidation, setDiscountValidation] = useState<DiscountValidationResult | null>(null)
   const [isValidatingDiscount, setIsValidatingDiscount] = useState(false)
   const [userWaitlistEntries, setUserWaitlistEntries] = useState<Record<string, { position: number, id: string }>>({})
   const [reservationExpiresAt, setReservationExpiresAt] = useState<string | null>(null)
@@ -123,7 +121,7 @@ export default function RegistrationPurchase({
   const [paymentPlanEligible, setPaymentPlanEligible] = useState(false)
   const [paymentPlanEnabled, setPaymentPlanEnabled] = useState(false)
   const [firstInstallmentAmount, setFirstInstallmentAmount] = useState<number | null>(null)
-  const [, setSurveyResponses] = useState<Record<string, any> | null>(null)
+  const [, setSurveyResponses] = useState<TallySubmissionPayload | null>(null)
   const [, setShowSurvey] = useState(false)
   const [surveyCompleted, setSurveyCompleted] = useState(false)
   const [surveyStarted, setSurveyStarted] = useState(false)
@@ -266,19 +264,19 @@ export default function RegistrationPurchase({
   
   // Get pricing for selected category
   const originalAmount = selectedCategory?.price ?? 0
-  const discountAmount = discountValidation?.isValid ? discountValidation.discountAmount : 0
+  const discountAmount = discountValidation?.isValid ? (discountValidation.discountAmount ?? 0) : 0
   const finalAmount = originalAmount - discountAmount
 
   // Calculate the amount to charge: first installment for payment plan, or full amount
   const amountToCharge = usePaymentPlan && firstInstallmentAmount ? firstInstallmentAmount : finalAmount
   
   // Check registration timing status
-  const registrationStatus = getRegistrationStatus(registration as any)
+  const registrationStatus = getRegistrationStatus(registration)
   const isPresale = registrationStatus === 'presale'
   const isLgbtqPresaleEligible = isPresale && isLgbtq && registration.allow_lgbtq_presale
   const hasValidPresaleCode = isPresale && 
     presaleCode.trim().toUpperCase() === registration.presale_code?.toUpperCase()
-  const isTimingAvailable = isRegistrationAvailable(registration as any, hasValidPresaleCode || isLgbtqPresaleEligible)
+  const isTimingAvailable = isRegistrationAvailable(registration, hasValidPresaleCode || isLgbtqPresaleEligible)
   
   // Check if selected category is at capacity
   const isCategoryAtCapacity = selectedCategory?.max_capacity !== null && selectedCategory?.max_capacity !== undefined
@@ -372,7 +370,7 @@ export default function RegistrationPurchase({
   }, [selectedCategoryId, registration.require_survey, registration.survey_id])
 
   // Handle survey completion
-  const handleSurveyComplete = (responseData: any) => {
+  const handleSurveyComplete = (responseData: TallySubmissionPayload | null) => {
     console.log('Survey completed with data:', responseData)
     setSurveyResponses(responseData)
     setSurveyCompleted(true)
@@ -788,7 +786,7 @@ export default function RegistrationPurchase({
           </label>
           <div className="grid grid-cols-1 gap-2">
             {categories.map((category) => {
-              const categoryName = getCategoryDisplayName(category as any)
+              const categoryName = getCategoryDisplayName(category)
               const requiresMembership = registration.required_membership_id || category.required_membership_id
               
               // Use the proper validation service to check BOTH registration and category level memberships
@@ -926,7 +924,7 @@ export default function RegistrationPurchase({
           <h4 className="text-sm font-medium text-gray-900 mb-3">Select Registration Category</h4>
           <div className="space-y-2">
             {categories.map((category) => {
-              const categoryName = getCategoryDisplayName(category as any)
+              const categoryName = getCategoryDisplayName(category)
               const requiresMembership = registration.required_membership_id || category.required_membership_id
 
               // Use the proper validation service to check BOTH registration and category level memberships
@@ -1074,7 +1072,7 @@ export default function RegistrationPurchase({
             </div>
             <div className="flex justify-between">
               <span className="text-gray-600">Category:</span>
-              <span className="text-gray-900">{getCategoryDisplayName(selectedCategory as any)}</span>
+              <span className="text-gray-900">{getCategoryDisplayName(selectedCategory)}</span>
             </div>
             {registration.season && (
               <div className="flex justify-between">
@@ -1091,7 +1089,7 @@ export default function RegistrationPurchase({
                   <span className="text-gray-900">${(originalAmount / 100).toFixed(2)}</span>
                 </div>
                 <div className="flex justify-between text-green-600">
-                  <span>Discount ({discountValidation.discountCode.code}):</span>
+                  <span>Discount ({discountValidation.discountCode?.code}):</span>
                   <span>-${(discountAmount / 100).toFixed(2)}</span>
                 </div>
                 <div className="flex justify-between border-t pt-2 font-medium">
@@ -1262,7 +1260,7 @@ export default function RegistrationPurchase({
               userId={userId}
               firstName={firstName}
               lastName={lastName}
-              registrationCategory={selectedCategory ? getCategoryDisplayName(selectedCategory as any) : 'Unknown'}
+              registrationCategory={selectedCategory ? getCategoryDisplayName(selectedCategory) : 'Unknown'}
               onComplete={handleSurveyComplete}
               onClose={handleSurveyClose}
               onError={(error) => setError(`Survey error: ${error}`)}
@@ -1322,14 +1320,14 @@ export default function RegistrationPurchase({
                         discountValidation.partialDiscountMessage
                       ) : (
                         <>
-                          {discountValidation.discountCode.percentage}% discount applied! 
-                          Save ${(discountValidation.discountAmount / 100).toFixed(2)}
+                          {discountValidation.discountCode?.percentage}% discount applied!
+                          Save ${((discountValidation.discountAmount ?? 0) / 100).toFixed(2)}
                         </>
                       )}
                     </div>
                     {!discountValidation.isPartialDiscount && (
                       <div className="text-xs">
-                        {discountValidation.discountCode.category.name}
+                        {discountValidation.discountCode?.category.name}
                       </div>
                     )}
                   </div>
@@ -1610,7 +1608,7 @@ export default function RegistrationPurchase({
             </div>
             
             <div className="mb-4 p-3 bg-gray-50 rounded">
-              <div className="text-sm text-gray-600">{registration.name} - {selectedCategory ? getCategoryDisplayName(selectedCategory as any) : ''}</div>
+              <div className="text-sm text-gray-600">{registration.name} - {selectedCategory ? getCategoryDisplayName(selectedCategory) : ''}</div>
               
               {/* Pricing Breakdown */}
               {discountValidation?.isValid ? (
@@ -1620,7 +1618,7 @@ export default function RegistrationPurchase({
                     <span>${(originalAmount / 100).toFixed(2)}</span>
                   </div>
                   <div className="flex justify-between text-sm text-green-600">
-                    <span>Discount ({discountValidation.discountCode.code}):</span>
+                    <span>Discount ({discountValidation.discountCode?.code}):</span>
                     <span>-${(discountAmount / 100).toFixed(2)}</span>
                   </div>
                   <div className="border-t pt-1 flex justify-between font-medium text-gray-900">
@@ -1720,7 +1718,7 @@ export default function RegistrationPurchase({
                 discountAmount={discountAmount}
                 discountCode={discountValidation?.isValid ? discountCode : undefined}
                 registrationName={registration.name}
-                categoryName={selectedCategory ? getCategoryDisplayName(selectedCategory as any) : ''}
+                categoryName={selectedCategory ? getCategoryDisplayName(selectedCategory) : ''}
                 seasonName={registration.season?.name}
                 reservationExpiresAt={reservationExpiresAt || undefined}
                 onTimerExpired={handleTimerExpired}

--- a/src/components/RegistrationsList.tsx
+++ b/src/components/RegistrationsList.tsx
@@ -2,25 +2,16 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
-import { getRegistrationStatus, getStatusDisplayText, getStatusBadgeStyle } from '@/lib/registration-status'
+import { getRegistrationStatus, getStatusDisplayText, getStatusBadgeStyle, type RegistrationWithTiming } from '@/lib/registration-status'
 import RegistrationTypeBadge from '@/components/RegistrationTypeBadge'
 import { formatEventDateTime } from '@/lib/date-utils'
 import ConfirmationDialog from '@/components/ConfirmationDialog'
 
-interface Registration {
-  id: string
+interface Registration extends RegistrationWithTiming {
   name: string
-  type: string
-  is_active: boolean
-  published_at?: string | null
+  published_at: string | null
   allow_discounts: boolean
-  presale_code: string | null
-  presale_start_at?: string | null
-  regular_start_at?: string | null
-  registration_end_at?: string | null
   created_at: string
-  start_date?: string | null
-  end_date?: string | null
   seasons?: {
     name: string
   }
@@ -91,7 +82,7 @@ function RegistrationItem({
   registration: Registration
   onDeleteClick: (id: string, name: string) => void
 }) {
-  const status = getRegistrationStatus(registration as any)
+  const status = getRegistrationStatus(registration)
 
   return (
     <li>
@@ -160,19 +151,19 @@ export default function RegistrationsList({ registrations }: RegistrationsListPr
 
   // Group registrations by status
   const activeRegistrations = regs.filter(reg => {
-    const status = getRegistrationStatus(reg as any)
+    const status = getRegistrationStatus(reg)
     return status === 'open' || status === 'presale'
   })
 
   const comingSoonRegistrations = regs.filter(reg => {
-    const status = getRegistrationStatus(reg as any)
+    const status = getRegistrationStatus(reg)
     return status === 'coming_soon'
   })
 
   const draftRegistrations = regs.filter(reg => !reg.is_active)
 
   const closedRegistrations = regs.filter(reg => {
-    const status = getRegistrationStatus(reg as any)
+    const status = getRegistrationStatus(reg)
     return status === 'expired' || status === 'past'
   })
 

--- a/src/components/SignOutButton.tsx
+++ b/src/components/SignOutButton.tsx
@@ -24,7 +24,7 @@ export default function SignOutButton() {
         showSuccess('Signed out successfully', 'You have been signed out of your account')
         router.push('/auth/login')
       }
-    } catch (error: any) {
+    } catch (error) {
       console.error('Sign out error:', error)
       showError('Sign out failed', 'An error occurred while signing out')
       setIsSigningOut(false)

--- a/src/components/SystemCategoriesDndList.tsx
+++ b/src/components/SystemCategoriesDndList.tsx
@@ -6,6 +6,7 @@ import { formatDate } from '@/lib/date-utils'
 import {
   DndContext,
   closestCenter,
+  type DragEndEvent,
 } from '@dnd-kit/core'
 import {
   arrayMove,
@@ -22,7 +23,6 @@ export interface Category {
   description?: string
   created_at: string
   sort_order?: number
-  [key: string]: any
 }
 
 interface SystemCategoriesDndListProps {
@@ -46,11 +46,11 @@ export default function SystemCategoriesDndList({ categories }: SystemCategories
     })
   }, [categories])
 
-  const handleDragEnd = async (event: any) => {
+  const handleDragEnd = async (event: DragEndEvent) => {
     const { active, over } = event
-    if (active.id !== over?.id) {
-      const oldIndex = items.indexOf(active.id)
-      const newIndex = items.indexOf(over.id)
+    if (over && active.id !== over.id) {
+      const oldIndex = items.indexOf(String(active.id))
+      const newIndex = items.indexOf(String(over.id))
       const newItems = arrayMove(items, oldIndex, newIndex)
       setItems(newItems)
 

--- a/src/components/TallySurveyEmbed.tsx
+++ b/src/components/TallySurveyEmbed.tsx
@@ -2,6 +2,34 @@
 
 import React, { useEffect, useState, useRef } from 'react'
 
+/** Payload passed to Tally's onSubmit handler; Tally does not publish TS types. */
+export interface TallySubmissionPayload {
+  respondentId?: string
+  formId?: string
+  formName?: string
+  [key: string]: unknown
+}
+
+interface TallyPopupOptions {
+  layout: string
+  width: number
+  autoClose: number
+  emoji: { text: string; animation: string }
+  hiddenFields: Record<string, string>
+  onOpen: () => void
+  onClose: () => void
+  onSubmit: (payload: TallySubmissionPayload) => void
+}
+
+declare global {
+  interface Window {
+    Tally?: {
+      openPopup: (formId: string, options: TallyPopupOptions) => void
+      closePopup: (formId: string) => void
+    }
+  }
+}
+
 interface TallySurveyEmbedProps {
   surveyId: string                    // e.g., "VLzWBv"
   userEmail: string                   // from users table
@@ -12,7 +40,7 @@ interface TallySurveyEmbedProps {
   memberNumber?: string               // member_id (e.g., "1002") - optional
   
   // Component behavior
-  onComplete?: (responseData: any) => void
+  onComplete?: (responseData: TallySubmissionPayload | null) => void
   onClose?: () => void
   onError?: (error: string) => void
 }
@@ -75,7 +103,7 @@ export default function TallySurveyEmbed({
   }
 
   // Store survey response in database
-  const storeSurveyResponse = async (responseData: any) => {
+  const storeSurveyResponse = async (responseData: TallySubmissionPayload) => {
     try {
       const response = await fetch('/api/user-survey-responses', {
         method: 'POST',
@@ -112,7 +140,7 @@ export default function TallySurveyEmbed({
 
         // Use Tally popup API for both desktop and mobile
         // Mobile gets full-screen appearance via CSS overrides in globals.css
-        if (typeof window !== 'undefined' && !(window as any).Tally) {
+        if (typeof window !== 'undefined' && !window.Tally) {
           console.log('Loading Tally embed script...')
           const script = document.createElement('script')
           script.src = 'https://tally.so/widgets/embed.js'
@@ -176,7 +204,7 @@ export default function TallySurveyEmbed({
             setSurveyOpened(false)
             onCloseRef.current?.()
           },
-          onSubmit: async (payload: any) => {
+          onSubmit: async (payload: TallySubmissionPayload) => {
             console.log('Survey submitted:', payload)
             setSurveyCompleted(true)
             setSurveyOpened(false)
@@ -185,7 +213,7 @@ export default function TallySurveyEmbed({
           }
         }
 
-        ;(window as any).Tally.openPopup(surveyId, popupOptions)
+        window.Tally?.openPopup(surveyId, popupOptions)
 
       } catch (err) {
         console.error('Error opening Tally popup:', err)
@@ -202,8 +230,8 @@ export default function TallySurveyEmbed({
 
     // Cleanup function
     return () => {
-      if (surveyOpened && (window as any).Tally?.closePopup) {
-        (window as any).Tally.closePopup(surveyId)
+      if (surveyOpened && window.Tally?.closePopup) {
+        window.Tally.closePopup(surveyId)
       }
     }
   }, [surveyId, userEmail, userId, firstName, lastName, registrationCategory, memberNumber])

--- a/src/components/admin/LogViewer.tsx
+++ b/src/components/admin/LogViewer.tsx
@@ -15,8 +15,14 @@ interface LogFilters {
   limit: number
 }
 
+/** A row from email_logs, email_change_logs, or xero_sync_logs — fields vary by table. */
+interface LogRecord {
+  id: string
+  [key: string]: unknown
+}
+
 interface LogResponse {
-  logs: any[]
+  logs: LogRecord[]
   logType: LogType
   total: number
   limit: number
@@ -24,7 +30,7 @@ interface LogResponse {
 }
 
 export default function LogViewer() {
-  const [logs, setLogs] = useState<any[]>([])
+  const [logs, setLogs] = useState<LogRecord[]>([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
   const [searchTerm, setSearchTerm] = useState('')
@@ -95,7 +101,7 @@ export default function LogViewer() {
   }
 
   // Render field value with appropriate formatting
-  const renderFieldValue = (key: string, value: any) => {
+  const renderFieldValue = (key: string, value: unknown) => {
     // Null/undefined
     if (value === null || value === undefined) {
       return <span className="text-gray-400 italic">null</span>
@@ -111,7 +117,7 @@ export default function LogViewer() {
     }
 
     // Date/timestamp fields
-    if (key.includes('_at') || key.includes('_date')) {
+    if ((key.includes('_at') || key.includes('_date')) && (typeof value === 'string' || typeof value === 'number')) {
       try {
         const date = new Date(value)
         if (!isNaN(date.getTime())) {
@@ -141,7 +147,7 @@ export default function LogViewer() {
     }
 
     // Status fields - color-coded
-    if (key === 'status') {
+    if (key === 'status' && typeof value === 'string') {
       const statusColors: Record<string, string> = {
         'success': 'bg-green-100 text-green-800 border-green-200',
         'sent': 'bg-green-100 text-green-800 border-green-200',
@@ -166,7 +172,7 @@ export default function LogViewer() {
   }
 
   // Get displayable fields (exclude internal/redundant fields)
-  const getDisplayFields = (log: any) => {
+  const getDisplayFields = (log: LogRecord) => {
     const excludeFields = ['id']
     return Object.keys(log).filter(key => !excludeFields.includes(key))
   }

--- a/src/lib/registration-utils.ts
+++ b/src/lib/registration-utils.ts
@@ -49,7 +49,10 @@ export interface Registration {
 /**
  * Get display name for a registration category
  */
-export function getCategoryDisplayName(category: RegistrationCategory): string {
+export function getCategoryDisplayName(category: {
+  custom_name: string | null
+  categories?: { name: string } | null
+}): string {
   return category.categories?.name || category.custom_name || 'Unknown Category'
 }
 


### PR DESCRIPTION
## Summary
- Replaces all 44 `@typescript-eslint/no-explicit-any` errors across the 17 files listed in #206 with real types, part of #197.
- Reuses shared types where a route/query already defines the shape it needs (`AlternateSelectionResponse` from the alternates `/select` route, `DiscountValidationResult` from `/api/validate-discount-code`, `RegistrationWithTiming` for `getRegistrationStatus`/`isRegistrationAvailable`, `TallySubmissionPayload` for the Tally embed's global/callback), `Pick<Database[...]>` for simple Supabase selects, and local interfaces matching actual usage where no shared type exists (`LogViewer`'s heterogeneous log rows, `PaymentMethodsSection`'s alternate-registration summary).
- Narrowed `getCategoryDisplayName`'s parameter to the two fields it actually reads, since `RegistrationPurchase`'s local category type couldn't satisfy the full `RegistrationCategory` shape without widening unrelated fields.
- Typed dnd-kit's `onDragEnd` handlers with `DragEndEvent` instead of `any`, which surfaced two real (previously `any`-masked) gaps in `SystemCategoriesDndList`: no null check on `over`, and comparing a `UniqueIdentifier` to `string` without coercion.
- Consolidated a few duplicate local type definitions between components and their callers along the way (`Game` between `GameCreationForm`/`GamesPreview`, `AlternateSelectionResult`/`Response` between `AlternateSelectionInterface` and its admin page caller).

## Test plan
- [x] `npm run lint` — 0 `no-explicit-any` errors remain in `src/components`; total error/warning count dropped from 145 to 101 lines (exactly the 44 removed errors); no new errors/warnings in touched files (pre-existing `react-hooks/exhaustive-deps` warnings untouched).
- [x] `npm test` — 292/292 tests pass.
- [x] `npm run build` — compiles successfully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)