### PR TITLE
Document schema.sql staleness and magic-link email template gotchas in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,8 @@ NEXT_PUBLIC_APP_TIMEZONE=America/New_York
    # Apply the schema.sql file in your Supabase SQL editor
    ```
 
+   **Note:** `supabase/schema.sql` is a periodically-refreshed snapshot, not auto-generated on every migration — it can lag `supabase/migrations/` by months (tracked in dwenderf/membership-system#256). After applying it, check `supabase/migrations/` for any files dated after schema.sql's own last-modified date (`git log -1 -- supabase/schema.sql`) and apply those too, in filename order, to get a fully current schema. A missing table/column/view during local setup is often this, not a real bug.
+
 4. Set up Row Level Security (RLS) policies as defined in `supabase/schema.sql`
 
 ### 4. Run Development Server

--- a/README.md
+++ b/README.md
@@ -197,6 +197,14 @@ NEXT_PUBLIC_APP_TIMEZONE=America/New_York
 
 4. Set up Row Level Security (RLS) policies as defined in `supabase/schema.sql`
 
+5. **Fix the magic-link email template** (required — every fresh Supabase project needs this): Supabase's default "Magic Link" email template uses `{{ .ConfirmationURL }}`, which sends a PKCE-flow link (`?code=...`). This app's magic-link confirmation page (`src/app/auth/magic-confirm/page.tsx`) instead expects `?token_hash=...&type=...` and calls `supabase.auth.verifyOtp({ token_hash, type })` — so every magic-link sign-in will silently 404 into `/auth/auth-code-error` until you fix the template. Go to **Authentication** → **Email Templates** → **Magic Link** in the Supabase dashboard and set the link in the template body to:
+
+   ```
+   {{ .SiteURL }}/auth/magic-confirm?token_hash={{ .TokenHash }}&type=magiclink
+   ```
+
+   This is a dashboard-only setting with no trace in the repo (tracked in dwenderf/membership-system#265), so it has to be set by hand on every fresh Supabase project.
+
 ### 4. Run Development Server
 
 ```bash


### PR DESCRIPTION
## Summary
- Adds a note after README's Database Setup step 3 (applying `schema.sql`) explaining that `schema.sql` is a periodically-refreshed snapshot that can lag `supabase/migrations/`, and pointing readers to check for and apply newer migration files.
- Adds a new step 5 to Database Setup documenting that Supabase's default Magic Link email template must be manually changed to use `{{ .SiteURL }}/auth/magic-confirm?token_hash={{ .TokenHash }}&type=magiclink`, since this app's `src/app/auth/magic-confirm/page.tsx` reads `token_hash`/`type` and calls `supabase.auth.verifyOtp()` rather than following Supabase's default PKCE `ConfirmationURL` link — without this, magic-link sign-in silently 404s into `/auth/auth-code-error` on every fresh Supabase project.

Scope note: both linked issues also propose a bigger architectural fix (auto-regenerating `schema.sql`, or a setup script that configures the email template via Supabase's Management API). This PR only adds the documentation/warning notes — those bigger decisions are left open for the repo owner.

- Partially addresses #256 (documents the staleness gotcha; the underlying schema.sql regeneration approach is still an open decision for the repo owner)
- Partially addresses #265 (documents the required template fix; whether to codify it via a setup script using Supabase's Management API is still open)

## Test plan
- [x] `npm run build` — succeeds
- [x] `npx tsc --noEmit` — no errors
- [x] `npm run lint` — no errors
- [x] Verified `src/app/auth/magic-confirm/page.tsx` actually reads `token_hash`/`type` from the URL and calls `supabase.auth.verifyOtp({ token_hash, type })`, confirming the README claim is accurate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)