### PR TITLE
Fix #241: typecheck cleanup for component/page prop-type mismatches

### DIFF
--- a/src/app/(user)/user/account/page.tsx
+++ b/src/app/(user)/user/account/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useEffect } from 'react'
-import { User } from '@supabase/supabase-js'
+import { User, UserIdentity } from '@supabase/supabase-js'
 import { formatDate } from '@/lib/date-utils'
 import { createClient } from '@/lib/supabase/client'
 import { useToast } from '@/contexts/ToastContext'
@@ -41,7 +41,7 @@ export default function AccountPage() {
   const [userProfile, setUserProfile] = useState<UserProfile | null>(null)
   const [loading, setLoading] = useState(true)
   const [showDeleteAccount, setShowDeleteAccount] = useState(false)
-  const [googleOAuth, setGoogleOAuth] = useState<{ email: string; id: string } | null>(null)
+  const [googleOAuth, setGoogleOAuth] = useState<UserIdentity | null>(null)
   const [hasEmailAuth, setHasEmailAuth] = useState(false)
   const [showUnlinkConfirm, setShowUnlinkConfirm] = useState(false)
   const [unlinking, setUnlinking] = useState(false)
@@ -77,10 +77,7 @@ export default function AccountPage() {
       // Check for Google OAuth
       const googleIdentity = identities.find(id => id.provider === 'google')
       if (googleIdentity) {
-        setGoogleOAuth({
-          email: googleIdentity.identity_data?.email || '',
-          id: googleIdentity.identity_id  // Use identity_id (UUID), not id (provider ID)
-        })
+        setGoogleOAuth(googleIdentity)
       }
 
       // Check for email auth (magic link/PIN capability)
@@ -117,7 +114,7 @@ export default function AccountPage() {
 
     setUnlinking(true)
     try {
-      const { error } = await supabase.auth.unlinkIdentity({ identity_id: googleOAuth.id })
+      const { error } = await supabase.auth.unlinkIdentity(googleOAuth)
 
       if (error) {
         // Handle specific Supabase errors
@@ -518,7 +515,7 @@ export default function AccountPage() {
               {googleOAuth && hasEmailAuth && (
                 <div className="mt-3 pt-3 border-t border-blue-200">
                   <p className="text-sm text-blue-700 mb-2">
-                    <strong>Connected Google Account:</strong> {googleOAuth.email}
+                    <strong>Connected Google Account:</strong> {googleOAuth.identity_data?.email}
                   </p>
                   <p className="text-sm text-blue-700">
                     You can{' '}
@@ -538,7 +535,7 @@ export default function AccountPage() {
               {googleOAuth && !hasEmailAuth && (
                 <div className="mt-3 pt-3 border-t border-blue-200">
                   <p className="text-sm text-blue-700 mb-2">
-                    <strong>Connected Google Account:</strong> {googleOAuth.email}
+                    <strong>Connected Google Account:</strong> {googleOAuth.identity_data?.email}
                   </p>
                   <p className="text-sm text-blue-700">
                     You currently sign in with Google only. To unlink your Google account, you must first set up email authentication by signing out and using the &quot;Sign in with Email&quot; option to create a magic link login.
@@ -612,7 +609,7 @@ export default function AccountPage() {
                 </h3>
                 <div className="mt-2 px-7 py-3">
                   <p className="text-sm text-gray-500">
-                    Are you sure you want to unlink your Google account ({googleOAuth.email})?
+                    Are you sure you want to unlink your Google account ({googleOAuth.identity_data?.email})?
                   </p>
                   <p className="text-sm text-gray-500 mt-2">
                     After unlinking, you will only be able to sign in using magic links sent to your email address.

--- a/src/app/(user)/user/captain/[id]/roster/page.tsx
+++ b/src/app/(user)/user/captain/[id]/roster/page.tsx
@@ -78,6 +78,8 @@ interface AlternateData {
   }>
 }
 
+type AlternateSortField = Exclude<keyof AlternateData, 'selections'>
+
 type LgbtqFilter = 'lgbtq' | 'ally' | 'no_response'
 type GoalieFilter = 'goalie' | 'non_goalie'
 
@@ -97,7 +99,7 @@ export default function CaptainRosterPage() {
   const [searchTerm, setSearchTerm] = useState('')
   const [sortField, setSortField] = useState<keyof RegistrationData>('first_name')
   const [sortDirection, setSortDirection] = useState<'asc' | 'desc'>('asc')
-  const [alternatesSortField, setAlternatesSortField] = useState<keyof AlternateData>('first_name')
+  const [alternatesSortField, setAlternatesSortField] = useState<AlternateSortField>('first_name')
   const [alternatesSortDirection, setAlternatesSortDirection] = useState<'asc' | 'desc'>('asc')
 
   // Filter state
@@ -166,7 +168,7 @@ export default function CaptainRosterPage() {
     }
   }
 
-  const handleAlternatesSort = (field: keyof AlternateData) => {
+  const handleAlternatesSort = (field: AlternateSortField) => {
     if (alternatesSortField === field) {
       setAlternatesSortDirection(alternatesSortDirection === 'asc' ? 'desc' : 'asc')
     } else {
@@ -795,7 +797,7 @@ export default function CaptainRosterPage() {
                           <th
                             key={key}
                             className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider cursor-pointer hover:bg-gray-100"
-                            onClick={() => handleAlternatesSort(key as keyof AlternateData)}
+                            onClick={() => handleAlternatesSort(key as AlternateSortField)}
                           >
                             <div className="flex items-center">
                               {label}

--- a/src/app/api/admin/registrations/[id]/captains/[captainId]/route.ts
+++ b/src/app/api/admin/registrations/[id]/captains/[captainId]/route.ts
@@ -5,12 +5,11 @@ import { emailService, EMAIL_EVENTS } from '@/lib/email/service'
 // DELETE /api/admin/registrations/[id]/captains/[captainId] - Remove a captain
 export async function DELETE(
   request: NextRequest,
-  { params }: { params: { id: string; captainId: string } }
+  { params }: { params: Promise<{ id: string; captainId: string }> }
 ) {
   try {
     const supabase = await createClient()
-    const registrationId = params.id
-    const captainId = params.captainId
+    const { id: registrationId, captainId } = await params
     const body = await request.json()
     const { registrationName, seasonName } = body
 

--- a/src/app/api/admin/users/[id]/invoices/[invoiceId]/refund/route.ts
+++ b/src/app/api/admin/users/[id]/invoices/[invoiceId]/refund/route.ts
@@ -4,10 +4,11 @@ import { Logger } from '@/lib/logging/logger'
 
 export async function POST(
   request: NextRequest,
-  { params }: { params: { id: string; invoiceId: string } }
+  { params }: { params: Promise<{ id: string; invoiceId: string }> }
 ) {
   const supabase = await createClient()
   const logger = Logger.getInstance()
+  const { id, invoiceId } = await params
 
   try {
     // Check if current user is admin
@@ -42,8 +43,8 @@ export async function POST(
     // 5. Update payment status in database
 
     logger.logSystem('refund-requested', 'Refund requested (not yet implemented)', {
-      targetUserId: params.id,
-      invoiceId: params.invoiceId,
+      targetUserId: id,
+      invoiceId,
       amount,
       reason,
       requestedByUserId: authUser.id
@@ -55,15 +56,15 @@ export async function POST(
       details: {
         requestedAmount: amount,
         reason,
-        invoiceId: params.invoiceId,
-        userId: params.id
+        invoiceId,
+        userId: id
       }
     })
 
   } catch (error) {
     logger.logSystem('refund-error', 'Error processing refund request', { 
-      targetUserId: params.id,
-      invoiceId: params.invoiceId,
+      targetUserId: id,
+      invoiceId,
       error: error instanceof Error ? error.message : 'Unknown error'
     })
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 })

--- a/src/components/AdminHeader.tsx
+++ b/src/components/AdminHeader.tsx
@@ -7,13 +7,22 @@ interface AdminHeaderProps {
   title: string
   description?: string
   useToggle?: boolean
+  backLink?: string
 }
 
-export default function AdminHeader({ title, description, useToggle = false }: AdminHeaderProps) {
+export default function AdminHeader({ title, description, useToggle = false, backLink }: AdminHeaderProps) {
   return (
     <div className="mb-8">
       <div className="flex items-center justify-between">
         <div>
+          {backLink && (
+            <Link
+              href={backLink}
+              className="text-blue-600 hover:text-blue-500 text-sm font-medium"
+            >
+              ← Back
+            </Link>
+          )}
           <h1 className="text-3xl font-bold text-gray-900">{title}</h1>
           {description && (
             <p className="mt-1 text-sm text-gray-600">{description}</p>

--- a/src/components/UserNavigation.tsx
+++ b/src/components/UserNavigation.tsx
@@ -21,6 +21,13 @@ interface UserNavigationProps {
   useToggle?: boolean
 }
 
+interface NavItem {
+  name: string
+  href: string
+  current: boolean
+  badge?: string
+}
+
 export default function UserNavigation({ user }: UserNavigationProps) {
   const [isMenuOpen, setIsMenuOpen] = useState(false)
   const [hasUnpaid, setHasUnpaid] = useState(false)
@@ -53,7 +60,7 @@ export default function UserNavigation({ user }: UserNavigationProps) {
     }
   }, [user?.id])
 
-  const baseNavigation = [
+  const baseNavigation: NavItem[] = [
     { name: 'Dashboard', href: '/user', current: pathname === '/user' },
     { name: 'My Memberships', href: '/user/memberships', current: pathname === '/user/memberships' },
     { name: 'My Registrations', href: '/user/registrations', current: pathname === '/user/registrations' },


### PR DESCRIPTION
## Summary

Fixes all 11 typecheck errors from #241 (part of #236), a grab-bag of prop/type mismatches across 5 files:

- `src/components/UserNavigation.tsx` — declares a `NavItem` type with an optional `badge` field instead of letting the array literal infer a type without it (5 errors)
- `src/app/(user)/user/account/page.tsx` — stores the full `UserIdentity` object returned by Supabase instead of a partial `{email, id}` shape, fixing the `unlinkIdentity()` call signature (1 error)
- `src/app/admin/registration-categories/new/page.tsx` — the page was already passing a `backLink` prop to `AdminHeader`; `AdminHeaderProps` didn't declare it and the component silently dropped it. Added the prop and rendered it as an actual back link (1 error)
- `src/app/(user)/user/captain/[id]/roster/page.tsx` — excludes the non-sortable `selections` array field from the alternates sort-field type, since it was never a clickable column and its value type doesn't fit the `string | number | boolean | null` sort comparison (2 errors)
- `.next/types/validator.ts` (generated) — the real fix is in the two flagged route handlers: `src/app/api/admin/registrations/[id]/captains/[captainId]/route.ts` and `src/app/api/admin/users/[id]/invoices/[invoiceId]/refund/route.ts` still destructured `params` synchronously; switched both to the async `Promise<...>` shape Next 15 requires, matching every other route handler in the codebase (2 errors)

## Test plan

- [x] `npx tsc --noEmit` — 0 errors in the 5 target files, no regressions elsewhere (remaining errors are pre-existing, tracked separately under #236)
- [x] `npm run build` — succeeds, full route table generated cleanly
- [x] `npm run lint` — clean
- [x] `npm test` — 306/306 passing
- [x] Manually verified on a live Vercel preview deployment via the preview-auth bypass:
  - `/user/account` — Account Settings page loads, no console errors
  - `/admin/registration-categories/new` — back link renders and navigates to `/admin/registration-categories`
  - `/user` — nav bar renders correctly (badge type change)
  - `/user/captain/[id]/roster` — roster page loads for a captain, no console errors
  - Exercised the fixed `DELETE /api/admin/registrations/[id]/captains/[captainId]` route end-to-end by adding then removing a test captain via the admin UI — succeeded with no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)