### PR TITLE
Exclude .claude/worktrees/ from ESLint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -2,6 +2,12 @@ import nextCoreWebVitals from "eslint-config-next/core-web-vitals";
 import nextTypescript from "eslint-config-next/typescript";
 
 const eslintConfig = [
+  {
+    // Claude Code creates other git worktrees under .claude/worktrees/ inside
+    // this checkout. ESLint's flat config doesn't read .gitignore, so without
+    // this they get linted too — including their own .next build output.
+    ignores: ["**/.claude/worktrees/**"],
+  },
   ...nextCoreWebVitals,
   ...nextTypescript,
   {


### PR DESCRIPTION
## Summary
- Adds `ignores: ["**/.claude/worktrees/**"]` to `eslint.config.mjs`.
- Claude Code creates other git worktrees as plain subdirectories under `.claude/worktrees/` inside a checkout. That path is only excluded via the local, uncommitted `.git/info/exclude`, and ESLint's flat config (v9+) doesn't read `.gitignore`/`.git/info/exclude` at all — only `ignores` entries in `eslint.config.mjs` count.
- Without this, `eslint .` recurses into every other worktree physically present on disk, linting their `.next` build output (huge generated bundles) and their own `src/` (possibly a different branch/lint state). In a checkout with a handful of active worktrees this turned a ~1s lint run into a multi-minute run reporting hundreds of thousands of findings.
- CI is unaffected — a fresh CI checkout never has nested worktree directories, so this only ever showed up locally.

## Test plan
- [x] `npm run lint` from the main checkout (which has several `.claude/worktrees/*` present) — was 20k+ errors / 200k+ warnings taking minutes, now finishes fast with the same 0 errors / 5 pre-existing warnings as a clean worktree
- [x] `npm test` — 306/306 passing
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)