### PR TITLE
Fix control-flow bugs flagged by tsc: join-waitlist, membership-validation

### DIFF
--- a/src/app/api/join-waitlist/route.ts
+++ b/src/app/api/join-waitlist/route.ts
@@ -169,42 +169,39 @@ export async function POST(request: NextRequest) {
       .eq('registration_category_id', categoryId)
       .maybeSingle()
 
+    if (existingWaitlist && existingWaitlist.removed_at === null) {
+      // Already on active waitlist
+      return NextResponse.json({
+        error: `You are already on the waitlist for this category`
+      }, { status: 400 })
+    }
+
     let waitlistEntry: WaitlistRow | undefined
     let nextPosition: number
 
     if (existingWaitlist) {
-      if (existingWaitlist.removed_at === null) {
-        // Already on active waitlist
-        return NextResponse.json({
-          error: `You are already on the waitlist for this category`
-        }, { status: 400 })
-      } else {
-        // Previously removed from waitlist - update the existing record instead of inserting
-        nextPosition = await getNextPosition(supabase, registrationId, categoryId)
+      // Previously removed from waitlist - update the existing record instead of inserting
+      nextPosition = await getNextPosition(supabase, registrationId, categoryId)
 
-        const { data: reactivatedEntry, error: reactivateError } = await supabase
-          .from('waitlists')
-          .update({
-            removed_at: null,
-            position: nextPosition,
-            discount_code_id: validatedDiscountCodeId,
-            joined_at: new Date().toISOString()
-          })
-          .eq('id', existingWaitlist.id)
-          .select()
-          .single()
+      const { data: reactivatedEntry, error: reactivateError } = await supabase
+        .from('waitlists')
+        .update({
+          removed_at: null,
+          position: nextPosition,
+          discount_code_id: validatedDiscountCodeId,
+          joined_at: new Date().toISOString()
+        })
+        .eq('id', existingWaitlist.id)
+        .select()
+        .single()
 
-        if (reactivateError) {
-          console.error('Error reactivating waitlist entry:', reactivateError)
-          return NextResponse.json({ error: 'Failed to rejoin waitlist' }, { status: 500 })
-        }
-
-        waitlistEntry = reactivatedEntry
+      if (reactivateError) {
+        console.error('Error reactivating waitlist entry:', reactivateError)
+        return NextResponse.json({ error: 'Failed to rejoin waitlist' }, { status: 500 })
       }
-    }
 
-    // Only insert if we didn't reactivate an existing entry
-    if (!existingWaitlist) {
+      waitlistEntry = reactivatedEntry
+    } else {
       // Get the next position in line for this category
       nextPosition = await getNextPosition(supabase, registrationId, categoryId)
 

--- a/src/lib/membership-validation.ts
+++ b/src/lib/membership-validation.ts
@@ -109,19 +109,6 @@ export function formatMembershipWarning(validation: MembershipValidationResult):
 }
 
 /**
- * Calculate the cost for extending membership
- */
-export function calculateExtensionCost(
-  membership: UserMembership,
-  monthsNeeded: number
-): number {
-  if (!membership.membership) return 0
-
-  const monthlyPrice = membership.membership.price_monthly
-  return monthsNeeded * monthlyPrice
-}
-
-/**
  * Validate the "how much are you able to pay?" field on an assistance
  * purchase. Returns an error message when the value is blank, non-numeric,
  * negative, or exceeds the membership price; null when it's a valid amount.


### PR DESCRIPTION
## Summary

Part of #236. Investigates and fixes the two "higher-risk" `tsc --noEmit` findings from #238.

- **`src/app/api/join-waitlist/route.ts`** — `nextPosition` was flagged as used-before-assigned. Traced the branches: it's a TS false positive, not a runtime bug. `nextPosition` was assigned inside two separate `if` blocks (`if (existingWaitlist) {...}` / `if (!existingWaitlist) {...}`) that are logically exhaustive, but TS can't prove two independent `if` statements are complementary for definite-assignment purposes. Merged them into a single `if`/`else` — identical behavior, now provably assigned in every reachable path.
- **`src/lib/membership-validation.ts:121`** — `monthlyPrice` possibly `undefined` in `calculateExtensionCost`. Traced this to dead code: the function's only caller (`RegistrationPurchase.tsx`) had its import removed as unused during the #199 lint cleanup, but the function itself was left behind and has had zero callers since (verified via `git log -S` and a full-repo grep). The undefined value could never actually reach a calculation, so removed the unused function instead of guarding an unreachable path.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors remaining in either touched file (worked around a pre-existing, unrelated duplicate-`@types` issue caused by nested `node_modules` in this worktree layout, present on `main` too, via `--typeRoots ./node_modules/@types`); overall error count dropped 114 → 109
- [x] `npm test` — 306/306 passing
- [x] `npm run lint` — clean
- [x] `npm run build` — compiles successfully, exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)