### PR TITLE
Fix #242: typecheck cleanup for test Request/mock-client shapes

### DIFF
--- a/src/__tests__/api/admin/payment-plan-eligibility.test.ts
+++ b/src/__tests__/api/admin/payment-plan-eligibility.test.ts
@@ -3,6 +3,7 @@
  * Endpoint: /api/admin/users/[id]/payment-plan-eligibility
  */
 
+import { NextRequest } from 'next/server'
 import { GET, PUT } from '@/app/api/admin/users/[id]/payment-plan-eligibility/route'
 import { createClient, createAdminClient } from '@/lib/supabase/server'
 
@@ -48,8 +49,8 @@ describe('/api/admin/users/[id]/payment-plan-eligibility', () => {
         error: null
       })
 
-      const request = new Request('http://localhost:3000/api/admin/users/test-id/payment-plan-eligibility')
-      const response = await GET(request, { params: { id: 'test-id' } })
+      const request = new NextRequest('http://localhost:3000/api/admin/users/test-id/payment-plan-eligibility')
+      const response = await GET(request, { params: Promise.resolve({ id: 'test-id' }) })
       const data = await response.json()
 
       expect(response.status).toBe(401)
@@ -70,8 +71,8 @@ describe('/api/admin/users/[id]/payment-plan-eligibility', () => {
 
       mockSupabase.from.mockReturnValueOnce(adminCheckChain)
 
-      const request = new Request('http://localhost:3000/api/admin/users/test-id/payment-plan-eligibility')
-      const response = await GET(request, { params: { id: 'test-id' } })
+      const request = new NextRequest('http://localhost:3000/api/admin/users/test-id/payment-plan-eligibility')
+      const response = await GET(request, { params: Promise.resolve({ id: 'test-id' }) })
       const data = await response.json()
 
       expect(response.status).toBe(403)
@@ -102,8 +103,8 @@ describe('/api/admin/users/[id]/payment-plan-eligibility', () => {
         .mockReturnValueOnce(adminCheckChain)
         .mockReturnValueOnce(userChain)
 
-      const request = new Request('http://localhost:3000/api/admin/users/target-user-id/payment-plan-eligibility')
-      const response = await GET(request, { params: { id: 'target-user-id' } })
+      const request = new NextRequest('http://localhost:3000/api/admin/users/target-user-id/payment-plan-eligibility')
+      const response = await GET(request, { params: Promise.resolve({ id: 'target-user-id' }) })
       const data = await response.json()
 
       expect(response.status).toBe(200)
@@ -135,8 +136,8 @@ describe('/api/admin/users/[id]/payment-plan-eligibility', () => {
         .mockReturnValueOnce(adminCheckChain)
         .mockReturnValueOnce(userChain)
 
-      const request = new Request('http://localhost:3000/api/admin/users/invalid-id/payment-plan-eligibility')
-      const response = await GET(request, { params: { id: 'invalid-id' } })
+      const request = new NextRequest('http://localhost:3000/api/admin/users/invalid-id/payment-plan-eligibility')
+      const response = await GET(request, { params: Promise.resolve({ id: 'invalid-id' }) })
       const data = await response.json()
 
       expect(response.status).toBe(404)
@@ -151,11 +152,11 @@ describe('/api/admin/users/[id]/payment-plan-eligibility', () => {
         error: null
       })
 
-      const request = new Request('http://localhost:3000/api/admin/users/test-id/payment-plan-eligibility', {
+      const request = new NextRequest('http://localhost:3000/api/admin/users/test-id/payment-plan-eligibility', {
         method: 'PUT',
         body: JSON.stringify({ enabled: true })
       })
-      const response = await PUT(request, { params: { id: 'test-id' } })
+      const response = await PUT(request, { params: Promise.resolve({ id: 'test-id' }) })
       const data = await response.json()
 
       expect(response.status).toBe(401)
@@ -176,11 +177,11 @@ describe('/api/admin/users/[id]/payment-plan-eligibility', () => {
 
       mockSupabase.from.mockReturnValueOnce(adminCheckChain)
 
-      const request = new Request('http://localhost:3000/api/admin/users/test-id/payment-plan-eligibility', {
+      const request = new NextRequest('http://localhost:3000/api/admin/users/test-id/payment-plan-eligibility', {
         method: 'PUT',
         body: JSON.stringify({ enabled: true })
       })
-      const response = await PUT(request, { params: { id: 'test-id' } })
+      const response = await PUT(request, { params: Promise.resolve({ id: 'test-id' }) })
       const data = await response.json()
 
       expect(response.status).toBe(403)
@@ -201,11 +202,11 @@ describe('/api/admin/users/[id]/payment-plan-eligibility', () => {
 
       mockSupabase.from.mockReturnValueOnce(adminCheckChain)
 
-      const request = new Request('http://localhost:3000/api/admin/users/test-id/payment-plan-eligibility', {
+      const request = new NextRequest('http://localhost:3000/api/admin/users/test-id/payment-plan-eligibility', {
         method: 'PUT',
         body: JSON.stringify({ enabled: 'yes' })
       })
-      const response = await PUT(request, { params: { id: 'test-id' } })
+      const response = await PUT(request, { params: Promise.resolve({ id: 'test-id' }) })
       const data = await response.json()
 
       expect(response.status).toBe(400)
@@ -241,11 +242,11 @@ describe('/api/admin/users/[id]/payment-plan-eligibility', () => {
 
       mockAdminSupabase.from.mockReturnValueOnce(updateChain)
 
-      const request = new Request('http://localhost:3000/api/admin/users/target-user-id/payment-plan-eligibility', {
+      const request = new NextRequest('http://localhost:3000/api/admin/users/target-user-id/payment-plan-eligibility', {
         method: 'PUT',
         body: JSON.stringify({ enabled: true })
       })
-      const response = await PUT(request, { params: { id: 'target-user-id' } })
+      const response = await PUT(request, { params: Promise.resolve({ id: 'target-user-id' }) })
       const data = await response.json()
 
       expect(response.status).toBe(200)
@@ -283,11 +284,11 @@ describe('/api/admin/users/[id]/payment-plan-eligibility', () => {
 
       mockAdminSupabase.from.mockReturnValueOnce(updateChain)
 
-      const request = new Request('http://localhost:3000/api/admin/users/test-id/payment-plan-eligibility', {
+      const request = new NextRequest('http://localhost:3000/api/admin/users/test-id/payment-plan-eligibility', {
         method: 'PUT',
         body: JSON.stringify({ enabled: false })
       })
-      const response = await PUT(request, { params: { id: 'test-id' } })
+      const response = await PUT(request, { params: Promise.resolve({ id: 'test-id' }) })
       const data = await response.json()
 
       expect(response.status).toBe(500)

--- a/src/__tests__/api/admin/user-payment-plans.test.ts
+++ b/src/__tests__/api/admin/user-payment-plans.test.ts
@@ -3,6 +3,7 @@
  * Endpoint: /api/admin/users/[id]/payment-plans
  */
 
+import { NextRequest } from 'next/server'
 import { GET } from '@/app/api/admin/users/[id]/payment-plans/route'
 import { createClient, createAdminClient } from '@/lib/supabase/server'
 
@@ -46,8 +47,8 @@ describe('/api/admin/users/[id]/payment-plans', () => {
         error: null
       })
 
-      const request = new Request('http://localhost:3000/api/admin/users/test-id/payment-plans')
-      const response = await GET(request, { params: { id: 'test-id' } })
+      const request = new NextRequest('http://localhost:3000/api/admin/users/test-id/payment-plans')
+      const response = await GET(request, { params: Promise.resolve({ id: 'test-id' }) })
       const data = await response.json()
 
       expect(response.status).toBe(401)
@@ -68,8 +69,8 @@ describe('/api/admin/users/[id]/payment-plans', () => {
 
       mockSupabase.from.mockReturnValueOnce(adminCheckChain)
 
-      const request = new Request('http://localhost:3000/api/admin/users/test-id/payment-plans')
-      const response = await GET(request, { params: { id: 'test-id' } })
+      const request = new NextRequest('http://localhost:3000/api/admin/users/test-id/payment-plans')
+      const response = await GET(request, { params: Promise.resolve({ id: 'test-id' }) })
       const data = await response.json()
 
       expect(response.status).toBe(403)
@@ -115,8 +116,8 @@ describe('/api/admin/users/[id]/payment-plans', () => {
       })
       mockAdminSupabase.from.mockReturnValueOnce(paymentPlansChain)
 
-      const request = new Request('http://localhost:3000/api/admin/users/target-user-id/payment-plans')
-      const response = await GET(request, { params: { id: 'target-user-id' } })
+      const request = new NextRequest('http://localhost:3000/api/admin/users/target-user-id/payment-plans')
+      const response = await GET(request, { params: Promise.resolve({ id: 'target-user-id' }) })
       const data = await response.json()
 
       expect(response.status).toBe(200)
@@ -150,8 +151,8 @@ describe('/api/admin/users/[id]/payment-plans', () => {
       })
       mockAdminSupabase.from.mockReturnValueOnce(paymentPlansChain)
 
-      const request = new Request('http://localhost:3000/api/admin/users/target-user-id/payment-plans')
-      const response = await GET(request, { params: { id: 'target-user-id' } })
+      const request = new NextRequest('http://localhost:3000/api/admin/users/target-user-id/payment-plans')
+      const response = await GET(request, { params: Promise.resolve({ id: 'target-user-id' }) })
       const data = await response.json()
 
       expect(response.status).toBe(200)
@@ -181,8 +182,8 @@ describe('/api/admin/users/[id]/payment-plans', () => {
       })
       mockAdminSupabase.from.mockReturnValueOnce(paymentPlansChain)
 
-      const request = new Request('http://localhost:3000/api/admin/users/target-user-id/payment-plans')
-      const response = await GET(request, { params: { id: 'target-user-id' } })
+      const request = new NextRequest('http://localhost:3000/api/admin/users/target-user-id/payment-plans')
+      const response = await GET(request, { params: Promise.resolve({ id: 'target-user-id' }) })
       const data = await response.json()
 
       expect(response.status).toBe(500)

--- a/src/__tests__/api/alternate-registrations-batch.test.ts
+++ b/src/__tests__/api/alternate-registrations-batch.test.ts
@@ -11,11 +11,7 @@ const mockSupabase = {
   auth: {
     getUser: jest.fn()
   },
-  from: jest.fn(() => ({
-    select: jest.fn().mockReturnThis(),
-    in: jest.fn().mockReturnThis(),
-    order: jest.fn().mockReturnThis()
-  }))
+  from: jest.fn() as jest.Mock
 }
 
 const mockLogger = {

--- a/src/__tests__/api/alternate-registrations.test.ts
+++ b/src/__tests__/api/alternate-registrations.test.ts
@@ -11,13 +11,7 @@ const mockSupabase = {
   auth: {
     getUser: jest.fn()
   },
-  from: jest.fn(() => ({
-    select: jest.fn().mockReturnThis(),
-    insert: jest.fn().mockReturnThis(),
-    eq: jest.fn().mockReturnThis(),
-    single: jest.fn(),
-    order: jest.fn().mockReturnThis()
-  }))
+  from: jest.fn() as jest.Mock
 }
 
 const mockLogger = {

--- a/src/__tests__/api/user-alternate-registrations.test.ts
+++ b/src/__tests__/api/user-alternate-registrations.test.ts
@@ -250,8 +250,7 @@ describe('/api/user-alternate-registrations', () => {
     it('should require authentication', async () => {
       mockSupabase.auth.getUser.mockResolvedValue({ data: { user: null } })
 
-      const request = new NextRequest('http://localhost/api/user-alternate-registrations')
-      const response = await GET(request)
+      const response = await GET()
       const data = await response.json()
 
       expect(response.status).toBe(401)
@@ -287,8 +286,7 @@ describe('/api/user-alternate-registrations', () => {
         }))
       })
 
-      const request = new NextRequest('http://localhost/api/user-alternate-registrations')
-      const response = await GET(request)
+      const response = await GET()
       const data = await response.json()
 
       expect(response.status).toBe(200)

--- a/src/__tests__/integration/report-consistency.test.ts
+++ b/src/__tests__/integration/report-consistency.test.ts
@@ -226,8 +226,7 @@ describe('Report Consistency Integration (End-to-End Resolution)', () => {
 
   it('Discount Usage and Discount Eligibility reports agree on remaining balance ($150) driven by allowance cap ($250), not category cap ($750)', async () => {
     // 1. Call Usage Report GET
-    const reqUsage = new NextRequest('http://localhost/api/admin/reports/discount-usage')
-    const resUsage = await getUsageReport(reqUsage)
+    const resUsage = await getUsageReport()
     expect(resUsage.status).toBe(200)
     const usageData = await resUsage.json() as UsageReportData
 


### PR DESCRIPTION
## Summary
- Swap plain `Request` for `NextRequest` in `payment-plan-eligibility.test.ts` and `user-payment-plans.test.ts`, and wrap route `params` in `Promise.resolve()` to match the async-params route signature (surfaced once the `NextRequest` mismatch was fixed).
- Loosen the `mockSupabase.from` mock type in `alternate-registrations.test.ts` and `alternate-registrations-batch.test.ts` so per-test partial mock chains (`select`/`insert`/`eq`/`single`/`order` subsets) don't need to satisfy the full inferred chain shape.
- Drop the unused `request` argument from `GET()` calls in `user-alternate-registrations.test.ts` and `report-consistency.test.ts`, where the underlying route handler takes no request parameter.

Closes #242, the last major subissue of #236.

## Test plan
- [x] `npx tsc --noEmit` — 0 errors (previously 37 in these 6 files; also confirmed 0 errors repo-wide)
- [x] `npm test` — 306/306 passing
- [x] `npm run lint` — clean
- [x] `npm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)