### PR TITLE
Fix #239: typecheck cleanup for Xero debug/diagnostic routes

### DIFF
--- a/src/app/api/debug/xero-contacts/route.ts
+++ b/src/app/api/debug/xero-contacts/route.ts
@@ -1,5 +1,58 @@
 import { NextRequest, NextResponse } from 'next/server'
+import { Contact } from 'xero-node'
 import { getAuthenticatedXeroClient, getActiveTenant } from '@/lib/xero/client'
+
+interface ContactSummary {
+  name?: string
+  contactID?: string
+  status: Contact.ContactStatusEnum | string
+  email?: string
+  firstName?: string
+  lastName?: string
+  isArchived: boolean
+}
+
+interface ContactIdSearchResult {
+  found: boolean
+  contact?: ContactSummary
+  error?: string
+}
+
+interface NameOrEmailSearchResult {
+  found: boolean
+  count?: number
+  contacts?: ContactSummary[]
+  error?: string
+}
+
+interface ExactMatchResult {
+  found: boolean
+  contactID?: string
+  status?: Contact.ContactStatusEnum | string
+  isArchived?: boolean
+}
+
+interface AnalysisResult {
+  total: number
+  active: number
+  archived: number
+  exactMatch?: ExactMatchResult
+}
+
+interface DebugResults {
+  email: string | null
+  memberId: string | null
+  contactId: string | null
+  tenant: string
+  nameSearch: NameOrEmailSearchResult | null
+  emailSearch: NameOrEmailSearchResult | null
+  contactIdSearch: ContactIdSearchResult | null
+  analysis: AnalysisResult | null
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}
 
 export async function GET(request: NextRequest) {
   try {
@@ -9,7 +62,7 @@ export async function GET(request: NextRequest) {
     const contactId = searchParams.get('contactId') // New parameter for debugging specific contact
 
     if (!email && !contactId) {
-      return NextResponse.json({ 
+      return NextResponse.json({
         error: 'Either email or contactId parameter is required',
         usage: 'GET /api/debug-xero-contacts?email=david@example.com&memberId=1002\nGET /api/debug-xero-contacts?contactId=f2d4371c-a474-4539-80e0-7c0cb63390b0'
       }, { status: 400 })
@@ -37,7 +90,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ error: 'Unable to authenticate with Xero' }, { status: 500 })
     }
 
-    const results = {
+    const results: DebugResults = {
       email,
       memberId,
       contactId,
@@ -51,13 +104,13 @@ export async function GET(request: NextRequest) {
     // Step 0: Search by specific contact ID (if provided)
     if (contactId) {
       console.log(`🔍 Step 0: Searching for specific contact ID: "${contactId}"`)
-      
+
       try {
         const contactResponse = await xeroApi.accountingApi.getContact(
           activeTenant.tenant_id,
           contactId
         )
-        
+
         if (contactResponse.body.contacts && contactResponse.body.contacts.length > 0) {
           const contact = contactResponse.body.contacts[0]
           console.log(`✅ Found contact with ID "${contactId}":`)
@@ -67,17 +120,17 @@ export async function GET(request: NextRequest) {
           console.log(`  First Name: ${contact.firstName || 'None'}`)
           console.log(`  Last Name: ${contact.lastName || 'None'}`)
           console.log('')
-          
+
           results.contactIdSearch = {
             found: true,
             contact: {
               name: contact.name,
               contactID: contact.contactID,
-              status: contact.contactStatus || 'ACTIVE',
+              status: contact.contactStatus || Contact.ContactStatusEnum.ACTIVE,
               email: contact.emailAddress,
               firstName: contact.firstName,
               lastName: contact.lastName,
-              isArchived: contact.contactStatus === 'ARCHIVED'
+              isArchived: contact.contactStatus === Contact.ContactStatusEnum.ARCHIVED
             }
           }
         } else {
@@ -85,8 +138,9 @@ export async function GET(request: NextRequest) {
           results.contactIdSearch = { found: false }
         }
       } catch (contactError) {
-        console.log(`❌ Contact ID search failed:`, contactError.message)
-        results.contactIdSearch = { found: false, error: contactError.message }
+        const message = errorMessage(contactError)
+        console.log(`❌ Contact ID search failed:`, message)
+        results.contactIdSearch = { found: false, error: message }
       }
     }
 
@@ -96,31 +150,31 @@ export async function GET(request: NextRequest) {
       const cleanMemberId = memberId.replace(/"/g, '')
       const expectedContactName = `David Wender - ${cleanMemberId}`
       console.log(`🔍 Step 1: Searching for exact contact name: "${expectedContactName}"`)
-      
+
       try {
         const nameSearchResponse = await xeroApi.accountingApi.getContacts(
           activeTenant.tenant_id,
           undefined,
           `Name="${expectedContactName}"`
         )
-        
+
         if (nameSearchResponse.body.contacts && nameSearchResponse.body.contacts.length > 0) {
           console.log(`✅ Found ${nameSearchResponse.body.contacts.length} contact(s) with exact name:`)
-          
+
           results.nameSearch = {
             found: true,
             count: nameSearchResponse.body.contacts.length,
             contacts: nameSearchResponse.body.contacts.map(contact => ({
               name: contact.name,
               contactID: contact.contactID,
-              status: contact.contactStatus || 'ACTIVE',
+              status: contact.contactStatus || Contact.ContactStatusEnum.ACTIVE,
               email: contact.emailAddress,
               firstName: contact.firstName,
               lastName: contact.lastName,
-              isArchived: contact.contactStatus === 'ARCHIVED'
+              isArchived: contact.contactStatus === Contact.ContactStatusEnum.ARCHIVED
             }))
           }
-          
+
           nameSearchResponse.body.contacts.forEach((contact, index) => {
             console.log(`  ${index + 1}. Name: "${contact.name}"`)
             console.log(`     ID: ${contact.contactID}`)
@@ -128,8 +182,8 @@ export async function GET(request: NextRequest) {
             console.log(`     Email: ${contact.emailAddress || 'None'}`)
             console.log(`     First Name: ${contact.firstName || 'None'}`)
             console.log(`     Last Name: ${contact.lastName || 'None'}`)
-            
-            if (contact.contactStatus === 'ARCHIVED') {
+
+            if (contact.contactStatus === Contact.ContactStatusEnum.ARCHIVED) {
               console.log(`     ⚠️  ARCHIVED - Would be renamed to "${contact.name} - Archived"`)
             }
             console.log('')
@@ -139,15 +193,16 @@ export async function GET(request: NextRequest) {
           results.nameSearch = { found: false, count: 0, contacts: [] }
         }
       } catch (nameSearchError) {
-        console.log(`❌ Name search failed:`, nameSearchError.message)
-        results.nameSearch = { found: false, error: nameSearchError.message }
+        const message = errorMessage(nameSearchError)
+        console.log(`❌ Name search failed:`, message)
+        results.nameSearch = { found: false, error: message }
       }
     }
 
     // Step 2: Search by email (only if email provided)
     if (email) {
       console.log(`🔍 Step 2: Searching by email: "${email}"`)
-      
+
       try {
         const emailSearchResponse = await xeroApi.accountingApi.getContacts(
           activeTenant.tenant_id,
@@ -157,21 +212,21 @@ export async function GET(request: NextRequest) {
 
         if (emailSearchResponse.body.contacts && emailSearchResponse.body.contacts.length > 0) {
           console.log(`✅ Found ${emailSearchResponse.body.contacts.length} contact(s) with email:`)
-          
+
           results.emailSearch = {
             found: true,
             count: emailSearchResponse.body.contacts.length,
             contacts: emailSearchResponse.body.contacts.map(contact => ({
               name: contact.name,
               contactID: contact.contactID,
-              status: contact.contactStatus || 'ACTIVE',
+              status: contact.contactStatus || Contact.ContactStatusEnum.ACTIVE,
               email: contact.emailAddress,
               firstName: contact.firstName,
               lastName: contact.lastName,
-              isArchived: contact.contactStatus === 'ARCHIVED'
+              isArchived: contact.contactStatus === Contact.ContactStatusEnum.ARCHIVED
             }))
           }
-          
+
           emailSearchResponse.body.contacts.forEach((contact, index) => {
             console.log(`  ${index + 1}. Name: "${contact.name}"`)
             console.log(`     ID: ${contact.contactID}`)
@@ -183,15 +238,15 @@ export async function GET(request: NextRequest) {
           })
 
           // Analyze the results
-          const archivedContacts = emailSearchResponse.body.contacts.filter(c => c.contactStatus === 'ARCHIVED')
-          const activeContacts = emailSearchResponse.body.contacts.filter(c => c.contactStatus !== 'ARCHIVED')
-          
-          results.analysis = {
+          const archivedContacts = emailSearchResponse.body.contacts.filter(c => c.contactStatus === Contact.ContactStatusEnum.ARCHIVED)
+          const activeContacts = emailSearchResponse.body.contacts.filter(c => c.contactStatus !== Contact.ContactStatusEnum.ARCHIVED)
+
+          const analysis: AnalysisResult = {
             total: emailSearchResponse.body.contacts.length,
             active: activeContacts.length,
             archived: archivedContacts.length
           }
-          
+
           console.log('📊 Analysis:')
           console.log(`  Total contacts: ${emailSearchResponse.body.contacts.length}`)
           console.log(`  Active contacts: ${activeContacts.length}`)
@@ -202,32 +257,35 @@ export async function GET(request: NextRequest) {
             const cleanMemberId = memberId.replace(/"/g, '')
             const expectedName = `David Wender - ${cleanMemberId}`
             const exactMatch = emailSearchResponse.body.contacts.find(c => c.name === expectedName)
-            
+
             if (exactMatch) {
               console.log(`🎯 Exact name match found: "${exactMatch.name}" (${exactMatch.contactID})`)
               console.log(`   Status: ${exactMatch.contactStatus || 'ACTIVE'}`)
-              if (exactMatch.contactStatus === 'ARCHIVED') {
+              if (exactMatch.contactStatus === Contact.ContactStatusEnum.ARCHIVED) {
                 console.log('   ⚠️  WARNING: This contact is archived!')
               }
-              results.analysis.exactMatch = {
+              analysis.exactMatch = {
                 found: true,
                 contactID: exactMatch.contactID,
-                status: exactMatch.contactStatus || 'ACTIVE',
-                isArchived: exactMatch.contactStatus === 'ARCHIVED'
+                status: exactMatch.contactStatus || Contact.ContactStatusEnum.ACTIVE,
+                isArchived: exactMatch.contactStatus === Contact.ContactStatusEnum.ARCHIVED
               }
             } else {
               console.log(`❌ No exact name match found for: "${expectedName}"`)
-              results.analysis.exactMatch = { found: false }
+              analysis.exactMatch = { found: false }
             }
           }
+
+          results.analysis = analysis
         } else {
           console.log(`❌ No contacts found with email: "${email}"`)
           results.emailSearch = { found: false, count: 0, contacts: [] }
           results.analysis = { total: 0, active: 0, archived: 0 }
         }
       } catch (emailSearchError) {
-        console.log(`❌ Email search failed:`, emailSearchError.message)
-        results.emailSearch = { found: false, error: emailSearchError.message }
+        const message = errorMessage(emailSearchError)
+        console.log(`❌ Email search failed:`, message)
+        results.emailSearch = { found: false, error: message }
       }
     }
 
@@ -237,4 +295,4 @@ export async function GET(request: NextRequest) {
     console.error('❌ Debug script failed:', error)
     return NextResponse.json({ error: error instanceof Error ? error.message : 'Unknown error' }, { status: 500 })
   }
-} 
+}

--- a/src/app/api/debug/xero-tokens/route.ts
+++ b/src/app/api/debug/xero-tokens/route.ts
@@ -1,6 +1,27 @@
 import { NextResponse } from 'next/server'
 import { createAdminClient } from '@/lib/supabase/server'
 
+interface TokenStatusResult {
+  status: string
+  tenant_name: string
+  tenant_id: string
+  expires_at: string
+  current_time: string
+  minutes_until_expiry: number
+  is_expired: boolean
+  days_since_auth: number
+  created_at: string
+  updated_at: string
+  access_token_prefix: string
+  refresh_token_prefix: string
+  message?: string
+  action?: string
+  warning?: string
+  recommended_action?: string
+  critical?: string
+  required_action?: string
+}
+
 export async function GET() {
   try {
     const supabase = createAdminClient()
@@ -34,7 +55,7 @@ export async function GET() {
     const createdAt = new Date(token.created_at)
     const daysSinceAuth = Math.floor((now.getTime() - createdAt.getTime()) / (1000 * 60 * 60 * 24))
     
-    const result = {
+    const result: TokenStatusResult = {
       status: isExpired ? 'expired' : (minutesUntilExpiry < 60 ? 'expiring_soon' : 'valid'),
       tenant_name: token.tenant_name,
       tenant_id: token.tenant_id,


### PR DESCRIPTION
## Summary

Part of #236, closes #239. Resolves all 37 `tsc` errors in the two Xero debug/diagnostic endpoints:

- **`src/app/api/debug/xero-contacts/route.ts`** (27 errors): replaced result fields that TS was inferring as `null` with explicit interfaces (`ContactSummary`, `NameOrEmailSearchResult`, `ContactIdSearchResult`, `AnalysisResult`, `DebugResults`); switched `contactStatus === 'ARCHIVED'` string comparisons to `Contact.ContactStatusEnum.ARCHIVED`, matching the established pattern in `src/lib/xero/contacts.ts`; added a shared `errorMessage()` helper to safely read `.message` off `unknown` catch-clause errors; restructured the `analysis.exactMatch` assignment to build a local object first instead of mutating a possibly-null property.
- **`src/app/api/debug/xero-tokens/route.ts`** (10 errors): added a `TokenStatusResult` interface covering the base fields plus the conditionally-set `message`/`action`/`warning`/`recommended_action`/`critical`/`required_action` fields.

No behavior changes — these are diagnostic-only routes, not part of the sync-critical path. All console output and JSON response shapes are unchanged.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors in either target file (56 pre-existing errors remain elsewhere, tracked by other #236 sub-issues, untouched by this change)
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [x] `npm test` — 28 suites / 306 tests pass
- [x] Manually hit both routes against a real (Demo Company) Xero connection: `/api/debug/xero-tokens` returned correct expired-token status; `/api/debug/xero-contacts` returned correct not-found results for an email search and correctly surfaced a real Xero 404 API error through the new error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)