### PR TITLE
Fix #207: remove no-explicit-any from src/__tests__ (44 errors, 17 files)

### DIFF
--- a/src/__tests__/api/admin/discount-allowances.test.ts
+++ b/src/__tests__/api/admin/discount-allowances.test.ts
@@ -28,9 +28,18 @@ import {
 } from '@/lib/services/discount-limit-service'
 import { NextRequest } from 'next/server'
 
+type MockSupabaseClient = {
+  auth: { getUser: jest.Mock }
+  from: jest.Mock
+}
+
+type MockAdminSupabaseClient = {
+  from: jest.Mock
+}
+
 describe('/api/admin/users/[id]/discount-allowances', () => {
-  let mockSupabase: any
-  let mockAdminSupabase: any
+  let mockSupabase: MockSupabaseClient
+  let mockAdminSupabase: MockAdminSupabaseClient
 
   beforeEach(() => {
     jest.clearAllMocks()

--- a/src/__tests__/api/admin/discount-codes-allowance-ui.test.ts
+++ b/src/__tests__/api/admin/discount-codes-allowance-ui.test.ts
@@ -2,7 +2,12 @@ import { PUT } from '@/app/api/admin/discount-codes/[id]/route'
 import { NextRequest } from 'next/server'
 
 // Mock Supabase Server Client
-const mockSupabase: any = {
+type MockSupabaseClient = {
+  auth: { getUser: jest.Mock }
+  from: jest.Mock
+}
+
+const mockSupabase: MockSupabaseClient = {
   auth: {
     getUser: jest.fn()
   },

--- a/src/__tests__/api/admin/discount-eligibility-report.test.ts
+++ b/src/__tests__/api/admin/discount-eligibility-report.test.ts
@@ -20,8 +20,21 @@ import {
 } from '@/lib/services/discount-limit-service'
 import { NextRequest } from 'next/server'
 
+type MockSupabaseClient = {
+  auth: { getUser: jest.Mock }
+  from: jest.Mock
+}
+
+interface EligibilityRow {
+  userId: string
+  totalUsed: number
+  remaining: number
+  source: string
+  isRevoked: boolean
+}
+
 describe('/api/admin/reports/discount-eligibility', () => {
-  let mockSupabase: any
+  let mockSupabase: MockSupabaseClient
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -144,23 +157,23 @@ describe('/api/admin/reports/discount-eligibility', () => {
     const res = await GET(req)
 
     expect(res.status).toBe(200)
-    const data = await res.json()
+    const data = await res.json() as { eligibility: EligibilityRow[] }
 
     expect(data.eligibility).toHaveLength(2)
 
     // Check user with zero usage
-    const activeRow = data.eligibility.find((r: any) => r.userId === 'user-zero-usage')
+    const activeRow = data.eligibility.find((r) => r.userId === 'user-zero-usage')
     expect(activeRow).toBeDefined()
-    expect(activeRow.totalUsed).toBe(0)
-    expect(activeRow.remaining).toBe(25000)
-    expect(activeRow.source).toBe('user_allowance')
-    expect(activeRow.isRevoked).toBe(false)
+    expect(activeRow!.totalUsed).toBe(0)
+    expect(activeRow!.remaining).toBe(25000)
+    expect(activeRow!.source).toBe('user_allowance')
+    expect(activeRow!.isRevoked).toBe(false)
 
     // Check revoked user
-    const revokedRow = data.eligibility.find((r: any) => r.userId === 'user-revoked')
+    const revokedRow = data.eligibility.find((r) => r.userId === 'user-revoked')
     expect(revokedRow).toBeDefined()
-    expect(revokedRow.remaining).toBe(0)
-    expect(revokedRow.source).toBe('denied')
-    expect(revokedRow.isRevoked).toBe(true)
+    expect(revokedRow!.remaining).toBe(0)
+    expect(revokedRow!.source).toBe('denied')
+    expect(revokedRow!.isRevoked).toBe(true)
   })
 })

--- a/src/__tests__/api/admin/registrations/alternates.test.ts
+++ b/src/__tests__/api/admin/registrations/alternates.test.ts
@@ -2,18 +2,16 @@
 import { PUT } from '@/app/api/admin/registrations/[id]/alternates/route'
 import { NextRequest } from 'next/server'
 
-// Jest globals are available, but we need to declare them for TypeScript
-declare const jest: any
-declare const describe: any
-declare const it: any
-declare const expect: any
-declare const beforeEach: any
-
 // Mock dependencies
 jest.mock('@/lib/supabase/server')
 jest.mock('@/lib/logging/logger')
 
-const mockSupabase = {
+type MockSupabaseClient = {
+  auth: { getUser: jest.Mock }
+  from: jest.Mock
+}
+
+const mockSupabase: MockSupabaseClient = {
   auth: {
     getUser: jest.fn()
   },

--- a/src/__tests__/api/alternate-registrations/alternates-ineligible.test.ts
+++ b/src/__tests__/api/alternate-registrations/alternates-ineligible.test.ts
@@ -32,9 +32,18 @@ import {
 } from '@/lib/services/discount-limit-service'
 import { NextRequest } from 'next/server'
 
+type MockSupabaseClient = {
+  auth: { getUser: jest.Mock }
+  from: jest.Mock
+}
+
+type MockAdminSupabaseClient = {
+  from: jest.Mock
+}
+
 describe('/api/alternate-registrations/[gameId]/alternates ineligible vs over-limit separation', () => {
-  let mockSupabase: any
-  let mockAdminSupabase: any
+  let mockSupabase: MockSupabaseClient
+  let mockAdminSupabase: MockAdminSupabaseClient
 
   beforeEach(() => {
     jest.clearAllMocks()

--- a/src/__tests__/api/user-alternate-registrations.test.ts
+++ b/src/__tests__/api/user-alternate-registrations.test.ts
@@ -2,19 +2,17 @@
 import { POST, GET } from '@/app/api/user-alternate-registrations/route'
 import { NextRequest } from 'next/server'
 
-// Jest globals are available, but we need to declare them for TypeScript
-declare const jest: any
-declare const describe: any
-declare const it: any
-declare const expect: any
-declare const beforeEach: any
-
 // Mock dependencies
 jest.mock('@/lib/supabase/server')
 jest.mock('@/lib/services/setup-intent-service')
 jest.mock('@/lib/logging/logger')
 
-const mockSupabase = {
+type MockSupabaseClient = {
+  auth: { getUser: jest.Mock }
+  from: jest.Mock
+}
+
+const mockSupabase: MockSupabaseClient = {
   auth: {
     getUser: jest.fn()
   },

--- a/src/__tests__/api/validate-discount-code.test.ts
+++ b/src/__tests__/api/validate-discount-code.test.ts
@@ -17,7 +17,12 @@ jest.mock('@/lib/services/discount-limit-service', () => {
   }
 })
 
-const mockSupabase: any = {
+type MockSupabaseClient = {
+  auth: { getUser: jest.Mock }
+  from: jest.Mock
+}
+
+const mockSupabase: MockSupabaseClient = {
   auth: {
     getUser: jest.fn()
   },

--- a/src/__tests__/api/xero/auth.test.ts
+++ b/src/__tests__/api/xero/auth.test.ts
@@ -15,7 +15,12 @@ jest.mock('@/lib/xero/client', () => ({
   createXeroOAuthClient: jest.fn()
 }))
 
-const mockSupabase: any = {
+type MockSupabaseClient = {
+  auth: { getUser: jest.Mock }
+  from: jest.Mock
+}
+
+const mockSupabase: MockSupabaseClient = {
   auth: {
     getUser: jest.fn()
   },

--- a/src/__tests__/api/xero/callback.test.ts
+++ b/src/__tests__/api/xero/callback.test.ts
@@ -17,18 +17,36 @@ jest.mock('@/lib/xero/client', () => ({
   revokeXeroTokens: jest.fn().mockResolvedValue(true)
 }))
 
-function makeQueryBuilder(result: any = { data: null, error: null }) {
-  const builder: any = {}
+interface QueryResult {
+  data: unknown
+  error: unknown
+}
+
+interface MockQueryBuilder {
+  select: jest.Mock
+  update: jest.Mock
+  eq: jest.Mock
+  single: jest.Mock
+  insert: jest.Mock
+  then: Promise<QueryResult>['then']
+}
+
+function makeQueryBuilder(result: QueryResult = { data: null, error: null }): MockQueryBuilder {
+  const builder = {} as MockQueryBuilder
   builder.select = jest.fn(() => builder)
   builder.update = jest.fn(() => builder)
   builder.eq = jest.fn(() => builder)
   builder.single = jest.fn(() => Promise.resolve(result))
   builder.insert = jest.fn(() => Promise.resolve(result))
-  builder.then = (onFulfilled: any, onRejected: any) => Promise.resolve(result).then(onFulfilled, onRejected)
+  builder.then = (onFulfilled, onRejected) => Promise.resolve(result).then(onFulfilled, onRejected)
   return builder
 }
 
-const mockSupabase: any = {
+type MockSupabaseClient = {
+  from: jest.Mock
+}
+
+const mockSupabase: MockSupabaseClient = {
   from: jest.fn(() => makeQueryBuilder())
 }
 

--- a/src/__tests__/integration/cross-path-discount-consistency.test.ts
+++ b/src/__tests__/integration/cross-path-discount-consistency.test.ts
@@ -8,9 +8,17 @@
 import { GET } from '@/app/api/alternate-registrations/[gameId]/alternates/route'
 import { AlternatePaymentService } from '@/lib/services/alternate-payment-service'
 import { NextRequest } from 'next/server'
+import { SupabaseClient } from '@supabase/supabase-js'
 
 // Mock Supabase Server Clients
-const mockSupabase: any = {
+type MockSupabaseClient = {
+  auth: { getUser: jest.Mock }
+  from: jest.Mock
+}
+
+type SelectWithEq = Promise<{ data: unknown; error: unknown }> & { eq: jest.Mock }
+
+const mockSupabase: MockSupabaseClient = {
   auth: {
     getUser: jest.fn()
   },
@@ -179,7 +187,7 @@ describe('Cross-Path Discount Consistency (Alternates List vs Alternate Charge)'
           requires_user_allowance: false,
           default_percentage: 50
         }
-        const selectObj: any = Promise.resolve({ data: [catData], error: null })
+        const selectObj = Promise.resolve({ data: [catData], error: null }) as SelectWithEq
         selectObj.eq = jest.fn().mockReturnValue({
           single: jest.fn().mockResolvedValue({
             data: catData,
@@ -298,7 +306,7 @@ describe('Cross-Path Discount Consistency (Alternates List vs Alternate Charge)'
 
     // Path B: AlternatePaymentService charge calculation
     const chargeResult = await AlternatePaymentService.calculateChargeAmount(
-      mockSupabase,
+      mockSupabase as unknown as SupabaseClient,
       registrationId,
       seasonId,
       discountCodeId,
@@ -433,7 +441,7 @@ describe('Cross-Path Discount Consistency (Alternates List vs Alternate Charge)'
           requires_user_allowance: true,
           default_percentage: 50
         }
-        const selectObj: any = Promise.resolve({ data: [catData], error: null })
+        const selectObj = Promise.resolve({ data: [catData], error: null }) as SelectWithEq
         selectObj.eq = jest.fn().mockReturnValue({
           single: jest.fn().mockResolvedValue({
             data: catData,
@@ -553,7 +561,7 @@ describe('Cross-Path Discount Consistency (Alternates List vs Alternate Charge)'
 
     // Path B: AlternatePaymentService charge calculation
     const chargeResult = await AlternatePaymentService.calculateChargeAmount(
-      mockSupabase,
+      mockSupabase as unknown as SupabaseClient,
       registrationId,
       seasonId,
       discountCodeId,
@@ -688,7 +696,7 @@ describe('Cross-Path Discount Consistency (Alternates List vs Alternate Charge)'
           requires_user_allowance: true,
           default_percentage: 50
         }
-        const selectObj: any = Promise.resolve({ data: [catData], error: null })
+        const selectObj = Promise.resolve({ data: [catData], error: null }) as SelectWithEq
         selectObj.eq = jest.fn().mockReturnValue({
           single: jest.fn().mockResolvedValue({
             data: catData,
@@ -785,7 +793,7 @@ describe('Cross-Path Discount Consistency (Alternates List vs Alternate Charge)'
 
     // Path B: AlternatePaymentService charge calculation
     const chargeResult = await AlternatePaymentService.calculateChargeAmount(
-      mockSupabase,
+      mockSupabase as unknown as SupabaseClient,
       registrationId,
       seasonId,
       discountCodeId,

--- a/src/__tests__/integration/report-consistency.test.ts
+++ b/src/__tests__/integration/report-consistency.test.ts
@@ -16,11 +16,30 @@ import { GET as getEligibilityReport } from '@/app/api/admin/reports/discount-el
 import { NextRequest } from 'next/server'
 
 // Mock Supabase Server Clients - Real discount-limit-service runs against this mocked client
-const mockSupabase: any = {
+type MockSupabaseClient = {
+  auth: { getUser: jest.Mock }
+  from: jest.Mock
+}
+
+const mockSupabase: MockSupabaseClient = {
   auth: {
     getUser: jest.fn()
   },
   from: jest.fn()
+}
+
+interface UsageReportData {
+  seasons: {
+    seasonId: string
+    categories: {
+      categoryId: string
+      users: { userId: string; totalAmount: number; remaining: number }[]
+    }[]
+  }[]
+}
+
+interface EligibilityReportData {
+  eligibility: { userId: string; categoryId: string; totalUsed: number; remaining: number }[]
 }
 
 jest.mock('@/lib/supabase/server', () => ({
@@ -210,32 +229,32 @@ describe('Report Consistency Integration (End-to-End Resolution)', () => {
     const reqUsage = new NextRequest('http://localhost/api/admin/reports/discount-usage')
     const resUsage = await getUsageReport(reqUsage)
     expect(resUsage.status).toBe(200)
-    const usageData = await resUsage.json()
+    const usageData = await resUsage.json() as UsageReportData
 
     // 2. Call Eligibility Report GET
     const reqEligibility = new NextRequest(`http://localhost/api/admin/reports/discount-eligibility?seasonId=${seasonId}`)
     const resEligibility = await getEligibilityReport(reqEligibility)
     expect(resEligibility.status).toBe(200)
-    const eligibilityData = await resEligibility.json()
+    const eligibilityData = await resEligibility.json() as EligibilityReportData
 
     // Extract user record from Usage Report
-    const seasonUsage = usageData.seasons.find((s: any) => s.seasonId === seasonId)
-    const catUsage = seasonUsage.categories.find((c: any) => c.categoryId === categoryId)
-    const userUsage = catUsage.users.find((u: any) => u.userId === userId)
+    const seasonUsage = usageData.seasons.find((s) => s.seasonId === seasonId)
+    const catUsage = seasonUsage!.categories.find((c) => c.categoryId === categoryId)
+    const userUsage = catUsage!.users.find((u) => u.userId === userId)
 
     // Extract user record from Eligibility Report
-    const userEligibility = eligibilityData.eligibility.find((e: any) => e.userId === userId && e.categoryId === categoryId)
+    const userEligibility = eligibilityData.eligibility.find((e) => e.userId === userId && e.categoryId === categoryId)
 
     // Verify both reports read the $100 total used
-    expect(userUsage.totalAmount).toBe(10000)
-    expect(userEligibility.totalUsed).toBe(10000)
+    expect(userUsage!.totalAmount).toBe(10000)
+    expect(userEligibility!.totalUsed).toBe(10000)
 
     // VERIFY NON-TAUTOLOGICAL RESOLUTION:
     // Allowance cap = $250 (25000 cents). Used = $100 (10000 cents).
     // Remaining MUST be $150 (15000 cents) on BOTH reports.
     // If either report read the category default cap ($750), remaining would be $650 (65000 cents) and fail here.
-    expect(userUsage.remaining).toBe(15000)
-    expect(userEligibility.remaining).toBe(15000)
-    expect(userUsage.remaining).toBe(userEligibility.remaining)
+    expect(userUsage!.remaining).toBe(15000)
+    expect(userEligibility!.remaining).toBe(15000)
+    expect(userUsage!.remaining).toBe(userEligibility!.remaining)
   })
 })

--- a/src/__tests__/lib/passkeys.test.ts
+++ b/src/__tests__/lib/passkeys.test.ts
@@ -9,9 +9,11 @@ import {
   getPasskeyStorageHint,
 } from '@/lib/passkeys'
 
+type GlobalWithWindow = { window?: { PublicKeyCredential?: unknown } }
+
 describe('isWebAuthnSupported', () => {
   afterEach(() => {
-    delete (global as any).window
+    delete (global as unknown as GlobalWithWindow).window
   })
 
   it('returns false when window is undefined (server)', () => {
@@ -19,12 +21,12 @@ describe('isWebAuthnSupported', () => {
   })
 
   it('returns false when PublicKeyCredential is absent', () => {
-    ;(global as any).window = {}
+    ;(global as unknown as GlobalWithWindow).window = {}
     expect(isWebAuthnSupported()).toBe(false)
   })
 
   it('returns true when PublicKeyCredential exists', () => {
-    ;(global as any).window = { PublicKeyCredential: function () {} }
+    ;(global as unknown as GlobalWithWindow).window = { PublicKeyCredential: function () {} }
     expect(isWebAuthnSupported()).toBe(true)
   })
 })

--- a/src/__tests__/services/alternate-payment-service.test.ts
+++ b/src/__tests__/services/alternate-payment-service.test.ts
@@ -45,9 +45,14 @@ jest.mock('@/lib/supabase/server', () => ({
 
 import { AlternatePaymentService } from '@/lib/services/alternate-payment-service'
 import { checkSeasonalDiscountLimit } from '@/lib/services/discount-limit-service'
+import { SupabaseClient } from '@supabase/supabase-js'
+
+type MockSupabaseClient = {
+  from: jest.Mock
+}
 
 describe('AlternatePaymentService - Seasonal Discount Caps', () => {
-  let mockSupabase: any
+  let mockSupabase: MockSupabaseClient
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -120,7 +125,7 @@ describe('AlternatePaymentService - Seasonal Discount Caps', () => {
       })
 
       const result = await AlternatePaymentService.calculateChargeAmount(
-        mockSupabase,
+        mockSupabase as unknown as SupabaseClient,
         'registration-id',
         'season-id',
         'code-id',
@@ -191,7 +196,7 @@ describe('AlternatePaymentService - Seasonal Discount Caps', () => {
       })
 
       const result = await AlternatePaymentService.calculateChargeAmount(
-        mockSupabase,
+        mockSupabase as unknown as SupabaseClient,
         'registration-id',
         'season-id',
         'code-id',
@@ -261,7 +266,7 @@ describe('AlternatePaymentService - Seasonal Discount Caps', () => {
       })
 
       const result = await AlternatePaymentService.calculateChargeAmount(
-        mockSupabase,
+        mockSupabase as unknown as SupabaseClient,
         'registration-id',
         'season-id',
         'code-id',
@@ -289,7 +294,7 @@ describe('AlternatePaymentService - Seasonal Discount Caps', () => {
       })
 
       const result = await AlternatePaymentService.calculateChargeAmount(
-        mockSupabase,
+        mockSupabase as unknown as SupabaseClient,
         'registration-id',
         'season-id',
         undefined, // No discount code
@@ -318,7 +323,7 @@ describe('AlternatePaymentService - Seasonal Discount Caps', () => {
       })
 
       const result = await AlternatePaymentService.calculateChargeAmount(
-        mockSupabase,
+        mockSupabase as unknown as SupabaseClient,
         'registration-id',
         'season-id',
         'code-id',
@@ -345,7 +350,7 @@ describe('AlternatePaymentService - Seasonal Discount Caps', () => {
 
       await expect(
         AlternatePaymentService.calculateChargeAmount(
-          mockSupabase,
+          mockSupabase as unknown as SupabaseClient,
           'invalid-id',
           'season-id',
           'code-id',

--- a/src/__tests__/services/discount-limit-service.test.ts
+++ b/src/__tests__/services/discount-limit-service.test.ts
@@ -13,6 +13,7 @@ import {
   resolveEffectiveDiscountLimitsBatch,
   resolveDiscountPercentage
 } from '@/lib/services/discount-limit-service'
+import { SupabaseClient } from '@supabase/supabase-js'
 
 // Mock dependencies
 jest.mock('@/lib/logging/logger', () => ({
@@ -21,8 +22,16 @@ jest.mock('@/lib/logging/logger', () => ({
   }
 }))
 
+type MockSupabaseClient = {
+  from: jest.Mock
+}
+
+function asClient(client: MockSupabaseClient): SupabaseClient {
+  return client as unknown as SupabaseClient
+}
+
 describe('DiscountLimitService', () => {
-  let mockSupabase: any
+  let mockSupabase: MockSupabaseClient
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -61,7 +70,7 @@ describe('DiscountLimitService', () => {
       })
 
       const result = await calculateSeasonalDiscountUsage(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-id',
         'category-id',
         'season-id'
@@ -89,7 +98,7 @@ describe('DiscountLimitService', () => {
       })
 
       const result = await calculateSeasonalDiscountUsage(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-id',
         'category-id',
         'season-id'
@@ -117,7 +126,7 @@ describe('DiscountLimitService', () => {
       })
 
       const result = await calculateSeasonalDiscountUsage(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-id',
         'category-id',
         'season-id'
@@ -142,7 +151,7 @@ describe('DiscountLimitService', () => {
 
       await expect(
         calculateSeasonalDiscountUsage(
-          mockSupabase,
+          asClient(mockSupabase),
           'user-id',
           'category-id',
           'season-id'
@@ -191,7 +200,7 @@ describe('DiscountLimitService', () => {
       })
 
       const result = await checkSeasonalDiscountLimit(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-id',
         'code-id',
         'season-id',
@@ -259,7 +268,7 @@ describe('DiscountLimitService', () => {
       })
 
       const result = await checkSeasonalDiscountLimit(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-id',
         'code-id',
         'season-id',
@@ -331,7 +340,7 @@ describe('DiscountLimitService', () => {
       })
 
       const result = await checkSeasonalDiscountLimit(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-id',
         'code-id',
         'season-id',
@@ -406,7 +415,7 @@ describe('DiscountLimitService', () => {
       })
 
       const result = await checkSeasonalDiscountLimit(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-id',
         'code-id',
         'season-id',
@@ -479,7 +488,7 @@ describe('DiscountLimitService', () => {
       })
 
       const result = await checkSeasonalDiscountLimit(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-id',
         'code-id',
         'season-id',
@@ -511,7 +520,7 @@ describe('DiscountLimitService', () => {
 
       await expect(
         checkSeasonalDiscountLimit(
-          mockSupabase,
+          asClient(mockSupabase),
           'user-id',
           'code-id',
           'season-id',
@@ -537,7 +546,7 @@ describe('DiscountLimitService', () => {
       })
 
       const result = await getSeasonalDiscountUsageSummary(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-id',
         'category-id',
         'season-id'
@@ -561,7 +570,7 @@ describe('DiscountLimitService', () => {
       })
 
       const result = await getSeasonalDiscountUsageSummary(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-id',
         'category-id',
         'season-id'
@@ -622,7 +631,7 @@ describe('DiscountLimitService', () => {
       })
 
       const result = await getSeasonalDiscountUsageSummary(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-id',
         'category-id',
         'season-id'
@@ -687,7 +696,7 @@ describe('DiscountLimitService', () => {
       })
 
       const result = await getSeasonalDiscountUsageSummary(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-id',
         'category-id',
         'season-id'
@@ -747,7 +756,7 @@ describe('DiscountLimitService', () => {
       })
 
       const result = await getSeasonalDiscountUsageSummary(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-id',
         'gated-cat-id',
         'season-id'
@@ -774,7 +783,7 @@ describe('DiscountLimitService', () => {
       })
 
       const result = await getSeasonalDiscountUsageSummary(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-id',
         'category-id',
         'season-id'
@@ -787,7 +796,7 @@ describe('DiscountLimitService', () => {
   describe('Phase 1 Refactor Extensions', () => {
     it('should bypass seasonal cap when isRefund is true', async () => {
       const result = await checkSeasonalDiscountLimit(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-id',
         'code-id',
         'season-id',
@@ -857,7 +866,7 @@ describe('DiscountLimitService', () => {
       })
 
       const result = await checkSeasonalDiscountLimit(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-1',
         'code-1',
         'season-1',
@@ -882,7 +891,7 @@ describe('DiscountLimitService', () => {
       }
 
       const result = await checkSeasonalDiscountLimit(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-1',
         'code-1',
         'season-1',
@@ -908,7 +917,7 @@ describe('DiscountLimitService', () => {
       }
 
       const result = await checkSeasonalDiscountLimit(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-1',
         'code-1',
         'season-1',
@@ -942,7 +951,7 @@ describe('DiscountLimitService', () => {
       })
 
       const map = await calculateSeasonalDiscountUsageBatch(
-        mockSupabase,
+        asClient(mockSupabase),
         ['u1', 'u2'],
         'season-1'
       )
@@ -954,7 +963,7 @@ describe('DiscountLimitService', () => {
 
     it('calculateSeasonalDiscountUsageBatch should throw if seasonId is missing', async () => {
       await expect(
-        calculateSeasonalDiscountUsageBatch(mockSupabase, ['u1'], '')
+        calculateSeasonalDiscountUsageBatch(asClient(mockSupabase), ['u1'], '')
       ).rejects.toThrow('Season ID is required for batch seasonal discount usage calculation')
     })
 
@@ -1035,7 +1044,7 @@ describe('DiscountLimitService', () => {
         return {}
       })
 
-      const res = await resolveEffectiveDiscountLimits(mockSupabase, 'user-1', 'cat-1', 'season-1')
+      const res = await resolveEffectiveDiscountLimits(asClient(mockSupabase), 'user-1', 'cat-1', 'season-1')
       expect(res).toEqual({
         maxAllowed: 5000,
         percentage: 25,
@@ -1084,7 +1093,7 @@ describe('DiscountLimitService', () => {
         return {}
       })
 
-      const res = await resolveEffectiveDiscountLimits(mockSupabase, 'user-1', 'cat-1', 'season-1')
+      const res = await resolveEffectiveDiscountLimits(asClient(mockSupabase), 'user-1', 'cat-1', 'season-1')
       expect(res).toEqual({
         maxAllowed: 10000,
         percentage: 50,
@@ -1127,7 +1136,7 @@ describe('DiscountLimitService', () => {
         return {}
       })
 
-      const res = await resolveEffectiveDiscountLimits(mockSupabase, 'user-1', 'cat-gated', 'season-1')
+      const res = await resolveEffectiveDiscountLimits(asClient(mockSupabase), 'user-1', 'cat-gated', 'season-1')
       expect(res).toEqual({
         maxAllowed: null,
         percentage: null,
@@ -1176,7 +1185,7 @@ describe('DiscountLimitService', () => {
         return {}
       })
 
-      const res = await resolveEffectiveDiscountLimits(mockSupabase, 'user-1', 'cat-gated', 'season-1')
+      const res = await resolveEffectiveDiscountLimits(asClient(mockSupabase), 'user-1', 'cat-gated', 'season-1')
       expect(res).toEqual({
         maxAllowed: 8000,
         percentage: 30,
@@ -1225,7 +1234,7 @@ describe('DiscountLimitService', () => {
         return {}
       })
 
-      const res = await resolveEffectiveDiscountLimits(mockSupabase, 'user-1', 'cat-1', 'season-1')
+      const res = await resolveEffectiveDiscountLimits(asClient(mockSupabase), 'user-1', 'cat-1', 'season-1')
       expect(res).toEqual({
         maxAllowed: 0,
         percentage: 20,
@@ -1264,7 +1273,7 @@ describe('DiscountLimitService', () => {
         return {}
       })
 
-      const batchMap = await resolveEffectiveDiscountLimitsBatch(mockSupabase, ['u1', 'u2'], 'season-1')
+      const batchMap = await resolveEffectiveDiscountLimitsBatch(asClient(mockSupabase), ['u1', 'u2'], 'season-1')
 
       // u1 on cat-gated -> user_allowance
       expect(batchMap.get('u1:cat-gated')).toEqual({
@@ -1321,7 +1330,7 @@ describe('DiscountLimitService', () => {
       })
 
       const res = await checkSeasonalDiscountLimit(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-revoked',
         'dc-1',
         'season-1',
@@ -1365,7 +1374,7 @@ describe('DiscountLimitService', () => {
       })
 
       await expect(
-        resolveEffectiveDiscountLimits(mockSupabase, 'user-1', 'cat-1', 'season-1')
+        resolveEffectiveDiscountLimits(asClient(mockSupabase), 'user-1', 'cat-1', 'season-1')
       ).rejects.toThrow('Database connection failed')
     })
   })
@@ -1413,7 +1422,7 @@ describe('DiscountLimitService', () => {
       }
 
       const res = await checkSeasonalDiscountLimit(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-ineligible',
         'code-gated',
         'season-1',

--- a/src/__tests__/services/payment-plan-service.test.ts
+++ b/src/__tests__/services/payment-plan-service.test.ts
@@ -20,10 +20,26 @@ jest.mock('stripe', () => {
   return jest.fn().mockImplementation(() => ({}))
 })
 
+interface InsertedPayment {
+  amount_paid: number
+  installment_number: number
+  sync_status: string
+  payment_type: string
+  staging_metadata: {
+    user_id: string
+    user_registration_id: string
+    first_payment_id?: string
+  }
+}
+
+type MockAdminSupabaseClient = {
+  from: jest.Mock
+}
+
 describe('PaymentPlanService', () => {
   describe('createPaymentPlan - Installment Amount Distribution', () => {
-    let mockAdminSupabase: any
-    let mockInsertedPayments: any[]
+    let mockAdminSupabase: MockAdminSupabaseClient
+    let mockInsertedPayments: InsertedPayment[]
 
     beforeEach(() => {
       jest.clearAllMocks()
@@ -42,7 +58,7 @@ describe('PaymentPlanService', () => {
           }
           if (table === 'xero_payments') {
             return {
-              insert: jest.fn((payments: any[]) => {
+              insert: jest.fn((payments: InsertedPayment[]) => {
                 mockInsertedPayments = payments
                 return Promise.resolve({ error: null })
               })

--- a/src/__tests__/services/registration-validation-service.test.ts
+++ b/src/__tests__/services/registration-validation-service.test.ts
@@ -8,9 +8,18 @@
  */
 
 import { RegistrationValidationService } from '@/lib/services/registration-validation-service'
+import { SupabaseClient } from '@supabase/supabase-js'
+
+type MockSupabaseClient = {
+  from: jest.Mock
+}
+
+function asClient(client: MockSupabaseClient): SupabaseClient {
+  return client as unknown as SupabaseClient
+}
 
 describe('RegistrationValidationService', () => {
-  let mockSupabase: any
+  let mockSupabase: MockSupabaseClient
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -39,7 +48,7 @@ describe('RegistrationValidationService', () => {
       })
 
       const result = await RegistrationValidationService.canUserRegister(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-123',
         'registration-456'
       )
@@ -74,7 +83,7 @@ describe('RegistrationValidationService', () => {
       })
 
       const result = await RegistrationValidationService.canUserRegister(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-123',
         'registration-456'
       )
@@ -103,7 +112,7 @@ describe('RegistrationValidationService', () => {
       })
 
       const result = await RegistrationValidationService.canUserRegister(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-123',
         'registration-456'
       )
@@ -131,7 +140,7 @@ describe('RegistrationValidationService', () => {
 
       await expect(
         RegistrationValidationService.canUserRegister(
-          mockSupabase,
+          asClient(mockSupabase),
           'user-123',
           'registration-456'
         )
@@ -156,7 +165,7 @@ describe('RegistrationValidationService', () => {
       })
 
       const result = await RegistrationValidationService.validatePaymentMethod(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-123'
       )
 
@@ -180,7 +189,7 @@ describe('RegistrationValidationService', () => {
       })
 
       const result = await RegistrationValidationService.validatePaymentMethod(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-123'
       )
 
@@ -207,7 +216,7 @@ describe('RegistrationValidationService', () => {
       })
 
       const result = await RegistrationValidationService.validatePaymentMethod(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-123'
       )
 
@@ -229,7 +238,7 @@ describe('RegistrationValidationService', () => {
 
       await expect(
         RegistrationValidationService.validatePaymentMethod(
-          mockSupabase,
+          asClient(mockSupabase),
           'user-123'
         )
       ).rejects.toThrow('User not found')
@@ -257,7 +266,7 @@ describe('RegistrationValidationService', () => {
       // No payment method validation should happen for effectivePrice = 0
 
       const result = await RegistrationValidationService.validateRegistrationEligibility(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-123',
         'registration-456',
         {
@@ -306,7 +315,7 @@ describe('RegistrationValidationService', () => {
       })
 
       const result = await RegistrationValidationService.validateRegistrationEligibility(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-123',
         'registration-456',
         {
@@ -345,7 +354,7 @@ describe('RegistrationValidationService', () => {
       // Payment method validation should NOT be called because duplicate check fails first
 
       const result = await RegistrationValidationService.validateRegistrationEligibility(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-123',
         'registration-456',
         {
@@ -394,7 +403,7 @@ describe('RegistrationValidationService', () => {
       })
 
       const result = await RegistrationValidationService.validateRegistrationEligibility(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-123',
         'registration-456',
         {
@@ -440,7 +449,7 @@ describe('RegistrationValidationService', () => {
       })
 
       const result = await RegistrationValidationService.validateRegistrationEligibility(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-123',
         'registration-456',
         {
@@ -492,7 +501,7 @@ describe('RegistrationValidationService', () => {
       })
 
       const result = await RegistrationValidationService.validateRegistrationEligibility(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-with-refunded-reg',
         'new-registration-789',
         {
@@ -527,7 +536,7 @@ describe('RegistrationValidationService', () => {
 
       // When we DON'T pass effectivePrice, payment method validation is skipped
       const result = await RegistrationValidationService.validateRegistrationEligibility(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-123',
         'registration-456',
         {

--- a/src/__tests__/services/waitlist-payment-service.test.ts
+++ b/src/__tests__/services/waitlist-payment-service.test.ts
@@ -59,9 +59,18 @@ jest.mock('@/lib/supabase/server', () => ({
 import { WaitlistPaymentService } from '@/lib/services/waitlist-payment-service'
 import { checkSeasonalDiscountLimit } from '@/lib/services/discount-limit-service'
 import { createClient, createAdminClient } from '@/lib/supabase/server'
+import { SupabaseClient } from '@supabase/supabase-js'
+
+type MockSupabaseClient = {
+  from: jest.Mock
+}
+
+function asClient(client: MockSupabaseClient): SupabaseClient {
+  return client as unknown as SupabaseClient
+}
 
 describe('WaitlistPaymentService - Seasonal Discount Caps', () => {
-  let mockSupabase: any
+  let mockSupabase: MockSupabaseClient
 
   beforeEach(() => {
     jest.clearAllMocks()
@@ -137,7 +146,7 @@ describe('WaitlistPaymentService - Seasonal Discount Caps', () => {
       })
 
       const result = await WaitlistPaymentService.calculateChargeAmount(
-        mockSupabase,
+        asClient(mockSupabase),
         'category-id',
         'season-id',
         'code-id',
@@ -150,7 +159,7 @@ describe('WaitlistPaymentService - Seasonal Discount Caps', () => {
 
       // Verify seasonal limit check was called
       expect(checkSeasonalDiscountLimit).toHaveBeenCalledWith(
-        mockSupabase,
+        asClient(mockSupabase),
         'user-id',
         'code-id',
         'season-id',
@@ -208,7 +217,7 @@ describe('WaitlistPaymentService - Seasonal Discount Caps', () => {
       })
 
       const result = await WaitlistPaymentService.calculateChargeAmount(
-        mockSupabase,
+        asClient(mockSupabase),
         'category-id',
         'season-id',
         'code-id',
@@ -269,7 +278,7 @@ describe('WaitlistPaymentService - Seasonal Discount Caps', () => {
       })
 
       const result = await WaitlistPaymentService.calculateChargeAmount(
-        mockSupabase,
+        asClient(mockSupabase),
         'category-id',
         'season-id',
         'code-id',
@@ -297,7 +306,7 @@ describe('WaitlistPaymentService - Seasonal Discount Caps', () => {
       })
 
       const result = await WaitlistPaymentService.calculateChargeAmount(
-        mockSupabase,
+        asClient(mockSupabase),
         'category-id',
         'season-id',
         undefined, // No discount code
@@ -324,7 +333,7 @@ describe('WaitlistPaymentService - Seasonal Discount Caps', () => {
 
       await expect(
         WaitlistPaymentService.calculateChargeAmount(
-          mockSupabase,
+          asClient(mockSupabase),
           'invalid-id',
           'season-id',
           'code-id',
@@ -384,7 +393,7 @@ describe('WaitlistPaymentService - Seasonal Discount Caps', () => {
       })
 
       const result = await WaitlistPaymentService.calculateChargeAmount(
-        mockSupabase,
+        asClient(mockSupabase),
         'category-id',
         'season-id',
         'code-id',
@@ -439,7 +448,7 @@ describe('WaitlistPaymentService - Seasonal Discount Caps', () => {
       })
 
       const result = await WaitlistPaymentService.calculateChargeAmount(
-        mockSupabase,
+        asClient(mockSupabase),
         'category-id',
         'season-id',
         'code-id',
@@ -655,7 +664,7 @@ describe('WaitlistPaymentService - Seasonal Discount Caps', () => {
       })
 
       const result = await WaitlistPaymentService.calculateChargeAmount(
-        mockSupabase,
+        asClient(mockSupabase),
         'cat-id',
         'season-id',
         'code-pride',
@@ -722,7 +731,7 @@ describe('WaitlistPaymentService - Seasonal Discount Caps', () => {
       })
 
       const result = await WaitlistPaymentService.calculateChargeAmount(
-        mockSupabase,
+        asClient(mockSupabase),
         'cat-id',
         'season-id',
         'code-fixed75',
@@ -783,7 +792,7 @@ describe('WaitlistPaymentService - Seasonal Discount Caps', () => {
       })
 
       const result = await WaitlistPaymentService.calculateChargeAmount(
-        mockSupabase,
+        asClient(mockSupabase),
         'cat-gated',
         'season-id',
         'code-gated',


### PR DESCRIPTION
## Summary
- Removes all 44 `@typescript-eslint/no-explicit-any` errors across the 17 files listed in #207, part of #197
- Local `MockSupabaseClient`/`MockAdminSupabaseClient` types (matching the actual `{ auth: { getUser }, from }` shape) replace `let mockSupabase: any`; an `asClient()` helper casts these to the real `SupabaseClient` type where service functions need it
- Local interfaces (`EligibilityRow`, `UsageReportData`, `InsertedPayment`, etc.) type JSON response shapes and ad hoc mock builders instead of `(r: any) =>` callbacks
- Removed two files' redundant `declare const jest: any` blocks — `@types/jest` is already available project-wide, so these were shadowing real jest types with `any`

Left untouched as pre-existing/out of scope: `no-require-imports` on the `mock-next-server` helper in the two xero test files, and a `GET()` called with an unused request argument in `user-alternate-registrations.test.ts` / `report-consistency.test.ts`.

## Test plan
- [x] `npm run lint` — 0 `no-explicit-any` errors remain; same pre-existing unrelated errors/warnings as on main
- [x] `npm test` — 292/292 tests passing across all 27 suites

🤖 Generated with [Claude Code](https://claude.com/claude-code)