### PR TITLE
Sync development.md file-structure section and bump last-updated stamp

### DIFF
--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -536,5 +536,5 @@ Document API endpoints with:
 
 ---
 
-*Last updated: October 23, 2025*
+*Last updated: August 22, 2026*
 *This document should be updated as new patterns and practices are established.*

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -237,15 +237,16 @@ const { data: profile } = await supabase
 src/
 ├── app/                    # Next.js app router pages and API routes
 ├── components/            # Reusable UI components
+├── config/                # App configuration
+├── contexts/              # React context providers
 ├── lib/                   # Business logic and utilities
 │   ├── services/         # Business services (payment, email, etc.)
 │   ├── logging/          # Centralized logging system
 │   └── supabase/         # Database client configuration
 ├── types/                # TypeScript type definitions
-scripts/                   # Development and administrative scripts
+scripts/                   # Development and administrative scripts (flat mix of .sql/.js/.sh files)
 ├── tests/                # Feature testing scripts
-├── debug/                # Debugging and troubleshooting scripts
-└── admin/                # Administrative and maintenance scripts
+└── debug/                # Debugging and troubleshooting scripts
 docs/                      # Project documentation
 └── logs/                  # Generated log files (gitignored)
 ```


### PR DESCRIPTION
## Summary
- Fixes #262: the `File Structure` tree under "Code Organization" was stale — `src/config/` and `src/contexts/` exist but were missing, and `scripts/admin/` was listed but doesn't exist (the real `scripts/` directory is a flat mix of `.sql`/`.js`/`.sh` files plus only `tests/` and `debug/` subdirectories). Verified against the current repo layout with `ls src/` and `ls scripts/`.
- Fixes #264: the `*Last updated*` footer stamp was stale (October 23, 2025). Bumped to today's date to accompany the real edits in this PR.

Note: #264 also raised an open question — whether this stamp should be automated going forward instead of hand-edited. That question is intentionally left open for the repo owner to decide separately; this PR only corrects the stale value.

## Test plan
- [x] `npm run build` — succeeds
- [x] `npx tsc --noEmit` — no errors
- [x] `npm run lint` — no errors

Fixes #262, Fixes #264