### PR TITLE
Fix #243: re-enable blocking typecheck in CI, remove ignoreBuildErrors

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,6 +31,9 @@ jobs:
     - name: Run lint
       run: npm run lint
 
+    - name: Run typecheck
+      run: npm run typecheck
+
     - name: Run build
       run: npm run build
       env:

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,9 +2,6 @@ import { withSentryConfig } from "@sentry/nextjs";
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  typescript: {
-    ignoreBuildErrors: true,
-  },
   webpack: (config) => {
     // Suppress Supabase realtime warnings
     config.ignoreWarnings = [

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
+    "typecheck": "tsc --noEmit",
     "test": "npx jest",
     "test:watch": "npx jest --watch",
     "test:coverage": "npx jest --coverage"


### PR DESCRIPTION
## Summary
- Adds a `"typecheck": "tsc --noEmit"` script to `package.json`
- Adds a "Run typecheck" step to `.github/workflows/test.yml`
- Removes `typescript: { ignoreBuildErrors: true }` from `next.config.ts` so `next build` itself enforces type safety

This is the exit-criteria issue for #236: the typecheck backlog (#237-#242) is paid down, `npx tsc --noEmit` is clean, so this flips the compiler from a suppressed/ignored check into an actual blocking gate in both CI and the build itself.

## Test plan
- [x] `npx tsc --noEmit` — clean, 0 errors
- [x] `npm run build` — compiles, runs TypeScript check (passes), generates all 152 pages
- [x] `npm run lint` — clean
- [x] `npm test` — 28 suites / 306 tests passing