### PR TITLE
Replace <img> with next/image to clear no-img-element lint warnings

### DIFF
--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import Image from 'next/image'
 import { KeyRound } from 'lucide-react'
 import { createClient } from '@/lib/supabase/client'
 import { useRouter } from 'next/navigation'
@@ -193,10 +194,13 @@ export default function LoginPage() {
       <div className="max-w-md w-full space-y-8">
         <div>
           <div className="flex justify-center mb-6">
-            <img 
-              src="/images/NYCPHA_Wordmark_Horizontal_Black_Tide.png" 
-              alt="NYC PHA" 
+            <Image
+              src="/images/NYCPHA_Wordmark_Horizontal_Black_Tide.png"
+              alt="NYC PHA"
+              width={640}
+              height={120}
               className="h-12 w-auto"
+              priority
             />
           </div>
           <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">

--- a/src/app/auth/magic-confirm/page.tsx
+++ b/src/app/auth/magic-confirm/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from 'next/navigation'
+import Image from 'next/image'
 import { createClient } from '@/lib/supabase/server'
 import { headers } from 'next/headers'
 
@@ -79,9 +80,11 @@ export default async function MagicConfirmPage({
         </div>
 
         <div className="text-center">
-          <img
-            src="https://my.nycpha.org/images/NYCPHA_Wordmark_Horizontal_Black_Tide.png"
+          <Image
+            src="/images/NYCPHA_Wordmark_Horizontal_Black_Tide.png"
             alt="NYCPHA Logo"
+            width={640}
+            height={120}
             className="mx-auto max-w-full h-auto"
           />
         </div>

--- a/src/app/auth/verify-otp/page.tsx
+++ b/src/app/auth/verify-otp/page.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect, useRef } from 'react'
+import Image from 'next/image'
 import { createClient } from '@/lib/supabase/client'
 import { useRouter } from 'next/navigation'
 import { useToast } from '@/contexts/ToastContext'
@@ -176,10 +177,13 @@ export default function VerifyOTPPage() {
       <div className="max-w-md w-full space-y-8">
         <div>
           <div className="flex justify-center mb-6">
-            <img 
-              src="/images/NYCPHA_Wordmark_Horizontal_Black_Tide.png" 
-              alt="NYC PHA" 
+            <Image
+              src="/images/NYCPHA_Wordmark_Horizontal_Black_Tide.png"
+              alt="NYC PHA"
+              width={640}
+              height={120}
               className="h-16 w-auto max-w-full"
+              priority
             />
           </div>
           <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">

--- a/src/components/AdminNavigation.tsx
+++ b/src/components/AdminNavigation.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState } from 'react'
+import Image from 'next/image'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { getOrganizationName } from '@/lib/organization'
@@ -93,9 +94,11 @@ export default function AdminNavigation({ user }: AdminNavigationProps) {
           <div className="flex">
             <div className="flex-shrink-0 flex items-center">
               <Link href="/admin" className="flex items-center space-x-2">
-                <img
+                <Image
                   src="/images/logo.png"
                   alt={`${getOrganizationName('short')} logo`}
+                  width={40}
+                  height={38}
                   className="h-10 w-auto"
                 />
                 <span className="text-xl font-bold text-gray-900">Admin</span>

--- a/src/components/UserNavigation.tsx
+++ b/src/components/UserNavigation.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
+import Image from 'next/image'
 import Link from 'next/link'
 import { usePathname } from 'next/navigation'
 import { getOrganizationName } from '@/lib/organization'
@@ -87,9 +88,11 @@ export default function UserNavigation({ user }: UserNavigationProps) {
           <div className="flex">
             <div className="flex-shrink-0 flex items-center">
               <Link href="/user" className="flex items-center">
-                <img
+                <Image
                   src="/images/logo.png"
                   alt={`${getOrganizationName('short')} logo`}
+                  width={40}
+                  height={38}
                   className="h-10 w-auto"
                 />
               </Link>


### PR DESCRIPTION
## Summary
- Replaces the 5 `<img>` tags flagged by `@next/next/no-img-element` with `next/image` in `src/app/auth/login/page.tsx`, `src/app/auth/verify-otp/page.tsx`, `src/app/auth/magic-confirm/page.tsx`, `src/components/AdminNavigation.tsx`, and `src/components/UserNavigation.tsx`.
- `magic-confirm/page.tsx` previously loaded the wordmark from an absolute `https://my.nycpha.org/...` URL; switched it to the local `/images/...` path (same asset used on the other auth pages) instead of adding `images.remotePatterns`, since there's no reason this in-app route needs an absolute URL.
- Set explicit `width`/`height` matching each asset's real intrinsic size (wordmark 640×120, logo ~40×38) while keeping the existing Tailwind `h-*`/`w-auto` classes, so rendered size is unchanged.

Fixes #233.

## Test plan
- [x] `npm run lint` — 0 errors, 0 warnings (issue's exit criteria)
- [x] `npm run build` — compiles successfully, all routes generated
- [x] Visually verified in a local browser: login page wordmark, verify-otp page wordmark (larger size), and a temporary local-only route rendering AdminNavigation/UserNavigation/magic-confirm's wordmark — all render at correct size with no distortion or layout shift (temp route removed before commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)