### PR TITLE
Fix registration category edit, add Goalie Only category flag

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,8 @@ This repo is linked to Vercel (`nycpha/membership-system`). A fresh git worktree
 
 Migrations are applied manually by the maintainer. Write the migration file only. Do not run `supabase db push`, `db reset`, `migration up`, or `supabase link` under any circumstances. Do not attempt to verify the migration by connecting to the database. The migration file existing in `supabase/migrations/` is the complete deliverable.
 
+Write migrations idempotently where possible (`ADD COLUMN IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`, `DROP ... IF EXISTS`, etc.) so a migration can be safely re-applied without erroring if it was already partially or fully applied.
+
 ## Supabase relation queries
 
 The Supabase clients in `src/lib/supabase/` (`createServerClient`/`createBrowserClient`/`createClient`) don't pass the generated `Database` type as a generic, so it defaults to `any` — `.select()` results, including embedded relations (joins), are not compiler-checked by default. When postgrest-js can't resolve real foreign-key cardinality from schema metadata, it silently infers **every** embedded relation as an array, even a true one-to-one "belongs-to" join. Don't trust the inferred type's array-ness as a signal of real cardinality, and don't blindly add `[0]` indexing or `Array.isArray()` handling to silence a type error without checking first.

--- a/src/app/(user)/user/browse-registrations/[id]/page.tsx
+++ b/src/app/(user)/user/browse-registrations/[id]/page.tsx
@@ -37,7 +37,7 @@ interface RegistrationCategoryRow {
   max_capacity: number | null
   required_membership_id: string | null
   sort_order: number
-  categories: Pick<Database['public']['Tables']['categories']['Row'], 'name'> | null
+  categories: Pick<Database['public']['Tables']['categories']['Row'], 'name' | 'is_goalie_only'> | null
   memberships: Pick<MembershipRow, 'id' | 'name'> | null
 }
 
@@ -87,7 +87,7 @@ export default async function RegistrationDetailPage({ params }: PageProps) {
   // Get user profile to check LGBTQ status and name
   const { data: userProfile } = await supabase
     .from('users')
-    .select('is_lgbtq, first_name, last_name')
+    .select('is_lgbtq, is_goalie, first_name, last_name')
     .eq('id', user.id)
     .single()
 
@@ -131,7 +131,7 @@ export default async function RegistrationDetailPage({ params }: PageProps) {
       memberships:required_membership_id(id, name),
       registration_categories(
         *,
-        categories:category_id(name),
+        categories:category_id(name, is_goalie_only),
         memberships:required_membership_id(id, name)
       )
     `)
@@ -481,6 +481,7 @@ export default async function RegistrationDetailPage({ params }: PageProps) {
                 activeMemberships={activeMembershipsForValidation}
                 isEligible={hasEligibleMembership}
                 isLgbtq={userProfile?.is_lgbtq || false}
+                isGoalie={userProfile?.is_goalie || false}
                 isAlreadyRegistered={isAlreadyRegistered}
                 isAlreadyAlternate={userAlternateRegistrationIds.includes(registration.id)}
               />

--- a/src/app/admin/registration-categories/[id]/edit/page.tsx
+++ b/src/app/admin/registration-categories/[id]/edit/page.tsx
@@ -13,6 +13,7 @@ interface Category {
   description: string | null
   category_type: string
   created_at: string
+  is_goalie_only: boolean
 }
 
 export default function EditRegistrationCategoryPage() {
@@ -23,6 +24,7 @@ export default function EditRegistrationCategoryPage() {
   const [category, setCategory] = useState<Category | null>(null)
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
+  const [isGoalieOnly, setIsGoalieOnly] = useState(false)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
   const [initialLoading, setInitialLoading] = useState(true)
@@ -41,6 +43,7 @@ export default function EditRegistrationCategoryPage() {
         setCategory(data)
         setName(data.name)
         setDescription(data.description || '')
+        setIsGoalieOnly(data.is_goalie_only ?? false)
       } catch (err) {
         setError('An unexpected error occurred')
         console.error('Error fetching category:', err)
@@ -66,6 +69,7 @@ export default function EditRegistrationCategoryPage() {
         body: JSON.stringify({
           name: name.trim(),
           description: description.trim() || null,
+          is_goalie_only: isGoalieOnly,
         }),
       })
 
@@ -182,6 +186,26 @@ export default function EditRegistrationCategoryPage() {
             <p className="mt-2 text-sm text-gray-500">
               Provide additional context about when and how this category should be used.
             </p>
+          </div>
+
+          <div className="flex items-start">
+            <div className="flex items-center h-5">
+              <input
+                id="is_goalie_only"
+                type="checkbox"
+                checked={isGoalieOnly}
+                onChange={(e) => setIsGoalieOnly(e.target.checked)}
+                className="focus:ring-blue-500 h-4 w-4 text-blue-600 border-gray-300 rounded"
+              />
+            </div>
+            <div className="ml-3 text-sm">
+              <label htmlFor="is_goalie_only" className="font-medium text-gray-700">
+                Goalie Only
+              </label>
+              <p className="text-gray-500 text-xs mt-1">
+                Only members who have identified themselves as a goalie will be able to register in this category.
+              </p>
+            </div>
           </div>
 
           <div className="bg-gray-50 border border-gray-200 rounded-md p-4">

--- a/src/app/admin/registration-categories/new/page.tsx
+++ b/src/app/admin/registration-categories/new/page.tsx
@@ -9,6 +9,7 @@ export default function NewRegistrationCategoryPage() {
   const router = useRouter()
   const [name, setName] = useState('')
   const [description, setDescription] = useState('')
+  const [isGoalieOnly, setIsGoalieOnly] = useState(false)
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
 
@@ -26,6 +27,7 @@ export default function NewRegistrationCategoryPage() {
         body: JSON.stringify({
           name: name.trim(),
           description: description.trim() || null,
+          is_goalie_only: isGoalieOnly,
         }),
       })
 
@@ -102,6 +104,26 @@ export default function NewRegistrationCategoryPage() {
             <p className="mt-2 text-sm text-gray-500">
               Provide additional context about when and how this category should be used.
             </p>
+          </div>
+
+          <div className="flex items-start">
+            <div className="flex items-center h-5">
+              <input
+                id="is_goalie_only"
+                type="checkbox"
+                checked={isGoalieOnly}
+                onChange={(e) => setIsGoalieOnly(e.target.checked)}
+                className="focus:ring-blue-500 h-4 w-4 text-blue-600 border-gray-300 rounded"
+              />
+            </div>
+            <div className="ml-3 text-sm">
+              <label htmlFor="is_goalie_only" className="font-medium text-gray-700">
+                Goalie Only
+              </label>
+              <p className="text-gray-500 text-xs mt-1">
+                Only members who have identified themselves as a goalie will be able to register in this category.
+              </p>
+            </div>
           </div>
 
           <div className="bg-blue-50 border border-blue-200 rounded-md p-4">

--- a/src/app/admin/registration-categories/page.tsx
+++ b/src/app/admin/registration-categories/page.tsx
@@ -69,6 +69,7 @@ export default async function RegistrationCategoriesPage() {
                         <tr>
                           <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
                           <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+                          <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Goalie</th>
                           <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
                           <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                         </tr>
@@ -81,6 +82,13 @@ export default async function RegistrationCategoriesPage() {
                             </td>
                             <td className="px-6 py-4">
                               <div className="text-sm text-gray-500 max-w-xs truncate">{category.description || 'No description'}</div>
+                            </td>
+                            <td className="px-6 py-4 whitespace-nowrap">
+                              {category.is_goalie_only ? (
+                                <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">Yes</span>
+                              ) : (
+                                <span className="text-sm text-gray-400">—</span>
+                              )}
                             </td>
                             <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{formatDate(new Date(category.created_at))}</td>
                             <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">
@@ -110,6 +118,7 @@ export default async function RegistrationCategoriesPage() {
                         <tr>
                           <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Name</th>
                           <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Description</th>
+                          <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Goalie</th>
                           <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Created</th>
                           <th className="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
                         </tr>
@@ -122,6 +131,13 @@ export default async function RegistrationCategoriesPage() {
                             </td>
                             <td className="px-6 py-4">
                               <div className="text-sm text-gray-500 max-w-xs truncate">{category.description || 'No description'}</div>
+                            </td>
+                            <td className="px-6 py-4 whitespace-nowrap">
+                              {category.is_goalie_only ? (
+                                <span className="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-green-100 text-green-800">Yes</span>
+                              ) : (
+                                <span className="text-sm text-gray-400">—</span>
+                              )}
                             </td>
                             <td className="px-6 py-4 whitespace-nowrap text-sm text-gray-500">{formatDate(new Date(category.created_at))}</td>
                             <td className="px-6 py-4 whitespace-nowrap text-right text-sm font-medium">

--- a/src/app/admin/registrations/[id]/page.tsx
+++ b/src/app/admin/registrations/[id]/page.tsx
@@ -207,27 +207,17 @@ export default async function RegistrationDetailPage({
                       </dd>
                     </div>
                   )}
-                  <div>
-                    <dt className="text-sm font-medium text-gray-500">Required Membership</dt>
-                    <dd className="mt-1">
-                      <EditableRegistrationMembership
-                        registrationId={id}
-                        initialMembershipId={registration.required_membership_id}
-                      />
-                    </dd>
-                  </div>
-                  <div>
-                    <dt className="text-sm font-medium text-gray-500">Survey</dt>
-                    <dd className="mt-1">
-                      <EditableSurveyConfiguration
-                        registrationId={id}
-                        initialConfig={{
-                          require_survey: registration.require_survey || false,
-                          survey_id: registration.survey_id
-                        }}
-                      />
-                    </dd>
-                  </div>
+                  <EditableRegistrationMembership
+                    registrationId={id}
+                    initialMembershipId={registration.required_membership_id}
+                  />
+                  <EditableSurveyConfiguration
+                    registrationId={id}
+                    initialConfig={{
+                      require_survey: registration.require_survey || false,
+                      survey_id: registration.survey_id
+                    }}
+                  />
                   <EditableEventDates
                     registrationId={id}
                     registrationType={registration.type}
@@ -244,19 +234,14 @@ export default async function RegistrationDetailPage({
                       )}
                     </dd>
                   </div>
-                  <div>
-                    <dt className="text-sm font-medium text-gray-500">Alternates</dt>
-                    <dd className="mt-1 text-sm text-gray-900">
-                      <EditableAlternateConfiguration
-                        registrationId={id}
-                        initialConfig={{
-                          allow_alternates: registration.allow_alternates || false,
-                          alternate_price: registration.alternate_price,
-                          alternate_accounting_code: registration.alternate_accounting_code
-                        }}
-                      />
-                    </dd>
-                  </div>
+                  <EditableAlternateConfiguration
+                    registrationId={id}
+                    initialConfig={{
+                      allow_alternates: registration.allow_alternates || false,
+                      alternate_price: registration.alternate_price,
+                      alternate_accounting_code: registration.alternate_accounting_code
+                    }}
+                  />
                   <div>
                     <dt className="flex items-center justify-between">
                       <span className="text-sm font-medium text-gray-500">Registration Timing</span>

--- a/src/app/api/admin/registration-categories/[id]/route.ts
+++ b/src/app/api/admin/registration-categories/[id]/route.ts
@@ -1,0 +1,117 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { createClient, createAdminClient } from '@/lib/supabase/server'
+
+// GET /api/admin/registration-categories/[id] - Get single master category
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    const supabase = await createClient()
+    const adminSupabase = createAdminClient()
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { data: userData, error: userError } = await supabase
+      .from('users')
+      .select('is_admin')
+      .eq('id', user.id)
+      .single()
+
+    if (userError || !userData?.is_admin) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
+    }
+
+    const { data: category, error } = await adminSupabase
+      .from('categories')
+      .select('*')
+      .eq('id', id)
+      .single()
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return NextResponse.json({ error: 'Category not found' }, { status: 404 })
+      }
+      throw error
+    }
+
+    return NextResponse.json(category)
+  } catch (error) {
+    console.error('Error fetching registration category:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}
+
+// PUT /api/admin/registration-categories/[id] - Update master category
+export async function PUT(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const { id } = await params
+    const supabase = await createClient()
+    const adminSupabase = createAdminClient()
+
+    const { data: { user }, error: authError } = await supabase.auth.getUser()
+    if (authError || !user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+    }
+
+    const { data: userData, error: userError } = await supabase
+      .from('users')
+      .select('is_admin')
+      .eq('id', user.id)
+      .single()
+
+    if (userError || !userData?.is_admin) {
+      return NextResponse.json({ error: 'Admin access required' }, { status: 403 })
+    }
+
+    const body = await request.json()
+    const { name, description, is_goalie_only } = body
+
+    if (!name || typeof name !== 'string' || name.trim().length === 0) {
+      return NextResponse.json({ error: 'Category name is required' }, { status: 400 })
+    }
+
+    // Check for duplicate name among other system categories
+    const { data: existingCategory } = await adminSupabase
+      .from('categories')
+      .select('id')
+      .eq('name', name.trim())
+      .eq('category_type', 'system')
+      .neq('id', id)
+      .single()
+
+    if (existingCategory) {
+      return NextResponse.json({ error: 'A system category with this name already exists' }, { status: 400 })
+    }
+
+    const { data: category, error } = await adminSupabase
+      .from('categories')
+      .update({
+        name: name.trim(),
+        description: description?.trim() || null,
+        is_goalie_only: Boolean(is_goalie_only)
+      })
+      .eq('id', id)
+      .select()
+      .single()
+
+    if (error) {
+      if (error.code === 'PGRST116') {
+        return NextResponse.json({ error: 'Category not found' }, { status: 404 })
+      }
+      throw error
+    }
+
+    return NextResponse.json(category)
+  } catch (error) {
+    console.error('Error updating registration category:', error)
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 })
+  }
+}

--- a/src/app/api/admin/registration-categories/route.ts
+++ b/src/app/api/admin/registration-categories/route.ts
@@ -24,7 +24,7 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json()
-    const { name, description } = body
+    const { name, description, is_goalie_only } = body
 
     if (!name || typeof name !== 'string' || name.trim().length === 0) {
       return NextResponse.json({ error: 'Category name is required' }, { status: 400 })
@@ -49,7 +49,8 @@ export async function POST(request: NextRequest) {
         name: name.trim(),
         description: description?.trim() || null,
         category_type: 'system',
-        created_by: user.id
+        created_by: user.id,
+        is_goalie_only: Boolean(is_goalie_only)
       })
       .select()
       .single()

--- a/src/app/api/create-registration-payment-intent/route.ts
+++ b/src/app/api/create-registration-payment-intent/route.ts
@@ -32,7 +32,7 @@ interface RegistrationCategoryJoin {
   required_membership_id: string | null
   price: number
   sort_order: number
-  category: { name: string } | null
+  category: { name: string; is_goalie_only: boolean } | null
 }
 
 interface RegistrationWithDetails extends RegistrationRow {
@@ -75,7 +75,7 @@ async function handleFreeRegistration({
         season:seasons(*),
         registration_categories(
           *,
-          category:categories(name)
+          category:categories(name, is_goalie_only)
         )
       `)
       .eq('id', registrationId)
@@ -96,6 +96,27 @@ async function handleFreeRegistration({
       const error = new Error('Category not found')
       capturePaymentError(error, paymentContext, 'error')
       return NextResponse.json({ error: 'Category not found' }, { status: 404 })
+    }
+
+    // Check goalie-only eligibility
+    if (selectedCategory.category?.is_goalie_only) {
+      const { data: userProfile } = await supabase
+        .from('users')
+        .select('is_goalie')
+        .eq('id', user.id)
+        .single()
+
+      const goalieValidation = RegistrationValidationService.validateGoalieRequirement(
+        true,
+        !!userProfile?.is_goalie
+      )
+
+      if (!goalieValidation.eligible) {
+        capturePaymentError(new Error('Goalie-only category'), paymentContext, 'warning')
+        return NextResponse.json({
+          error: goalieValidation.error || 'This category is only open to registered goalies'
+        }, { status: 400 })
+      }
     }
 
     // Get user's active membership for eligibility (if any)
@@ -561,7 +582,7 @@ export async function POST(request: NextRequest) {
         season:seasons(*),
         registration_categories(
           *,
-          category:categories(name),
+          category:categories(name, is_goalie_only),
           membership:memberships(name)
         )
       `)
@@ -615,6 +636,27 @@ export async function POST(request: NextRequest) {
         capturePaymentError(new Error('Membership required'), paymentContext, 'warning')
         return NextResponse.json({
           error: membershipValidation.error || 'Required membership not found'
+        }, { status: 400 })
+      }
+    }
+
+    // Check goalie-only eligibility
+    if (selectedCategory.category?.is_goalie_only) {
+      const { data: userProfile } = await supabase
+        .from('users')
+        .select('is_goalie')
+        .eq('id', user.id)
+        .single()
+
+      const goalieValidation = RegistrationValidationService.validateGoalieRequirement(
+        true,
+        !!userProfile?.is_goalie
+      )
+
+      if (!goalieValidation.eligible) {
+        capturePaymentError(new Error('Goalie-only category'), paymentContext, 'warning')
+        return NextResponse.json({
+          error: goalieValidation.error || 'This category is only open to registered goalies'
         }, { status: 400 })
       }
     }

--- a/src/app/api/join-waitlist/route.ts
+++ b/src/app/api/join-waitlist/route.ts
@@ -4,6 +4,7 @@ import { formatDate } from '@/lib/date-utils'
 import { createClient, createAdminClient } from '@/lib/supabase/server'
 import { emailService } from '@/lib/email'
 import { getUserSavedPaymentMethodId } from '@/lib/services/payment-method-service'
+import { RegistrationValidationService } from '@/lib/services/registration-validation-service'
 import { SupabaseClient } from '@supabase/supabase-js'
 
 
@@ -102,20 +103,42 @@ export async function POST(request: NextRequest) {
     const { data: category, error: categoryError } = await supabase
       .from('registration_categories')
       .select(`
-        id, 
+        id,
         max_capacity,
         custom_name,
         category_id,
         accounting_code,
         required_membership_id,
         sort_order,
-        registration_id
+        registration_id,
+        categories:category_id (is_goalie_only)
       `)
       .eq('id', categoryId)
       .single()
 
     if (categoryError || !category) {
       return NextResponse.json({ error: 'Category not found' }, { status: 404 })
+    }
+
+    // Check goalie-only eligibility
+    const goalieOnlyCategory = category.categories as unknown as { is_goalie_only: boolean } | null
+    if (goalieOnlyCategory?.is_goalie_only) {
+      const { data: userProfile } = await supabase
+        .from('users')
+        .select('is_goalie')
+        .eq('id', user.id)
+        .single()
+
+      const goalieValidation = RegistrationValidationService.validateGoalieRequirement(
+        true,
+        !!userProfile?.is_goalie
+      )
+
+      if (!goalieValidation.eligible) {
+        return NextResponse.json({
+          error: goalieValidation.error || 'This category is only open to registered goalies'
+        }, { status: 400 })
+      }
     }
 
     // Check if category has capacity limits (null/undefined = unlimited; 0 = waitlist-only)

--- a/src/components/AdminHeader.tsx
+++ b/src/components/AdminHeader.tsx
@@ -1,51 +1,28 @@
 'use client'
 
 import Link from 'next/link'
-import AdminToggle from './AdminToggle'
 
 interface AdminHeaderProps {
   title: string
   description?: string
-  useToggle?: boolean
   backLink?: string
 }
 
-export default function AdminHeader({ title, description, useToggle = false, backLink }: AdminHeaderProps) {
+export default function AdminHeader({ title, description, backLink }: AdminHeaderProps) {
   return (
     <div className="mb-8">
-      <div className="flex items-center justify-between">
-        <div>
-          {backLink && (
-            <Link
-              href={backLink}
-              className="text-blue-600 hover:text-blue-500 text-sm font-medium"
-            >
-              ← Back
-            </Link>
-          )}
-          <h1 className="text-3xl font-bold text-gray-900">{title}</h1>
-          {description && (
-            <p className="mt-1 text-sm text-gray-600">{description}</p>
-          )}
-        </div>
-        <div className="flex items-center">
-          {useToggle ? (
-            <AdminToggle isAdminView={true} />
-          ) : (
-            <div className="flex items-center space-x-1 bg-gray-100 rounded-md p-1">
-              <span className="px-3 py-1 rounded text-sm font-medium bg-blue-600 text-white">
-                Admin
-              </span>
-              <Link
-                href="/user"
-                className="px-3 py-1 rounded text-sm font-medium text-gray-600 hover:bg-white hover:text-gray-800"
-              >
-                Member
-              </Link>
-            </div>
-          )}
-        </div>
-      </div>
+      {backLink && (
+        <Link
+          href={backLink}
+          className="text-blue-600 hover:text-blue-500 text-sm font-medium"
+        >
+          ← Back
+        </Link>
+      )}
+      <h1 className="text-3xl font-bold text-gray-900">{title}</h1>
+      {description && (
+        <p className="mt-1 text-sm text-gray-600">{description}</p>
+      )}
     </div>
   )
 }

--- a/src/components/EditableAlternateConfiguration.tsx
+++ b/src/components/EditableAlternateConfiguration.tsx
@@ -75,8 +75,17 @@ export default function EditableAlternateConfiguration({
 
   if (!isEditing) {
     return (
-      <div className="flex items-center justify-between">
-        <div>
+      <div>
+        <dt className="flex items-center justify-between">
+          <span className="text-sm font-medium text-gray-500">Alternates</span>
+          <button
+            onClick={() => setIsEditing(true)}
+            className="text-xs text-blue-600 hover:text-blue-500 font-medium"
+          >
+            Edit
+          </button>
+        </dt>
+        <dd className="mt-1 text-sm text-gray-900">
           {config.allow_alternates ? (
             <div className="space-y-1">
               <span className="text-green-600">Enabled</span>
@@ -94,105 +103,102 @@ export default function EditableAlternateConfiguration({
           ) : (
             <span className="text-red-600">Disabled</span>
           )}
-        </div>
-        <button
-          onClick={() => setIsEditing(true)}
-          className="text-xs text-blue-600 hover:text-blue-500 font-medium"
-        >
-          Edit
-        </button>
+        </dd>
       </div>
     )
   }
 
   return (
-    <div className="space-y-4">
-      {error && (
-        <div className="text-red-600 text-sm">{error}</div>
-      )}
-      
-      {/* Allow Alternates Toggle */}
-      <div className="flex items-center">
-        <input
-          id="allow_alternates"
-          type="checkbox"
-          checked={config.allow_alternates}
-          onChange={(e) => setConfig(prev => ({ 
-            ...prev, 
-            allow_alternates: e.target.checked,
-            // Clear fields if disabling
-            alternate_price: e.target.checked ? prev.alternate_price : '',
-            alternate_accounting_code: e.target.checked ? prev.alternate_accounting_code : ''
-          }))}
-          className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-        />
-        <label htmlFor="allow_alternates" className="ml-2 block text-sm text-gray-900">
-          Enable alternates
-        </label>
-      </div>
+    <div>
+      <dt className="text-sm font-medium text-gray-500 mb-1">Alternates</dt>
+      <dd className="space-y-4">
+        {error && (
+          <div className="text-red-600 text-sm">{error}</div>
+        )}
 
-      {/* Alternate Configuration Fields */}
-      {config.allow_alternates && (
-        <div className="space-y-3 p-3 bg-blue-50 border border-blue-200 rounded-md">
-          {/* Alternate Price */}
-          <div>
-            <label htmlFor="alternate_price" className="block text-xs font-medium text-gray-700">
-              Price (USD)
-            </label>
-            <div className="mt-1 relative rounded-md shadow-sm">
-              <div className="absolute inset-y-0 left-0 pl-2 flex items-center pointer-events-none">
-                <span className="text-gray-500 text-sm">$</span>
+        {/* Allow Alternates Toggle */}
+        <div className="flex items-center">
+          <input
+            id="allow_alternates"
+            type="checkbox"
+            checked={config.allow_alternates}
+            onChange={(e) => setConfig(prev => ({
+              ...prev,
+              allow_alternates: e.target.checked,
+              // Clear fields if disabling
+              alternate_price: e.target.checked ? prev.alternate_price : '',
+              alternate_accounting_code: e.target.checked ? prev.alternate_accounting_code : ''
+            }))}
+            className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
+          />
+          <label htmlFor="allow_alternates" className="ml-2 block text-sm text-gray-900">
+            Enable alternates
+          </label>
+        </div>
+
+        {/* Alternate Configuration Fields */}
+        {config.allow_alternates && (
+          <div className="space-y-3 p-3 bg-blue-50 border border-blue-200 rounded-md">
+            {/* Alternate Price */}
+            <div>
+              <label htmlFor="alternate_price" className="block text-xs font-medium text-gray-700">
+                Price (USD)
+              </label>
+              <div className="mt-1 relative rounded-md shadow-sm">
+                <div className="absolute inset-y-0 left-0 pl-2 flex items-center pointer-events-none">
+                  <span className="text-gray-500 text-sm">$</span>
+                </div>
+                <input
+                  type="number"
+                  id="alternate_price"
+                  value={config.alternate_price}
+                  onChange={(e) => setConfig(prev => ({ ...prev, alternate_price: e.target.value }))}
+                  className="block w-full pl-6 pr-3 py-1 text-sm border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+                  placeholder="0.00"
+                  step="0.01"
+                  min="0"
+                  required
+                />
               </div>
-              <input
-                type="number"
-                id="alternate_price"
-                value={config.alternate_price}
-                onChange={(e) => setConfig(prev => ({ ...prev, alternate_price: e.target.value }))}
-                className="block w-full pl-6 pr-3 py-1 text-sm border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
-                placeholder="0.00"
-                step="0.01"
-                min="0"
+            </div>
+
+            {/* Alternate Accounting Code */}
+            <div>
+              <AccountingCodeInput
+                value={config.alternate_accounting_code}
+                onChange={(value) => setConfig(prev => ({ ...prev, alternate_accounting_code: value }))}
+                label="Accounting Code"
                 required
+                placeholder="Search by code or name..."
+                suggestedAccountType="REVENUE"
+                className="text-sm"
               />
             </div>
           </div>
+        )}
 
-          {/* Alternate Accounting Code */}
-          <div>
-            <AccountingCodeInput
-              value={config.alternate_accounting_code}
-              onChange={(value) => setConfig(prev => ({ ...prev, alternate_accounting_code: value }))}
-              label="Accounting Code"
-              required
-              placeholder="Search by code or name..."
-              suggestedAccountType="REVENUE"
-              className="text-sm"
-            />
-          </div>
+        {/* Action Buttons */}
+        <div className="flex space-x-2">
+          <button
+            onClick={handleSave}
+            disabled={loading || !canSave}
+            className={`px-3 py-1 text-sm font-medium rounded-md ${
+              canSave && !loading
+                ? 'bg-blue-600 text-white hover:bg-blue-700'
+                : 'bg-gray-300 text-gray-500 cursor-not-allowed'
+            }`}
+          >
+            {loading ? 'Saving...' : 'Save'}
+          </button>
+          <button
+            onClick={handleCancel}
+            disabled={loading}
+            className="px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
+          >
+            Cancel
+          </button>
         </div>
-      )}
-
-      {/* Action Buttons */}
-      <div className="flex space-x-2">
-        <button
-          onClick={handleSave}
-          disabled={loading || !canSave}
-          className={`px-3 py-1 text-sm font-medium rounded-md ${
-            canSave && !loading
-              ? 'bg-blue-600 text-white hover:bg-blue-700'
-              : 'bg-gray-300 text-gray-500 cursor-not-allowed'
-          }`}
-        >
-          {loading ? 'Saving...' : 'Save'}
-        </button>
-        <button
-          onClick={handleCancel}
-          disabled={loading}
-          className="px-3 py-1 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50"
-        >
-          Cancel
-        </button>
-      </div>
+      </dd>
     </div>
   )
 }

--- a/src/components/EditableEventDates.tsx
+++ b/src/components/EditableEventDates.tsx
@@ -93,60 +93,62 @@ export default function EditableEventDates({
 
   if (isEditing) {
     return (
-      <div className="space-y-4">
-        <EventDateTimeInput
-          startDate={startDate}
-          durationMinutes={durationMinutes}
-          onStartDateChange={setStartDate}
-          onDurationChange={setDurationMinutes}
-          registrationType={registrationType}
-          required={true}
-          disabled={loading}
-        />
-
-        {error && (
-          <p className="text-sm text-red-600">{error}</p>
-        )}
-
-        <div className="flex items-center space-x-2">
-          <button
-            onClick={handleSave}
-            disabled={loading || !startDate || !durationMinutes}
-            className="px-3 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
-          >
-            {loading ? 'Saving...' : 'Save Dates'}
-          </button>
-          <button
-            onClick={handleCancel}
+      <div>
+        <dt className="text-sm font-medium text-gray-500 mb-1">Event Date &amp; Time</dt>
+        <dd className="space-y-4">
+          <EventDateTimeInput
+            startDate={startDate}
+            durationMinutes={durationMinutes}
+            onStartDateChange={setStartDate}
+            onDurationChange={setDurationMinutes}
+            registrationType={registrationType}
+            required={true}
             disabled={loading}
-            className="px-3 py-2 text-sm bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 disabled:opacity-50"
-          >
-            Cancel
-          </button>
-        </div>
+          />
+
+          {error && (
+            <p className="text-sm text-red-600">{error}</p>
+          )}
+
+          <div className="flex items-center space-x-2">
+            <button
+              onClick={handleSave}
+              disabled={loading || !startDate || !durationMinutes}
+              className="px-3 py-2 text-sm bg-blue-600 text-white rounded-md hover:bg-blue-700 disabled:opacity-50"
+            >
+              {loading ? 'Saving...' : 'Save Dates'}
+            </button>
+            <button
+              onClick={handleCancel}
+              disabled={loading}
+              className="px-3 py-2 text-sm bg-gray-200 text-gray-700 rounded-md hover:bg-gray-300 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+          </div>
+        </dd>
       </div>
     )
   }
 
   return (
     <div>
-      <dt className="text-sm font-medium text-gray-500 mb-1">Event Date & Time</dt>
-      <dd className="text-sm text-gray-900 flex items-center space-x-2">
+      <dt className="flex items-center justify-between">
+        <span className="text-sm font-medium text-gray-500">Event Date &amp; Time</span>
+        {initialStartDate && initialEndDate && (
+          <button
+            onClick={() => setIsEditing(true)}
+            className="text-xs text-blue-600 hover:text-blue-500 font-medium"
+          >
+            Edit
+          </button>
+        )}
+      </dt>
+      <dd className="mt-1 text-sm text-gray-900">
         {initialStartDate && initialEndDate ? (
-          <div className="flex items-center space-x-2">
-            <div>
-              <div><strong>Start:</strong> {formatDateTime(initialStartDate)}</div>
-              <div><strong>End:</strong> {formatDateTime(initialEndDate)}</div>
-            </div>
-            <button
-              onClick={() => setIsEditing(true)}
-              className="p-1 text-gray-400 hover:text-gray-600 transition-colors"
-              title="Edit event dates"
-            >
-              <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z" />
-              </svg>
-            </button>
+          <div>
+            <div><strong>Start:</strong> {formatDateTime(initialStartDate)}</div>
+            <div><strong>End:</strong> {formatDateTime(initialEndDate)}</div>
           </div>
         ) : (
           <div className="flex items-center space-x-2">

--- a/src/components/EditableRegistrationMembership.tsx
+++ b/src/components/EditableRegistrationMembership.tsx
@@ -63,60 +63,66 @@ export default function EditableRegistrationMembership({
 
   if (isEditing) {
     return (
-      <div className="space-y-2">
-        <select
-          value={membershipId}
-          onChange={(e) => setMembershipId(e.target.value)}
-          className="block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
-          disabled={loading}
-        >
-          <option value="">None (optional)</option>
-          {availableMemberships.map((membership) => (
-            <option key={membership.id} value={membership.id}>
-              {membership.name}
-            </option>
-          ))}
-        </select>
-
-        <p className="text-xs text-gray-500">
-          Optional default requirement. Categories can offer alternatives.
-        </p>
-
-        {error && (
-          <div className="text-sm text-red-600">{error}</div>
-        )}
-
-        <div className="flex space-x-2">
-          <button
-            onClick={handleSave}
+      <div>
+        <dt className="text-sm font-medium text-gray-500 mb-1">Required Membership</dt>
+        <dd className="space-y-2">
+          <select
+            value={membershipId}
+            onChange={(e) => setMembershipId(e.target.value)}
+            className="block w-full border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500 sm:text-sm"
             disabled={loading}
-            className="text-sm text-blue-600 hover:text-blue-500 disabled:opacity-50"
           >
-            {loading ? 'Saving...' : 'Save'}
-          </button>
-          <button
-            onClick={handleCancel}
-            disabled={loading}
-            className="text-sm text-gray-600 hover:text-gray-500 disabled:opacity-50"
-          >
-            Cancel
-          </button>
-        </div>
+            <option value="">None (optional)</option>
+            {availableMemberships.map((membership) => (
+              <option key={membership.id} value={membership.id}>
+                {membership.name}
+              </option>
+            ))}
+          </select>
+
+          <p className="text-xs text-gray-500">
+            Optional default requirement. Categories can offer alternatives.
+          </p>
+
+          {error && (
+            <div className="text-sm text-red-600">{error}</div>
+          )}
+
+          <div className="flex space-x-2">
+            <button
+              onClick={handleSave}
+              disabled={loading}
+              className="text-sm text-blue-600 hover:text-blue-500 disabled:opacity-50"
+            >
+              {loading ? 'Saving...' : 'Save'}
+            </button>
+            <button
+              onClick={handleCancel}
+              disabled={loading}
+              className="text-sm text-gray-600 hover:text-gray-500 disabled:opacity-50"
+            >
+              Cancel
+            </button>
+          </div>
+        </dd>
       </div>
     )
   }
 
   return (
-    <div className="flex items-center space-x-2">
-      <span className="text-sm text-gray-900">
+    <div>
+      <dt className="flex items-center justify-between">
+        <span className="text-sm font-medium text-gray-500">Required Membership</span>
+        <button
+          onClick={() => setIsEditing(true)}
+          className="text-xs text-blue-600 hover:text-blue-500 font-medium"
+        >
+          Edit
+        </button>
+      </dt>
+      <dd className="mt-1 text-sm text-gray-900">
         {selectedMembership ? selectedMembership.name : 'None (optional)'}
-      </span>
-      <button
-        onClick={() => setIsEditing(true)}
-        className="text-sm text-blue-600 hover:text-blue-500"
-      >
-        Edit
-      </button>
+      </dd>
     </div>
   )
 }

--- a/src/components/EditableSurveyConfiguration.tsx
+++ b/src/components/EditableSurveyConfiguration.tsx
@@ -65,8 +65,17 @@ export default function EditableSurveyConfiguration({
 
   if (!isEditing) {
     return (
-      <div className="flex items-start justify-between">
-        <div className="flex-1">
+      <div>
+        <dt className="flex items-center justify-between">
+          <span className="text-sm font-medium text-gray-500">Survey</span>
+          <button
+            onClick={() => setIsEditing(true)}
+            className="text-xs text-blue-600 hover:text-blue-500 font-medium"
+          >
+            Edit
+          </button>
+        </dt>
+        <dd className="mt-1">
           {requireSurvey ? (
             <div className="space-y-1">
               <div className="text-sm text-gray-900">
@@ -83,76 +92,73 @@ export default function EditableSurveyConfiguration({
           ) : (
             <span className="text-sm text-gray-500">Not required</span>
           )}
-        </div>
-        <button
-          onClick={() => setIsEditing(true)}
-          className="ml-3 text-sm text-blue-600 hover:text-blue-500 font-medium"
-        >
-          Edit
-        </button>
+        </dd>
       </div>
     )
   }
 
   return (
-    <div className="space-y-3">
-      {error && (
-        <div className="text-xs text-red-600 bg-red-50 p-2 rounded">
-          {error}
-        </div>
-      )}
+    <div>
+      <dt className="text-sm font-medium text-gray-500 mb-1">Survey</dt>
+      <dd className="space-y-3">
+        {error && (
+          <div className="text-xs text-red-600 bg-red-50 p-2 rounded">
+            {error}
+          </div>
+        )}
 
-      <div className="flex items-center">
-        <input
-          id="require_survey_edit"
-          type="checkbox"
-          checked={requireSurvey}
-          onChange={(e) => {
-            setRequireSurvey(e.target.checked)
-            // Clear survey_id if unchecked
-            if (!e.target.checked) {
-              setSurveyId('')
-            }
-          }}
-          className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
-        />
-        <label htmlFor="require_survey_edit" className="ml-2 block text-sm text-gray-900">
-          Require survey before payment
-        </label>
-      </div>
-
-      {requireSurvey && (
-        <div>
-          <label htmlFor="survey_id_edit" className="block text-xs font-medium text-gray-700 mb-1">
-            Survey ID (Tally)
-          </label>
+        <div className="flex items-center">
           <input
-            id="survey_id_edit"
-            type="text"
-            value={surveyId}
-            onChange={(e) => setSurveyId(e.target.value)}
-            placeholder="e.g., VLzWBv"
-            className="block w-full text-sm border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+            id="require_survey_edit"
+            type="checkbox"
+            checked={requireSurvey}
+            onChange={(e) => {
+              setRequireSurvey(e.target.checked)
+              // Clear survey_id if unchecked
+              if (!e.target.checked) {
+                setSurveyId('')
+              }
+            }}
+            className="h-4 w-4 text-blue-600 focus:ring-blue-500 border-gray-300 rounded"
           />
+          <label htmlFor="require_survey_edit" className="ml-2 block text-sm text-gray-900">
+            Require survey before payment
+          </label>
         </div>
-      )}
 
-      <div className="flex justify-end space-x-2">
-        <button
-          onClick={handleCancel}
-          disabled={isSaving}
-          className="px-3 py-1 text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50"
-        >
-          Cancel
-        </button>
-        <button
-          onClick={handleSave}
-          disabled={isSaving}
-          className="px-3 py-1 text-xs font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700 disabled:opacity-50"
-        >
-          {isSaving ? 'Saving...' : 'Save'}
-        </button>
-      </div>
+        {requireSurvey && (
+          <div>
+            <label htmlFor="survey_id_edit" className="block text-xs font-medium text-gray-700 mb-1">
+              Survey ID (Tally)
+            </label>
+            <input
+              id="survey_id_edit"
+              type="text"
+              value={surveyId}
+              onChange={(e) => setSurveyId(e.target.value)}
+              placeholder="e.g., VLzWBv"
+              className="block w-full text-sm border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
+            />
+          </div>
+        )}
+
+        <div className="flex justify-end space-x-2">
+          <button
+            onClick={handleCancel}
+            disabled={isSaving}
+            className="px-3 py-1 text-xs font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSave}
+            disabled={isSaving}
+            className="px-3 py-1 text-xs font-medium text-white bg-blue-600 border border-transparent rounded-md hover:bg-blue-700 disabled:opacity-50"
+          >
+            {isSaving ? 'Saving...' : 'Save'}
+          </button>
+        </div>
+      </dd>
     </div>
   )
 }

--- a/src/components/RegistrationPurchase.tsx
+++ b/src/components/RegistrationPurchase.tsx
@@ -42,6 +42,7 @@ interface RegistrationCategory {
   price?: number
   categories?: {
     name: string
+    is_goalie_only?: boolean
   } | null
   memberships?: {
     name: string
@@ -79,19 +80,21 @@ interface RegistrationPurchaseProps {
   activeMemberships?: UserMembership[]
   isEligible: boolean
   isLgbtq: boolean
+  isGoalie: boolean
   isAlreadyRegistered?: boolean
   isAlreadyAlternate?: boolean
 }
 
-export default function RegistrationPurchase({ 
-  registration, 
-  userEmail, 
+export default function RegistrationPurchase({
+  registration,
+  userEmail,
   userId,
   firstName,
   lastName,
   activeMemberships = [],
   isEligible,
   isLgbtq,
+  isGoalie,
   isAlreadyRegistered = false,
   isAlreadyAlternate = false
 }: RegistrationPurchaseProps) {
@@ -252,7 +255,7 @@ export default function RegistrationPurchase({
     current_count: 0,
     required_membership_id: null,
     memberships: null,
-    categories: { name: 'Alternate' }
+    categories: { name: 'Alternate', is_goalie_only: false }
   } : null
   
   const categories = alternateCategory ? [...baseCategories, alternateCategory] : baseCategories
@@ -315,9 +318,17 @@ export default function RegistrationPurchase({
   
 
   // Check if selected category is eligible (basic membership check)
-  const isCategoryEligible = selectedCategory ? 
-    !selectedCategory.required_membership_id || 
+  const hasRequiredMembershipForSelected = selectedCategory ?
+    !selectedCategory.required_membership_id ||
     activeMemberships.some(um => um.memberships?.id === selectedCategory.required_membership_id)
+    : false
+  const isGoalieOnlySelectedCategory = !!selectedCategory?.categories?.is_goalie_only
+  const isGoalieEligibleForSelected = RegistrationValidationService.validateGoalieRequirement(
+    isGoalieOnlySelectedCategory,
+    isGoalie
+  ).eligible
+  const isCategoryEligible = selectedCategory
+    ? hasRequiredMembershipForSelected && isGoalieEligibleForSelected
     : false
 
 
@@ -502,7 +513,11 @@ export default function RegistrationPurchase({
 
     // Regular category registration logic
     if (!isCategoryEligible) {
-      setError('You need the required membership for this category')
+      setError(
+        isGoalieOnlySelectedCategory && !isGoalieEligibleForSelected
+          ? 'This category is only open to registered goalies'
+          : 'You need the required membership for this category'
+      )
       return
     }
 
@@ -796,23 +811,32 @@ export default function RegistrationPurchase({
                 activeMemberships
               )
               const hasRequiredMembership = membershipValidationResult.hasRequiredMembership
+
+              // Check goalie-only eligibility for this category
+              const isGoalieOnlyCategory = !!category.categories?.is_goalie_only
+              const isGoalieEligible = RegistrationValidationService.validateGoalieRequirement(
+                isGoalieOnlyCategory,
+                isGoalie
+              ).eligible
+              const isEligibleForSelection = hasRequiredMembership && isGoalieEligible
+
               const categoryPrice = category.price ?? 0
-              
+
               // Determine availability logic
               const isAlternateCategory = category.id === 'alternate'
               const isRegularCategory = !isAlternateCategory
-              
+
               // For regular categories: unavailable if user is already registered for ANY regular category
               const isRegularCategoryUnavailable = isRegularCategory && isAlreadyRegistered
-              
+
               // For alternate category: unavailable if user is already registered as alternate
               const isAlternateCategoryUnavailable = isAlternateCategory && isUserAlreadyAlternate
-              
+
               // Overall availability
               const isUnavailableDueToExistingRegistration = isRegularCategoryUnavailable || isAlternateCategoryUnavailable
-              
+
               // Visual state logic - no additional variables needed
-              
+
               return (
                 <label
                   key={category.id}
@@ -821,7 +845,7 @@ export default function RegistrationPurchase({
                       ? 'border-gray-300 bg-gray-50 opacity-60 cursor-default'
                       : selectedCategoryId === category.id
                       ? 'border-blue-600 ring-2 ring-blue-600 bg-blue-50 cursor-pointer'
-                      : hasRequiredMembership
+                      : isEligibleForSelection
                       ? 'border-gray-300 hover:border-gray-400 cursor-pointer'
                       : 'border-yellow-300 bg-yellow-50 cursor-not-allowed'
                   }`}
@@ -832,7 +856,7 @@ export default function RegistrationPurchase({
                     value={category.id}
                     checked={selectedCategoryId === category.id || isUnavailableDueToExistingRegistration || !!userWaitlistEntries[category.id]}
                     onChange={(e) => !(isUnavailableDueToExistingRegistration || userWaitlistEntries[category.id]) && setSelectedCategoryId(e.target.value)}
-                    disabled={!hasRequiredMembership || isUnavailableDueToExistingRegistration || !!userWaitlistEntries[category.id]}
+                    disabled={!isEligibleForSelection || isUnavailableDueToExistingRegistration || !!userWaitlistEntries[category.id]}
                     className="sr-only"
                   />
                   <div className="flex w-full justify-between">
@@ -841,7 +865,7 @@ export default function RegistrationPurchase({
                         <div className={`font-medium ${
                           isUnavailableDueToExistingRegistration || userWaitlistEntries[category.id] ? 'text-gray-700' :
                           selectedCategoryId === category.id ? 'text-blue-900' :
-                          hasRequiredMembership ? 'text-gray-900' : 'text-yellow-800'
+                          isEligibleForSelection ? 'text-gray-900' : 'text-yellow-800'
                         }`}>
                           {categoryName}
                           {isUnavailableDueToExistingRegistration && (
@@ -865,6 +889,11 @@ export default function RegistrationPurchase({
                               }
                               return requirements.length > 0 ? requirements.join(' OR ') : 'Membership'
                             })()}
+                          </div>
+                        )}
+                        {isGoalieOnlyCategory && (
+                          <div className="text-xs text-gray-600">
+                            Goalies only
                           </div>
                         )}
                         {isAlternateCategory && (
@@ -934,6 +963,15 @@ export default function RegistrationPurchase({
                 activeMemberships
               )
               const hasRequiredMembership = membershipValidationResult.hasRequiredMembership
+
+              // Check goalie-only eligibility for this category
+              const isGoalieOnlyCategory = !!category.categories?.is_goalie_only
+              const isGoalieEligible = RegistrationValidationService.validateGoalieRequirement(
+                isGoalieOnlyCategory,
+                isGoalie
+              ).eligible
+              const isEligibleForSelection = hasRequiredMembership && isGoalieEligible
+
               const categoryPrice = category.price ?? 0
 
               const isOnWaitlist = !!userWaitlistEntries[category.id]
@@ -959,10 +997,10 @@ export default function RegistrationPurchase({
                     isOnWaitlist || isUnavailableDueToExistingRegistration
                       ? 'border-gray-300 bg-gray-50 opacity-60'
                       : selectedCategoryId === category.id
-                      ? hasRequiredMembership
+                      ? isEligibleForSelection
                         ? 'border-blue-600 ring-2 ring-blue-600 bg-blue-50'
                         : 'border-yellow-500 bg-yellow-50'
-                      : hasRequiredMembership
+                      : isEligibleForSelection
                       ? 'border-gray-300 hover:border-gray-400'
                       : 'border-yellow-300 bg-yellow-50 hover:border-yellow-400'
                   }`}>
@@ -971,8 +1009,8 @@ export default function RegistrationPurchase({
                         <div className={`font-medium text-sm ${
                           isOnWaitlist || isUnavailableDueToExistingRegistration ? 'text-gray-700' :
                           selectedCategoryId === category.id
-                            ? hasRequiredMembership ? 'text-blue-900' : 'text-yellow-800'
-                            : hasRequiredMembership ? 'text-gray-900' : 'text-yellow-800'
+                            ? isEligibleForSelection ? 'text-blue-900' : 'text-yellow-800'
+                            : isEligibleForSelection ? 'text-gray-900' : 'text-yellow-800'
                         }`}>
                           {categoryName}
                           {isUnavailableDueToExistingRegistration && (
@@ -996,6 +1034,11 @@ export default function RegistrationPurchase({
                               }
                               return requirements.length > 0 ? requirements.join(' OR ') : 'Membership'
                             })()}
+                          </div>
+                        )}
+                        {isGoalieOnlyCategory && (
+                          <div className="text-xs text-gray-600">
+                            Goalies only
                           </div>
                         )}
                         {(category.max_capacity !== null && category.max_capacity !== undefined) && (
@@ -1473,7 +1516,7 @@ export default function RegistrationPurchase({
          !selectedCategoryId ? 'Select Category to Continue' :
          (selectedCategory && selectedCategory.id !== 'alternate' && isAlreadyRegistered) ? 'Registered' :
          (selectedCategory && selectedCategory.id === 'alternate' && isUserAlreadyAlternate) ? 'Registered' :
-         !isCategoryEligible ? 'Membership Required' :
+         !isCategoryEligible ? (isGoalieOnlySelectedCategory && !isGoalieEligibleForSelected ? 'Goalies Only' : 'Membership Required') :
          !hasSeasonCoverage ? 'Membership Extension Required' :
          !isTimingAvailable ? (isPresale ? 'Pre-Sale Code Required' : 'Registration Not Available') :
          (registration.require_survey && !surveyCompleted) ? 'Complete Survey to Continue' :

--- a/src/lib/services/registration-validation-service.ts
+++ b/src/lib/services/registration-validation-service.ts
@@ -25,6 +25,11 @@ export interface MembershipValidationResult {
   }
 }
 
+export interface GoalieValidationResult {
+  eligible: boolean
+  error?: string
+}
+
 export interface UserMembership {
   id: string
   membership_id: string
@@ -275,6 +280,26 @@ export class RegistrationValidationService {
     return {
       hasRequiredMembership: false,
       error: `You need ${requirementText} to register for this event`
+    }
+  }
+
+  /**
+   * Check whether a user is eligible for a category that may be restricted to goalies.
+   *
+   * @param isCategoryGoalieOnly - Whether the category is marked goalie-only
+   * @param isUserGoalie - Whether the user has identified themselves as a goalie
+   */
+  static validateGoalieRequirement(
+    isCategoryGoalieOnly: boolean,
+    isUserGoalie: boolean
+  ): GoalieValidationResult {
+    if (!isCategoryGoalieOnly || isUserGoalie) {
+      return { eligible: true }
+    }
+
+    return {
+      eligible: false,
+      error: 'This category is only open to registered goalies'
     }
   }
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -70,6 +70,7 @@ export type Database = {
           category_type: 'system' | 'user'
           created_by: string | null
           created_at: string
+          is_goalie_only: boolean
         }
         Insert: {
           id?: string
@@ -78,6 +79,7 @@ export type Database = {
           category_type: 'system' | 'user'
           created_by?: string | null
           created_at?: string
+          is_goalie_only?: boolean
         }
         Update: {
           id?: string
@@ -86,6 +88,7 @@ export type Database = {
           category_type?: 'system' | 'user'
           created_by?: string | null
           created_at?: string
+          is_goalie_only?: boolean
         }
       }
       seasons: {

--- a/supabase/migrations/2026-08-23-add-goalie-only-to-categories.sql
+++ b/supabase/migrations/2026-08-23-add-goalie-only-to-categories.sql
@@ -1,0 +1,7 @@
+-- Add goalie-only flag to master categories table
+-- When true, only users with users.is_goalie = true may register in a
+-- registration_category that references this category.
+
+ALTER TABLE categories ADD COLUMN IF NOT EXISTS is_goalie_only BOOLEAN NOT NULL DEFAULT false;
+
+COMMENT ON COLUMN categories.is_goalie_only IS 'When true, only members who have identified as a goalie (users.is_goalie) may register in registration categories that reference this master category.';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -221,7 +221,8 @@ CREATE TABLE categories (
     category_type TEXT NOT NULL CHECK (category_type IN ('system', 'user')),
     created_by UUID REFERENCES users(id), -- NULL for system categories
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),
-    
+    is_goalie_only BOOLEAN NOT NULL DEFAULT false,
+
     -- Ensure no duplicate names within the same type
     UNIQUE(name, category_type)
 );


### PR DESCRIPTION
## Summary
- Fix `/admin/registration-categories/[id]/edit` always showing "Category not found" — the page's fetch calls hit `/api/admin/registration-categories/[id]`, which didn't exist (it was renamed to a different route in a past commit and nothing was left behind for this path). Added the missing GET/PUT route.
- Fix a duplicated Admin/Member switcher on `AdminHeader`-based pages — it rendered its own switcher on top of the one `AdminNavigation` already renders globally.
- Add a `is_goalie_only` flag on registration categories. When set, only users with `users.is_goalie = true` can register in that category:
  - Settable via checkbox on the new/edit category admin pages.
  - New "Goalie" column on the `/admin/registration-categories` list.
  - Enforced in the member-facing registration UI (`RegistrationPurchase.tsx`) — a goalie-only category a non-goalie can't register for stays visible but disabled, with a "Goalies only" caption, matching the existing pattern for missing-membership categories.
  - Enforced server-side in `create-registration-payment-intent` and `join-waitlist`, so the check can't be bypassed by calling the API directly.
- Right-align the "Edit" controls on the `/admin/registrations/[id]` sidebar (Required Membership, Survey, Event Date & Time, Alternates) so they sit on the same line as their section header, matching the existing Registration Timing block; the Event Date & Time trigger changed from a left-aligned pencil icon to "Edit" text.
- New migration: `supabase/migrations/2026-08-23-add-goalie-only-to-categories.sql` (written idempotently — `ADD COLUMN IF NOT EXISTS`). Already applied by the maintainer to the preview Supabase project. Also added a note to `AGENTS.md` that migrations should be written idempotently where possible.

## Test plan
- [x] `npx tsc --noEmit`, `npm run build`, `npm run lint` all pass clean
- [x] Verified live on a Vercel preview deployment via the preview auth bypass (`preview-admin@test.com`, `is_goalie=false`; `preview-member@test.com`, `is_goalie=true`):
  - Admin: edit page loads correctly for an existing category, only one Admin/Member switcher shows, "Goalie Only" checkbox persists across create/edit/reload
  - New "Goalie" column shows on the categories list
  - Non-goalie: goalie-only category tile shown disabled with warning styling and "Goalies only" caption; submit button reads "Goalies Only"
  - Goalie: category is selectable and a free ($0) registration completes end-to-end
  - Direct API call to `create-registration-payment-intent` as a non-goalie against a goalie-only category returns 400 with the correct error, confirming server-side enforcement
  - Edit controls on the registration detail sidebar right-align correctly and still function

🤖 Generated with [Claude Code](https://claude.com/claude-code)