### PR TITLE
Fix #209: re-enable blocking lint in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,6 @@ jobs:
 
     - name: Run lint
       run: npm run lint
-      continue-on-error: true
 
     - name: Run build
       run: npm run build

--- a/src/__tests__/api/xero/auth.test.ts
+++ b/src/__tests__/api/xero/auth.test.ts
@@ -4,7 +4,7 @@
  * and set as an httpOnly cookie on the response.
  */
 
-jest.mock('next/server', () => require('../../../test-helpers/mock-next-server'))
+jest.mock('next/server', () => jest.requireActual('../../../test-helpers/mock-next-server'))
 
 import { GET } from '@/app/api/xero/auth/route'
 import { createXeroOAuthClient } from '@/lib/xero/client'

--- a/src/__tests__/api/xero/callback.test.ts
+++ b/src/__tests__/api/xero/callback.test.ts
@@ -3,7 +3,7 @@
  * Verifies the CSRF state cookie is validated before any token exchange happens
  */
 
-jest.mock('next/server', () => require('../../../test-helpers/mock-next-server'))
+jest.mock('next/server', () => jest.requireActual('../../../test-helpers/mock-next-server'))
 
 import { NextRequest } from 'next/server'
 import { GET } from '@/app/api/xero/callback/route'

--- a/src/__tests__/lib/xero/oauth-state.test.ts
+++ b/src/__tests__/lib/xero/oauth-state.test.ts
@@ -2,7 +2,7 @@
  * Unit tests for src/lib/xero/oauth-state.ts CSRF state cookie helpers
  */
 
-jest.mock('next/server', () => require('../../../test-helpers/mock-next-server'))
+jest.mock('next/server', () => jest.requireActual('../../../test-helpers/mock-next-server'))
 
 import { NextRequest, NextResponse } from 'next/server'
 import {

--- a/src/app/admin/reports/users/UsersTable.tsx
+++ b/src/app/admin/reports/users/UsersTable.tsx
@@ -29,6 +29,26 @@ interface UsersTableProps {
 type SortField = 'name' | 'email' | 'member_id' | 'account_type' | 'payment' | 'created_at'
 type SortDirection = 'asc' | 'desc'
 
+function SortIcon({ active, direction }: { active: boolean; direction: SortDirection }) {
+  if (!active) {
+    return (
+      <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l4-4 4 4m0 6l-4 4-4-4" />
+      </svg>
+    )
+  }
+
+  return direction === 'asc' ? (
+    <svg className="w-4 h-4 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
+    </svg>
+  ) : (
+    <svg className="w-4 h-4 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+    </svg>
+  )
+}
+
 export default function UsersTable({ users, currentUserId, searchTerm = '' }: UsersTableProps) {
   const [sortField, setSortField] = useState<SortField>('name')
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
@@ -95,26 +115,6 @@ export default function UsersTable({ users, currentUserId, searchTerm = '' }: Us
     }
   }
 
-  const SortIcon = ({ field }: { field: SortField }) => {
-    if (sortField !== field) {
-      return (
-        <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 9l4-4 4 4m0 6l-4 4-4-4" />
-        </svg>
-      )
-    }
-    
-    return sortDirection === 'asc' ? (
-      <svg className="w-4 h-4 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 15l7-7 7 7" />
-      </svg>
-    ) : (
-      <svg className="w-4 h-4 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
-      </svg>
-    )
-  }
-
   return (
     <div className="overflow-x-auto">
         <table className="min-w-full divide-y divide-gray-200">
@@ -126,7 +126,7 @@ export default function UsersTable({ users, currentUserId, searchTerm = '' }: Us
               >
                 <div className="flex items-center space-x-1">
                   <span>Name</span>
-                  <SortIcon field="name" />
+                  <SortIcon active={sortField === 'name'} direction={sortDirection} />
                 </div>
               </th>
               <th 
@@ -135,7 +135,7 @@ export default function UsersTable({ users, currentUserId, searchTerm = '' }: Us
               >
                 <div className="flex items-center space-x-1">
                   <span>Member #</span>
-                  <SortIcon field="member_id" />
+                  <SortIcon active={sortField === 'member_id'} direction={sortDirection} />
                 </div>
               </th>
               <th 
@@ -144,7 +144,7 @@ export default function UsersTable({ users, currentUserId, searchTerm = '' }: Us
               >
                 <div className="flex items-center space-x-1">
                   <span>Account Type</span>
-                  <SortIcon field="account_type" />
+                  <SortIcon active={sortField === 'account_type'} direction={sortDirection} />
                 </div>
               </th>
               <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">
@@ -156,7 +156,7 @@ export default function UsersTable({ users, currentUserId, searchTerm = '' }: Us
               >
                 <div className="flex items-center space-x-1">
                   <span>Saved Payment</span>
-                  <SortIcon field="payment" />
+                  <SortIcon active={sortField === 'payment'} direction={sortDirection} />
                 </div>
               </th>
               <th
@@ -165,7 +165,7 @@ export default function UsersTable({ users, currentUserId, searchTerm = '' }: Us
               >
                 <div className="flex items-center space-x-1">
                   <span>Created</span>
-                  <SortIcon field="created_at" />
+                  <SortIcon active={sortField === 'created_at'} direction={sortDirection} />
                 </div>
               </th>
             </tr>

--- a/src/components/EventDateTimeInput.tsx
+++ b/src/components/EventDateTimeInput.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect } from 'react'
+import { useMemo } from 'react'
 import DateTimePicker from '@/components/DateTimePicker'
 import DurationInput from '@/components/DurationInput'
 import { convertToNYTimezone } from '@/lib/date-utils'
@@ -24,26 +24,23 @@ export default function EventDateTimeInput({
   required = false,
   disabled = false,
 }: EventDateTimeInputProps) {
-  const [isPastDate, setIsPastDate] = useState(false)
   const isTournament = registrationType === 'tournament'
 
   // Check if the selected date is in the past
-  useEffect(() => {
-    if (startDate) {
-      // For tournaments, append time if not present
-      let dateTimeString = startDate
-      if (isTournament && !startDate.includes('T')) {
-        dateTimeString = startDate + 'T00:00'
-      }
+  const isPastDate = useMemo(() => {
+    if (!startDate) return false
 
-      // Convert datetime-local to NY timezone before comparing
-      const selectedDateISO = convertToNYTimezone(dateTimeString)
-      const selectedDate = new Date(selectedDateISO)
-      const now = new Date()
-      setIsPastDate(selectedDate < now)
-    } else {
-      setIsPastDate(false)
+    // For tournaments, append time if not present
+    let dateTimeString = startDate
+    if (isTournament && !startDate.includes('T')) {
+      dateTimeString = startDate + 'T00:00'
     }
+
+    // Convert datetime-local to NY timezone before comparing
+    const selectedDateISO = convertToNYTimezone(dateTimeString)
+    const selectedDate = new Date(selectedDateISO)
+    const now = new Date()
+    return selectedDate < now
   }, [startDate, isTournament])
 
   // For tournaments, convert between days and minutes


### PR DESCRIPTION
## Summary
- All sub-issues under #197 are closed, so this removes `continue-on-error: true` from the "Run lint" step in `.github/workflows/test.yml`, restoring lint as a blocking CI gate.
- Since #197's backlog was last counted, a dependency bump to `eslint-config-next@16.1.6` (`eslint-plugin-react-hooks` 7) introduced 3 new error-level rules. Fixed all 9 resulting findings so the newly-blocking gate starts green:
  - `@typescript-eslint/no-require-imports` (3x): test files used `require()` inside a `jest.mock()` factory to work around hoisting — switched to `jest.requireActual()`.
  - `react-hooks/static-components` (6x): `UsersTable` defined a `SortIcon` component inside the parent's render body — hoisted it to module scope, passed `active`/`direction` as props.
  - `react-hooks/set-state-in-effect`: `EventDateTimeInput` derived `isPastDate` via `setState` inside a `useEffect` — it's a pure derived value, so replaced with `useMemo`.

Closes #209.

## Test plan
- [x] `npm run lint` exits 0 (5 pre-existing `no-img-element` warnings remain; warnings don't block)
- [x] `npm test` — 306/306 passing
- [x] `npm run build` — succeeds
- [ ] After push, confirm the "Run lint" step is blocking (not `continue-on-error`) in the Actions UI for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)