### PR TITLE
Fix #240: typecheck cleanup for implicit-any Supabase cookie-handler params

### DIFF
--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,4 +1,4 @@
-import { createServerClient } from '@supabase/ssr'
+import { createServerClient, type SetAllCookies } from '@supabase/ssr'
 import { createClient as createSupabaseClient } from '@supabase/supabase-js'
 import { cookies } from 'next/headers'
 
@@ -13,7 +13,7 @@ export async function createClient() {
         getAll() {
           return cookieStore.getAll()
         },
-        setAll(cookiesToSet) {
+        setAll(cookiesToSet: Parameters<SetAllCookies>[0]) {
           try {
             cookiesToSet.forEach(({ name, value, options }) => {
               cookieStore.set(name, value, options)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,4 +1,4 @@
-import { createServerClient } from '@supabase/ssr'
+import { createServerClient, type SetAllCookies } from '@supabase/ssr'
 import { NextResponse, type NextRequest } from 'next/server'
 
 export async function proxy(request: NextRequest) {
@@ -28,7 +28,7 @@ export async function proxy(request: NextRequest) {
         getAll() {
           return request.cookies.getAll()
         },
-        setAll(cookiesToSet) {
+        setAll(cookiesToSet: Parameters<SetAllCookies>[0]) {
           cookiesToSet.forEach(({ name, value }) => request.cookies.set(name, value))
           response = NextResponse.next({
             request,


### PR DESCRIPTION
## Summary

- Part of #236, closes #240.
- `src/proxy.ts` and `src/lib/supabase/server.ts` both implement the same `@supabase/ssr` cookie-handling `setAll` callback with an implicit-`any` parameter (`cookiesToSet`, and its destructured `name`/`value`/`options`).
- Typed the callback param using `@supabase/ssr`'s own exported `SetAllCookies` type (`Parameters<SetAllCookies>[0]`), which resolves all 10 implicit-any errors without changing any runtime logic.
- Did not extract a shared helper between the two files — the issue called this optional, and the fix is purely mechanical typing.

## Test plan

- [x] `npx tsc --noEmit` — 0 errors in both changed files (remaining errors elsewhere in the repo are pre-existing and unrelated to this issue)
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds
- [x] `npm test` — 306/306 passing
- [x] Verified locally with `npm run dev`: unauthenticated request to `/dashboard` correctly redirects to `/auth/login` (exercises the proxy middleware's cookie `getAll`/`setAll` handling), no runtime errors in server logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)